### PR TITLE
Canonicalize include path in Windows to not contain UNC prefix

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -32,6 +32,7 @@ indoc = "1.0"
 bindgen = "0.55"
 itertools = "0.9"
 cxx-gen = { version="0.5.1", path="../../cxx/gen/lib" }
+dunce = "1.0.1"
 
 [dependencies.syn]
 version = "1.0.39"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -198,9 +198,15 @@ impl IncludeCpp {
         let inc_dirs = std::env::split_paths(&inc_dirs);
         // TODO consider if we can or should look up the include path automatically
         // instead of requiring callers always to set AUTOCXX_INC.
+
+        // On Windows, the canonical path begins with a UNC prefix that cannot be passed to
+        // the MSVC compiler, so dunce::canonicalize() is used instead of std::fs::canonicalize()
+        // See:
+        // * https://github.com/dtolnay/cxx/pull/41
+        // * https://github.com/alexcrichton/cc-rs/issues/169
         inc_dirs
             .map(|p| {
-                p.canonicalize()
+                dunce::canonicalize(&p)
                     .map_err(|_| Error::CouldNotCanoncalizeIncludeDir(p))
             })
             .collect()


### PR DESCRIPTION
Thanks for the fast fix of https://github.com/google/autocxx/issues/27!

> I would be shocked if this builds under Windows even after this is fixed. I anticipate that a load of bindgen configuration is necessary which isn't currently possible with the limited interface exposed by autocxx. (There's the AUTOCXX_INC environment variable to set an include path, but currently no other way to configure bindgen at all. It's my intention eventually that there are richer facilities here.)

I have shocking news for you. After some tweaking, I ran the Demo example:
```
cargo run
   Compiling autocxx-demo v0.2.0 (...\autocxx\demo)
    Finished dev [unoptimized + debuginfo] target(s) in 7.79s
     Running `...\autocxx\target\debug\autocxx-demo.exe`
Hello, world! - C++ math should say 12=12

Process finished with exit code 0
```

----

But from the beginning. The compilation step failed, and unfortunately the `cc` output is not that great -- it outputs the return code of MSVC compiler `cl`, however not the error message. I had to figure out which command failed, and reproduce it in the command line (which is not exactly the same setup, because `cc` loads the environment, e.g. to find standard headers).

Anyway, I found out that the include directory created by `std::fs::canonicalize()` on Windows is a _UNC path_, with a prefix `\\?\` that is not understood by many Microsoft tools, among others `cl`. There is an existing issue https://github.com/rust-lang/rust/issues/42869 on the Rust repo about this.

So I need to strip that prefix, and came across the [dunce](https://docs.rs/dunce) crate which did exactly that. It is of course also possible to write some inline code to not impose an extra dependency.

---

So far, so good, however I wasn't able to use autocxx from outside.
When I try to reproduce the Demo setup in a separate project, I get:
```
Compiling autocxx-test v0.1.0 (...\autocxx-test)
error: NoAutoCxxInc
   --> src\main.rs:17:1
    |
17  | include_cxx!(Header("input.h"), Allow("DoMath"),);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ in this macro invocation
    | 
   ::: ...\autocxx\src\lib.rs:106:1
    |
106 | pub fn include_cxx(input: TokenStream) -> TokenStream {
    | ----------------------------------------------------- in this expansion of `include_cxx!`

error[E0433]: failed to resolve: use of undeclared crate or module `ffi`
  --> src\main.rs:22:9
   |
22 |         ffi::cxxbridge::DoMath(4)
   |         ^^^ use of undeclared crate or module `ffi`
```

I saw the `NoAutoCxxInc` enumerator and was wondering, if the `AUTOCXX_INC` env var might be missing. I set it as `AUTOCXX_INC=src` (the relative path to `input.h` from the project root) but then got another error:

```
error: non-foreign item macro in foreign item position: include
   --> src\main.rs:17:1
    |
17  | include_cxx!(Header("input.h"), Allow("DoMath"),);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ in this macro invocation
    | 
   ::: ...\autocxx\src\lib.rs:106:1
    |
106 | pub fn include_cxx(input: TokenStream) -> TokenStream {
    | ----------------------------------------------------- in this expansion of `include_cxx!`

error[E0433]: failed to resolve: use of undeclared crate or module `cxx`
   --> src\main.rs:17:1
    |
17  | include_cxx!(Header("input.h"), Allow("DoMath"),);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | use of undeclared crate or module `cxx`
    | in this macro invocation
    | 
   ::: ...\autocxx\src\lib.rs:106:1
    |
106 | pub fn include_cxx(input: TokenStream) -> TokenStream {
    | ----------------------------------------------------- in this expansion of `include_cxx!`
```

Is there something obvious I'm doing wrong, or what setup would autocxx require? Is this the extra bindgen configuration you talked about?