### PR TITLE
Prevent field access for non-POD types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,6 @@ use syn::parse_macro_input;
 /// `UniquePtr` to an opaque type in Rust, but still allow calling existing C++
 /// APIs which take such things by value - we'll aim to generate automatic
 /// unwrappers. This won't work in all cases.
-/// The majority of this paragraph doesn't work at all yet, and it will never work
-/// for some cases. It remains to be seen whether this is good enough in practice.
 ///
 /// # Generated code
 ///


### PR DESCRIPTION
Because non-POD types can't have offsets calculated correctly in Rust,
field access needs to be done via C++ accessor methods. That's not yet
implemented, but this change prevents access to the incorrect offsets
meanwhile.

Fixes #18.