### PR TITLE
Refactor type database

### DIFF
--- a/engine/src/additional_cpp_generator.rs
+++ b/engine/src/additional_cpp_generator.rs
@@ -69,23 +69,7 @@ impl ArgumentConversion {
     }
 
     fn unwrapped_type_as_string(&self) -> String {
-        match self.unwrapped_type {
-            Type::Path(ref typ) => TypeName::from_type_path(typ).to_cpp_name().to_string(),
-            Type::Reference(ref typr) => {
-                let const_bit = match typr.mutability {
-                    None => "const ",
-                    Some(_) => "",
-                };
-                format!(
-                    "{}{}&",
-                    const_bit,
-                    TypeName::from_type(typr.elem.as_ref())
-                        .to_cpp_name()
-                        .to_string()
-                )
-            }
-            _ => unimplemented!(),
-        }
+        crate::types::to_cpp_name(&self.unwrapped_type)
     }
 
     fn wrapped_type(&self) -> String {

--- a/engine/src/byvalue_checker.rs
+++ b/engine/src/byvalue_checker.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::types::TypeName;
-use crate::types::KNOWN_TYPES;
 use std::collections::HashMap;
 use syn::{ItemStruct, Type};
 
@@ -50,8 +49,8 @@ pub struct ByValueChecker {
 impl ByValueChecker {
     pub fn new() -> Self {
         let mut results = HashMap::new();
-        for (tn, td) in KNOWN_TYPES.iter() {
-            let safety = if td.by_value_safe {
+        for (tn, by_value_safe) in crate::types::get_pod_safe_types() {
+            let safety = if by_value_safe {
                 PODState::IsPOD
             } else {
                 PODState::UnsafeToBePOD(format!("type {} is not safe for POD", tn))

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -100,30 +100,6 @@ fn dump_generated_code(gen: cxx_gen::GeneratedCode) -> Result<cxx_gen::Generated
     Ok(gen)
 }
 
-/// Prelude of C++ for squirting into bindgen. This configures
-/// bindgen to output simpler types to replace some STL types
-/// that bindgen just can't cope with. Although we then replace
-/// those types with cxx types (e.g. UniquePtr), this intermediate
-/// step is still necessary because bindgen can't otherwise
-/// give us the templated types (e.g. when faced with the STL
-/// unique_ptr, bindgen would normally give us std_unique_ptr
-/// as opposed to std_unique_ptr<T>.)
-static PRELUDE: &str = indoc! {"
-    /**
-    * <div rustbindgen=\"true\" replaces=\"std::unique_ptr\">
-    */
-    template<typename T> class UniquePtr {
-        T* ptr;
-    };
-
-    /**
-    * <div rustbindgen=\"true\" replaces=\"std::string\">
-    */
-    class CxxString {
-        char* str_data;
-    };
-    \n"};
-
 impl IncludeCpp {
     fn new_from_parse_stream(input: ParseStream) -> syn::Result<Self> {
         // Takes as inputs:
@@ -268,7 +244,7 @@ impl IncludeCpp {
         } else {
             String::new()
         };
-        let full_header = format!("{}{}\n\n{}", PRELUDE, more_decls, full_header,);
+        let full_header = format!("{}{}\n\n{}", types::get_prelude(), more_decls, full_header,);
         info!("Full header: {}", full_header);
         builder = builder.header_contents("example.hpp", &full_header);
         builder

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -26,7 +26,6 @@ mod integration_tests;
 use proc_macro2::TokenStream as TokenStream2;
 use std::path::PathBuf;
 
-use indoc::indoc;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::{parse_quote, ItemMod, Macro};

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use indoc::indoc;
 use lazy_static::lazy_static;
 use proc_macro2::Span;
 use std::collections::HashMap;
@@ -145,6 +146,34 @@ lazy_static! {
         map
     };
 }
+
+pub(crate) fn get_prelude() -> String {
+    return PRELUDE.into();
+}
+
+/// Prelude of C++ for squirting into bindgen. This configures
+/// bindgen to output simpler types to replace some STL types
+/// that bindgen just can't cope with. Although we then replace
+/// those types with cxx types (e.g. UniquePtr), this intermediate
+/// step is still necessary because bindgen can't otherwise
+/// give us the templated types (e.g. when faced with the STL
+/// unique_ptr, bindgen would normally give us std_unique_ptr
+/// as opposed to std_unique_ptr<T>.)
+static PRELUDE: &str = indoc! {"
+    /**
+    * <div rustbindgen=\"true\" replaces=\"std::unique_ptr\">
+    */
+    template<typename T> class UniquePtr {
+        T* ptr;
+    };
+
+    /**
+    * <div rustbindgen=\"true\" replaces=\"std::string\">
+    */
+    class CxxString {
+        char* str_data;
+    };
+    \n"};
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -163,24 +163,22 @@ lazy_static! {
 
 fn create_type_database() -> TypeDatabase {
     let mut by_cxx_name = HashMap::new();
-    by_cxx_name.insert(
-        TypeName::new_unchecked("UniquePtr"),
-        TypeDetails::new(
-            "UniquePtr".into(),
-            "std::unique_ptr".into(),
-            true,
-            PreludePolicy::IncludeTemplated,
-        ),
-    );
-    by_cxx_name.insert(
-        TypeName::new_unchecked("CxxString"),
-        TypeDetails::new(
-            "CxxString".into(),
-            "std::string".into(),
-            false,
-            PreludePolicy::IncludeNormal,
-        ),
-    );
+
+    let mut do_insert =
+        |td: TypeDetails| by_cxx_name.insert(TypeName::new_unchecked(&td.cxx_name), td);
+
+    do_insert(TypeDetails::new(
+        "UniquePtr".into(),
+        "std::unique_ptr".into(),
+        true,
+        PreludePolicy::IncludeTemplated,
+    ));
+    do_insert(TypeDetails::new(
+        "CxxString".into(),
+        "std::string".into(),
+        false,
+        PreludePolicy::IncludeNormal,
+    ));
     for (cpp_type, rust_type) in (3..7)
         .map(|x| 2i32.pow(x))
         .map(|x| {
@@ -191,10 +189,12 @@ fn create_type_database() -> TypeDatabase {
         })
         .flatten()
     {
-        by_cxx_name.insert(
-            TypeName::new_unchecked(&rust_type),
-            TypeDetails::new(rust_type.into(), cpp_type, true, PreludePolicy::Exclude),
-        );
+        do_insert(TypeDetails::new(
+            rust_type.into(),
+            cpp_type,
+            true,
+            PreludePolicy::Exclude,
+        ));
     }
 
     let mut by_deadname = HashMap::new();

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -98,9 +98,6 @@ enum PreludePolicy {
 pub(crate) struct TypeDetails {
     /// The name used by cxx for this type.
     cxx_name: String,
-    /// This type may be called this in bindgen-generated code.
-    /// We want to expunge that Bad Old Name as quickly as possible.
-    cpp_deadname: Option<String>,
     /// C++ equivalent name for a Rust type.
     pub(crate) cpp_name: String,
     /// Whether this can be safely represented by value.
@@ -112,14 +109,12 @@ pub(crate) struct TypeDetails {
 impl TypeDetails {
     fn new(
         cxx_name: String,
-        cpp_deadname: Option<String>,
         cpp_name: String,
         by_value_safe: bool,
         prelude_policy: PreludePolicy,
     ) -> Self {
         TypeDetails {
             cxx_name,
-            cpp_deadname,
             cpp_name,
             by_value_safe,
             prelude_policy,
@@ -161,7 +156,6 @@ lazy_static! {
             TypeName::new("UniquePtr"),
             TypeDetails::new(
                 "UniquePtr".into(),
-                Some("std_unique_ptr".into()),
                 "std::unique_ptr".into(),
                 true,
                 PreludePolicy::IncludeTemplated,
@@ -171,7 +165,6 @@ lazy_static! {
             TypeName::new("CxxString"),
             TypeDetails::new(
                 "CxxString".into(),
-                Some("std_string".into()),
                 "std::string".into(),
                 false,
                 PreludePolicy::IncludeNormal,
@@ -189,13 +182,7 @@ lazy_static! {
         {
             map.insert(
                 TypeName::new(&rust_type),
-                TypeDetails::new(
-                    rust_type.into(),
-                    None,
-                    cpp_type,
-                    true,
-                    PreludePolicy::Exclude,
-                ),
+                TypeDetails::new(rust_type.into(), cpp_type, true, PreludePolicy::Exclude),
             );
         }
         map

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -151,6 +151,26 @@ pub(crate) fn get_prelude() -> String {
     return PRELUDE.into();
 }
 
+pub(crate) fn to_cpp_name(typ: &Type) -> String {
+    match typ {
+        Type::Path(ref typ) => TypeName::from_type_path(typ).to_cpp_name().to_string(),
+        Type::Reference(ref typr) => {
+            let const_bit = match typr.mutability {
+                None => "const ",
+                Some(_) => "",
+            };
+            format!(
+                "{}{}&",
+                const_bit,
+                TypeName::from_type(typr.elem.as_ref())
+                    .to_cpp_name()
+                    .to_string()
+            )
+        }
+        _ => unimplemented!(),
+    }
+}
+
 /// Prelude of C++ for squirting into bindgen. This configures
 /// bindgen to output simpler types to replace some STL types
 /// that bindgen just can't cope with. Although we then replace


### PR DESCRIPTION
No intentional functional changes. Centralizes _all_ knowledge of types into `types.rs`. A pre-requisite for some of the work on #13 .