### PR TITLE
Make types opaque by default

### DIFF
--- a/engine/src/byvalue_checker.rs
+++ b/engine/src/byvalue_checker.rs
@@ -1,0 +1,120 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use syn::{ItemStruct, Type};
+
+pub struct ByValueChecker {
+    // Mapping from type name to whether it is POD
+    results: HashMap<String, bool>,
+}
+
+impl ByValueChecker {
+    pub fn new() -> Self {
+        let mut results = HashMap::new();
+        results.insert("CxxString".to_owned(), false);
+        results.insert("UniquePtr".to_owned(), true);
+        results.insert("i32".to_owned(), true);
+        results.insert("i64".to_owned(), true);
+        // TODO expand with all primitives, or find a better way.
+        ByValueChecker {
+            results
+        }
+    }
+
+    /// Can this C++ type be passed safely by value to/from Rust?
+    pub fn type_is_safe_for_pass_by_value(&mut self, def: ItemStruct) -> bool {
+        let id = def.ident.to_string();
+        let mut type_representable_as_pod = true;
+        for f in def.fields {
+            let fty = f.ty;
+            let field_representable_as_pod = match fty {
+                Type::Path(p) => {
+                    // TODO better handle generics
+                    let ty_id = p.path.segments.last().unwrap().ident.to_string();
+                    *self.results.get(&ty_id).expect("Not yet encountered type")
+                },
+                // TODO handle anything else which bindgen might spit out, e.g. arrays?
+                _ => false,
+            };
+            if !field_representable_as_pod {
+                type_representable_as_pod = false;
+                break;
+            }
+        };
+        self.results.insert(id, type_representable_as_pod);
+        type_representable_as_pod
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ByValueChecker;
+    use syn::{parse_quote, ItemStruct};
+
+    #[test]
+    fn test_primitives() {
+        let mut bvc = ByValueChecker::new();
+        let t: ItemStruct = parse_quote! {
+            struct Foo {
+                a: i32,
+                b: i64,
+            }
+        };
+        assert!(bvc.type_is_safe_for_pass_by_value(t));
+    }
+
+    #[test]
+    fn test_nested_primitives() {
+        let mut bvc = ByValueChecker::new();
+        let t: ItemStruct = parse_quote! {
+            struct Foo {
+                a: i32,
+                b: i64,
+            }
+        };
+        bvc.type_is_safe_for_pass_by_value(t);
+        let t: ItemStruct = parse_quote! {
+            struct Bar {
+                a: Foo,
+                b: i64,
+            }
+        };
+        assert!(bvc.type_is_safe_for_pass_by_value(t));
+    }
+
+    #[test]
+    fn test_with_up() {
+        let mut bvc = ByValueChecker::new();
+        let t: ItemStruct = parse_quote! {
+            struct Bar {
+                a: UniquePtr<CxxString>,
+                b: i64,
+            }
+        };
+        assert!(bvc.type_is_safe_for_pass_by_value(t));
+    }
+
+    #[test]
+    fn test_with_cxxstring() {
+        let mut bvc = ByValueChecker::new();
+        let t: ItemStruct = parse_quote! {
+            struct Bar {
+                a: CxxString,
+                b: i64,
+            }
+        };
+        assert!(!bvc.type_is_safe_for_pass_by_value(t));
+    }
+}

--- a/engine/src/byvalue_checker.rs
+++ b/engine/src/byvalue_checker.rs
@@ -15,6 +15,11 @@
 use std::collections::HashMap;
 use syn::{ItemStruct, Type};
 
+/// Type which is able to check whether it's safe to make a type
+/// fully representable by cxx. For instance if it is a struct containing
+/// a struct containing a std::string, the answer is no, because that
+/// std::string contains a self-referential pointer. Exact logic here
+/// is TBD.
 pub struct ByValueChecker {
     // Mapping from type name to whether it is POD
     results: HashMap<String, bool>,

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -212,7 +212,7 @@ fn test_two_funcs_with_definition() {
     let hdr = indoc! {"
         struct Bob {
             int a;
-        }
+        };
         void do_nothing1();
         void do_nothing2();
     "};

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -201,6 +201,32 @@ fn test_two_funcs() {
 }
 
 #[test]
+fn test_two_funcs_with_definition() {
+    // Test to ensure C++ header isn't included twice
+    let cxx = indoc! {"
+        void do_nothing1() {
+        }
+        void do_nothing2() {
+        }
+    "};
+    let hdr = indoc! {"
+        struct Bob {
+            int a;
+        }
+        void do_nothing1();
+        void do_nothing2();
+    "};
+    let rs = quote! {
+        ffi::cxxbridge::do_nothing1();
+        ffi::cxxbridge::do_nothing2();
+    };
+    println!("Here");
+
+    info!("Here2");
+    run_test(cxx, hdr, rs, &["do_nothing1", "do_nothing2"], &[]);
+}
+
+#[test]
 fn test_return_i32() {
     let cxx = indoc! {"
         uint32_t give_int() {

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -635,7 +635,7 @@ fn test_cycle_nonpod_with_str_by_ref() {
     "};
     let rs = quote! {
         let a = ffi::cxxbridge::make_bob();
-        assert_eq!(ffi::cxxbridge::take_bob(a.as_ref()), 32);
+        assert_eq!(ffi::cxxbridge::take_bob(a.as_ref().unwrap()), 32);
     };
     run_test(cxx, hdr, rs, &["take_bob", "Bob", "make_bob"], &[]);
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -15,6 +15,7 @@
 mod bridge_converter;
 mod cpp_postprocessor;
 mod preprocessor_parse_callbacks;
+mod byvalue_checker;
 
 #[cfg(test)]
 mod integration_tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,26 @@ use syn::parse_macro_input;
 /// * *Header(filename)*: a header filename to parse and include
 /// * *Allow(type or function name)*: a type or function name whose declaration
 ///   should be made available to C++.
+/// * *AllowPOD(type name)*: a struct name whose declaration
+///   should be made available to C++, and whose fields are sufficient simple
+///   that they can allow being passed back and forth by value (POD = 'plain old
+///   data').
+///
+/// # How to allow structs
+///
+/// A C++ struct can be listed under 'Allow' or 'AllowPOD' (or may be implicitly
+/// 'Allowed' because it's a type referenced by something else you've allowed.)
+///
+/// The current plan is to use 'Allow' under normal circumstances, but
+/// 'AllowPOD' only for structs where you absolutely do need to pass them
+/// truly by value and have direct field access.
+/// Some structs can't be represented as POD, e.g. those containing `std::string`
+/// due to self-referential pointers. We will always handle such things using
+/// `UniquePtr` to an opaque type in Rust, but still allow calling existing C++
+/// APIs which take such things by value - we'll aim to generate automatic
+/// unwrappers. This won't work in all cases.
+/// The majority of this paragraph doesn't work at all yet, and it will never work
+/// for some cases. It remains to be seen whether this is good enough in practice.
 ///
 /// # Generated code
 ///


### PR DESCRIPTION
This allows us to cope with structs types containing `std::string`, though they can only be manipulated by `UniquePtr` and reference within Rust.

Many details needed which are not yet done.