### PR TITLE
Reproduce wrong size of std::string

### DIFF
--- a/demo/build.rs
+++ b/demo/build.rs
@@ -19,10 +19,12 @@ fn main() {
     let path = std::path::PathBuf::from("src").canonicalize().unwrap();
     let mut b = autocxx_build::Builder::new("src/main.rs", &path.to_str().unwrap()).unwrap();
     b.builder()
+        .file("src/input.cc")
         .flag_if_supported("-std=c++14")
         .compile("autocxx-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/input.h");
+    println!("cargo:rerun-if-changed=src/input.cc");
     println!("cargo:rustc-env=AUTOCXX_INC={}", path.to_str().unwrap());
 }

--- a/demo/src/input.cc
+++ b/demo/src/input.cc
@@ -1,0 +1,6 @@
+#include "input.h"
+#include <iostream>
+
+S::S(uint32_t i) : i(i) {
+  std::cout << "C++:" << (size_t(&this->i) - size_t(this)) << std::endl;
+}

--- a/demo/src/input.h
+++ b/demo/src/input.h
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
 #include <cstdint>
-
-uint32_t DoMath(uint32_t a);
-
-uint32_t DoMath(uint32_t a) {
-    return a * 3;
-}
+#include <string>
+struct S {
+  explicit S(uint32_t i);
+  std::string s;
+  uint32_t i;
+};

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -14,11 +14,10 @@
 
 use autocxx::include_cxx;
 
-include_cxx!(Header("input.h"), Allow("DoMath"),);
+include_cxx!(Header("input.h"), Allow("S"));
 
 fn main() {
-    println!(
-        "Hello, world! - C++ math should say 12={}",
-        ffi::cxxbridge::DoMath(4)
-    );
+    let s = ffi::cxxbridge::S_make_unique(1);
+    println!("Rust:{}", (&s.i as *const _ as usize) - (&*s as *const _ as usize));
+    println!("{}", s.i);
 }


### PR DESCRIPTION
Sharing just to provide a runnable repro of #19.

In the demo directory:

<pre>
<i>demo</i>$  <b>cargo run</b>
C++:32
Rust:24
0
</pre>