### PR TITLE
Intended macro syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ The same code can be passed through tools that generate .cc and .h bindings too:
 
 # Current state of affairs
 
-There is an example of this macro working within the `demo` directory. It's not yet
-quite the above syntax, since my macro-parsing fu needs to be improved. And, at the moment,
-it will work with only the very simplest functions.
+There is an example of this macro working within the `demo` directory. At the
+moment, it will work with only the very simplest functions.
 
 The project also contains test code which does this end-to-end, for all sorts of C++ types and constructs which we eventually would like to support. They nearly all fail :)
 

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,13 +1,10 @@
 use autocxx_macro::include_cxx;
 
-// The following syntax is very interim as I haven't figured out
-// how to parse a string inside a procedural macro yet(!)
-// Also, 'input' is supposed to refer to input.h, but currently
-// that name is totally hardcoded in our hacky fork of bindgen, so don't
+// input.h is currently hardcoded in our hacky fork of bindgen, so don't
 // attempt to change it!
 include_cxx!(
-    <input>,
-    <DoMath>
+    Header("input.h"),
+    Allow("DoMath"),
 );
 
 fn main() {


### PR DESCRIPTION
This implements the syntax described in [README.md<i>#Intended eventual interface</i>](https://github.com/google/autocxx/tree/e650f4fd26978dde67eb0853a5ff709a275dd776#intended-eventual-interface).

- [ ] Tests pass
- [x] Appropriate changes to README are included in PR