### PR TITLE
Don't allow construction of non-POD types from Rust

### DIFF
--- a/engine/src/bridge_converter.rs
+++ b/engine/src/bridge_converter.rs
@@ -211,9 +211,11 @@ impl<'a> BridgeConversion<'a> {
                     let should_be_pod = self.byvalue_checker.is_pod(&tyname);
                     self.generate_type_alias(tyname, should_be_pod);
                     if !should_be_pod {
+                        // See cxx's opaque::Opaque for rationale for this type... in
+                        // short, it's to avoid being Send/Sync.
                         s.fields = syn::Fields::Named(parse_quote! {
                             {
-                                do_not_attempt_to_allocate_nonpod_types: u8,
+                                do_not_attempt_to_allocate_nonpod_types: [*const u8; 0],
                             }
                         });
                     }

--- a/engine/src/bridge_converter.rs
+++ b/engine/src/bridge_converter.rs
@@ -211,7 +211,11 @@ impl<'a> BridgeConversion<'a> {
                     let should_be_pod = self.byvalue_checker.is_pod(&tyname);
                     self.generate_type_alias(tyname, should_be_pod);
                     if !should_be_pod {
-                        s.fields = syn::Fields::Unit;
+                        s.fields = syn::Fields::Named(parse_quote! {
+                            {
+                                do_not_attempt_to_allocate_nonpod_types: u8,
+                            }
+                        });
                     }
                     self.bindgen_items.push(Item::Struct(s));
                 }

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -1096,7 +1096,7 @@ fn test_negative_make_nonpod() {
         ffi::cxxbridge::Bob { a: 12 };
     };
     let rs3 = quote! {
-        ffi::cxxbridge::Bob { do_not_attempt_to_allocate_nonpod_types: 12 };
+        ffi::cxxbridge::Bob { do_not_attempt_to_allocate_nonpod_types: [] };
     };
     run_test_expect_fail(cxx, hdr, rs, &["take_bob", "Bob", "make_bob"], &[]);
     run_test_expect_fail(cxx, hdr, rs2, &["take_bob", "Bob", "make_bob"], &[]);


### PR DESCRIPTION
Fixes #23 