### PR TITLE
Enable string tests which have been long-disabled

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["Adrian Taylor <adetaylor@chromium.org>"]
 edition = "2018"
 
 [dependencies]
-cxx = "0.5.1"
+cxx = "0.5.2"
 autocxx = { path = "..", version="0.3.2" }
 
 [build-dependencies]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1.4"
 indoc = "1.0"
 bindgen = "0.55"
 itertools = "0.9"
-cxx-gen = "0.5.1"
+cxx-gen = "0.5.2"
 dunce = "1.0.1"
 
 [dependencies.syn]
@@ -50,4 +50,4 @@ autocxx-build = { path="../gen/build" }
 # by the trybuild test system...
 autocxx = { path=".." }
 link-cplusplus = "1.0"
-cxx = "0.5.1"
+cxx = "0.5.2"

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -349,7 +349,6 @@ fn test_give_string_up() {
 }
 
 #[test]
-#[ignore] // because we don't yet support std::string by value
 fn test_give_string_plain() {
     let cxx = indoc! {"
         std::string give_str() {
@@ -361,7 +360,7 @@ fn test_give_string_plain() {
         std::string give_str();
     "};
     let rs = quote! {
-        assert_eq!(ffi::cxxbridge::give_str_up().to_str().unwrap(), "Bob");
+        assert_eq!(ffi::cxxbridge::give_str().as_ref().unwrap(), "Bob");
     };
     run_test(cxx, hdr, rs, &["give_str"], &[]);
 }
@@ -391,7 +390,6 @@ fn test_cycle_string_up() {
 }
 
 #[test]
-#[ignore] // because we don't yet support std::string by value
 fn test_cycle_string() {
     let cxx = indoc! {"
         std::string give_str() {

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -1185,7 +1185,6 @@ fn test_method_pass_pod_by_mut_reference() {
 }
 
 #[test]
-#[ignore] // pending https://github.com/dtolnay/cxx/pull/361
 fn test_method_pass_pod_by_up() {
     let cxx = indoc! {"
         uint32_t Bob::get_bob(std::unique_ptr<Anna>) const {
@@ -1212,8 +1211,6 @@ fn test_method_pass_pod_by_up() {
     };
     run_test(cxx, hdr, rs, &["take_bob"], &["Bob", "Anna"]);
 }
-
-// ===
 
 #[test]
 fn test_method_pass_nonpod_by_value() {


### PR DESCRIPTION
Builds on top of #43, though strictly that's not required for these tests to pass.