### PR TITLE
Move make_unique into an impl block.

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -748,9 +748,8 @@ fn test_make_up() {
         };
         uint32_t take_bob(const Bob& a);
     "};
-    // TODO rename Bob_make_unique to Bob::make_unique
     let rs = quote! {
-        let a = ffi::cxxbridge::Bob_make_unique(); // TODO test with all sorts of arguments.
+        let a = ffi::cxxbridge::Bob::make_unique(); // TODO test with all sorts of arguments.
         assert_eq!(ffi::cxxbridge::take_bob(a.as_ref().unwrap()), 3);
     };
     run_test(cxx, hdr, rs, &["Bob", "take_bob"], &[]);


### PR DESCRIPTION
... such that a caller can call Bob::make_unique(...)
instead of Bob_make_unique(...).

This is all rather temporary until cxx supports this natively.
