### PR TITLE
Removing duplicate binding printing.

### DIFF
--- a/engine/src/bridge_converter.rs
+++ b/engine/src/bridge_converter.rs
@@ -141,8 +141,6 @@ impl<'a> BridgeConversion<'a> {
         );
         let tynamestring = tyname.to_cpp_name();
         let mut for_extern_c_ts = TokenStream2::new();
-        // TODO - add #[rustfmt::skip] here until
-        // https://github.com/rust-lang/rustfmt/issues/4159 is fixed.
         for_extern_c_ts.extend(
             [
                 TokenTree::Ident(Ident::new("type", Span::call_site())),

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -373,10 +373,6 @@ impl IncludeCpp {
         };
         new_bindings.content.as_mut().unwrap().1.append(&mut items);
         info!(
-            "New bindings unprettied: {}",
-            new_bindings.to_token_stream().to_string()
-        );
-        info!(
             "New bindings:\n{}",
             rust_pretty_printer::pretty_print(&new_bindings.to_token_stream())
         );


### PR DESCRIPTION
Now rustfmt 1.4.22 is released:
https://github.com/rust-lang/rustfmt/pull/4447
