### PR TITLE
Add rust::Str and rust::String support in C++ headers

### DIFF
--- a/demo/src/input.h
+++ b/demo/src/input.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <cstdint>
 
 uint32_t DoMath(uint32_t a);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -41,7 +41,8 @@ use types::TypeName;
 
 pub use parse::{parse_file, ParseError};
 
-const BINDGEN_BLOCKLIST: &[&str] = &["std.*", "__gnu.*", ".*mbstate_t.*"];
+pub use cxx_gen::HEADER;
+
 pub struct CppFilePair {
     pub header: Vec<u8>,
     pub implementation: Vec<u8>,
@@ -204,8 +205,8 @@ impl IncludeCpp {
                 non_exhaustive: false,
             })
             .layout_tests(false); // TODO revisit later
-        for item in BINDGEN_BLOCKLIST.iter() {
-            builder = builder.blacklist_item(*item);
+        for item in types::get_initial_blocklist() {
+            builder = builder.blacklist_item(item);
         }
 
         for inc_dir in inc_dirs {

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use autocxx_engine::ParseError;
 pub use autocxx_engine::Error as EngineError;
+pub use autocxx_engine::ParseError;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -64,7 +64,8 @@ impl Builder {
         let tdir = tempdir().map_err(Error::TempDirCreationFailed)?;
         let mut builder = cc::Build::new();
         builder.cpp(true);
-        let autocxxes = autocxx_engine::parse_file(rs_file, Some(autocxx_inc)).map_err(Error::ParseError)?;
+        let autocxxes =
+            autocxx_engine::parse_file(rs_file, Some(autocxx_inc)).map_err(Error::ParseError)?;
         let mut counter = 0;
         for include_cpp in autocxxes {
             for inc_dir in include_cpp
@@ -79,9 +80,8 @@ impl Builder {
             for filepair in generated_code.0 {
                 let fname = format!("gen{}.cxx", counter);
                 counter += 1;
-                let gen_cxx_path =
-                    Self::write_to_file(&tdir, &fname, &filepair.implementation)
-                        .map_err(Error::FileWriteFail)?;
+                let gen_cxx_path = Self::write_to_file(&tdir, &fname, &filepair.implementation)
+                    .map_err(Error::FileWriteFail)?;
                 builder.file(gen_cxx_path);
 
                 Self::write_to_file(&tdir, &filepair.header_name, &filepair.header)


### PR DESCRIPTION
Fixes #13 (though there's some follow up work required to make this work with `build.rs`).