### PR TITLE
Add a string constructor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The project also contains test code which does this end-to-end, for all sorts of
 | Passing opaque structs (owned by UniquePtr) into C++ functions which take them by value | Works |
 | Passing opaque structs (owned by UniquePtr) into C++ methods which take them by value | Works, but with non-ideal syntax |
 | Constructors/make_unique | Works, though probably many problems |
+| Destructors | Works via cxx `UniquePtr` already |
+| Construction of std::unique_ptr<std::string> in Rust | - |
 | Field access to opaque objects via UniquePtr | - |
 | Plain-old-data structs containing opaque fields | Impossible by design, but may not be ergonomic so may need more thought |
 | Reference counting | - |
@@ -87,7 +89,6 @@ The project also contains test code which does this end-to-end, for all sorts of
 | Function pointers | - |
 | Unique ptrs to primitives | - |
 | Inheritance from pure virtual classes | - |
-| Destructors | Works via cxx `UniquePtr` already |
 | Namespaces | - |
 
 The plan is (roughly) to work through the above list of features. Some are going to be _very_ hard, and it's not at all clear that a plan will present itself. In particular, some will require that C++ structs are owned by `UniquePtr` yet passed to C++ by value. It's not clear how ergonomic the results will be. Until we are much further, I don't advise using this for anything in production.

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -17,7 +17,7 @@ fn main() {
     // C++ codegen and the macro codegen appears to be run from different
     // working directories.
     let path = std::path::PathBuf::from("src").canonicalize().unwrap();
-    let mut b = autocxx_build::build("src/main.rs", &path.to_str().unwrap(), None).unwrap();
+    let mut b = autocxx_build::build("src/main.rs", &path.to_str().unwrap()).unwrap();
     b.flag_if_supported("-std=c++14").compile("autocxx-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -24,5 +24,4 @@ fn main() {
 
     println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/input.h");
-    println!("cargo:rustc-env=AUTOCXX_INC={}", path.to_str().unwrap());
 }

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -17,10 +17,8 @@ fn main() {
     // C++ codegen and the macro codegen appears to be run from different
     // working directories.
     let path = std::path::PathBuf::from("src").canonicalize().unwrap();
-    let mut b = autocxx_build::Builder::new("src/main.rs", &path.to_str().unwrap()).unwrap();
-    b.builder()
-        .flag_if_supported("-std=c++14")
-        .compile("autocxx-demo");
+    let mut b = autocxx_build::build("src/main.rs", &path.to_str().unwrap()).unwrap();
+    b.flag_if_supported("-std=c++14").compile("autocxx-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/input.h");

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -17,7 +17,7 @@ fn main() {
     // C++ codegen and the macro codegen appears to be run from different
     // working directories.
     let path = std::path::PathBuf::from("src").canonicalize().unwrap();
-    let mut b = autocxx_build::build("src/main.rs", &path.to_str().unwrap()).unwrap();
+    let mut b = autocxx_build::build("src/main.rs", &[&path]).unwrap();
     b.flag_if_supported("-std=c++14").compile("autocxx-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -17,7 +17,7 @@ fn main() {
     // C++ codegen and the macro codegen appears to be run from different
     // working directories.
     let path = std::path::PathBuf::from("src").canonicalize().unwrap();
-    let mut b = autocxx_build::build("src/main.rs", &path.to_str().unwrap()).unwrap();
+    let mut b = autocxx_build::build("src/main.rs", &path.to_str().unwrap(), None).unwrap();
     b.flag_if_supported("-std=c++14").compile("autocxx-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/demo/src/input.h
+++ b/demo/src/input.h
@@ -18,6 +18,6 @@
 
 uint32_t DoMath(uint32_t a);
 
-uint32_t DoMath(uint32_t a) {
+inline uint32_t DoMath(uint32_t a) {
     return a * 3;
 }

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -190,9 +190,9 @@ fn do_run_test(
     let target_dir = tdir.path().join("target");
     std::fs::create_dir(&target_dir).unwrap();
     let target = rust_info::get().target_triple.unwrap();
-    let mut b = autocxx_build::Builder::new(&rs_path, tdir.path().to_str().unwrap())
+    let mut b = autocxx_build::build(&rs_path, tdir.path().to_str().unwrap())
         .map_err(TestError::AutoCxx)?;
-    b.builder()
+    b
         .file(cxx_path)
         .out_dir(&target_dir)
         .host(&target)

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -1566,6 +1566,7 @@ fn test_pass_rust_str() {
 // 7. Out params
 // 8. Opaque type handling
 // 9. Multiple functions in one header
+// 10. ExcludeUtilities
 // Stuff which requires much more thought:
 // 1. Shared pointers
 // Negative tests:

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -190,10 +190,10 @@ fn do_run_test(
     let target_dir = tdir.path().join("target");
     std::fs::create_dir(&target_dir).unwrap();
     let target = rust_info::get().target_triple.unwrap();
-    let mut b = autocxx_build::build(
+    let mut b = autocxx_build::build_to_custom_directory(
         &rs_path,
         tdir.path().to_str().unwrap(),
-        Some(target_dir.clone()),
+        target_dir.clone(),
     )
     .map_err(TestError::AutoCxx)?;
     b.file(cxx_path)

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -192,7 +192,7 @@ fn do_run_test(
     let target = rust_info::get().target_triple.unwrap();
     let mut b = autocxx_build::build_to_custom_directory(
         &rs_path,
-        tdir.path().to_str().unwrap(),
+        &[tdir.path()],
         target_dir.clone(),
     )
     .map_err(TestError::AutoCxx)?;

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -190,10 +190,13 @@ fn do_run_test(
     let target_dir = tdir.path().join("target");
     std::fs::create_dir(&target_dir).unwrap();
     let target = rust_info::get().target_triple.unwrap();
-    let mut b = autocxx_build::build(&rs_path, tdir.path().to_str().unwrap())
-        .map_err(TestError::AutoCxx)?;
-    b
-        .file(cxx_path)
+    let mut b = autocxx_build::build(
+        &rs_path,
+        tdir.path().to_str().unwrap(),
+        Some(target_dir.clone()),
+    )
+    .map_err(TestError::AutoCxx)?;
+    b.file(cxx_path)
         .out_dir(&target_dir)
         .host(&target)
         .target(&target)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -32,7 +32,7 @@ use syn::{parse_quote, ItemMod, Macro};
 
 use additional_cpp_generator::{AdditionalCpp, AdditionalCppGenerator, AdditionalNeed};
 use itertools::join;
-use log::{debug, info, warn};
+use log::{info, warn};
 use preprocessor_parse_callbacks::{PreprocessorDefinitions, PreprocessorParseCallbacks};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -194,10 +194,6 @@ impl IncludeCpp {
     }
 
     fn make_bindgen_builder(&self) -> Result<bindgen::Builder> {
-        let inc_dirs = self.determine_incdirs()?;
-
-        debug!("Inc dir: {:?}", inc_dirs);
-
         // TODO support different C++ versions
         let mut builder = bindgen::builder()
             .clang_args(&["-x", "c++", "-std=c++14"])
@@ -214,7 +210,7 @@ impl IncludeCpp {
             builder = builder.blacklist_item(item);
         }
 
-        for inc_dir in inc_dirs {
+        for inc_dir in self.determine_incdirs()? {
             // TODO work with OsStrs here to avoid the .display()
             builder = builder.clang_arg(format!("-I{}", inc_dir.display()));
         }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -30,7 +30,7 @@ use quote::ToTokens;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::{parse_quote, ItemMod, Macro};
 
-use additional_cpp_generator::{AdditionalCpp, AdditionalCppGenerator};
+use additional_cpp_generator::{AdditionalCpp, AdditionalCppGenerator, AdditionalNeed};
 use itertools::join;
 use log::{debug, info, warn};
 use preprocessor_parse_callbacks::{PreprocessorDefinitions, PreprocessorParseCallbacks};
@@ -79,6 +79,7 @@ pub struct IncludeCpp {
     pod_types: Vec<TypeName>,
     preconfigured_inc_dirs: Option<std::ffi::OsString>,
     parse_only: bool,
+    exclude_utilities: bool,
     preprocessor_definitions: Rc<Mutex<PreprocessorDefinitions>>,
 }
 
@@ -111,6 +112,7 @@ impl IncludeCpp {
         let mut allowlist = Vec::new();
         let mut pod_types = Vec::new();
         let mut parse_only = false;
+        let mut exclude_utilities = false;
 
         while !input.is_empty() {
             let ident: syn::Ident = input.parse()?;
@@ -129,10 +131,12 @@ impl IncludeCpp {
                 }
             } else if ident == "ParseOnly" {
                 parse_only = true;
+            } else if ident == "ExcludeUtilities" {
+                exclude_utilities = true;
             } else {
                 return Err(syn::Error::new(
                     ident.span(),
-                    "expected Header, Allow or AllowPOD",
+                    "expected Header, Allow, AllowPOD or ExcludeUtilities",
                 ));
             }
             if input.is_empty() {
@@ -147,6 +151,7 @@ impl IncludeCpp {
             pod_types,
             preconfigured_inc_dirs: None,
             parse_only,
+            exclude_utilities,
             preprocessor_definitions: Rc::new(Mutex::new(PreprocessorDefinitions::new())),
         })
     }
@@ -319,6 +324,14 @@ impl IncludeCpp {
             .map_err(Error::Conversion)?;
         let mut additional_cpp_generator = AdditionalCppGenerator::new(self.build_header());
         additional_cpp_generator.add_needs(conversion.additional_cpp_needs);
+        if !self.exclude_utilities {
+            // Unless we've been specifically asked not to do so, we always
+            // generate a 'make_string' function. That pretty much *always* means
+            // we run two passes through bindgen. i.e. the next 'if' is always true,
+            // and we always generate an additional C++ file for our bindings additions,
+            // unless the include_cpp macro has specified ExcludeUtilities.
+            additional_cpp_generator.add_needs(vec![AdditionalNeed::MakeStringConstructor]);
+        }
         let additional_cpp_items = additional_cpp_generator.generate();
         if let Some(additional_cpp_items) = additional_cpp_items {
             // When processing the bindings the first time, we discovered we wanted to add

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -26,7 +26,6 @@ categories = ["development-tools::ffi", "api-bindings"]
 [dependencies]
 cc = "1.0"
 autocxx-engine = { version="0.3.2", path="../../engine" }
-tempfile = "3.1"
 
 [dependencies.syn]
 version = "1.0"

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -46,10 +46,17 @@ pub enum Error {
 /// which should be used as include directories (as a string separated
 /// by the normal path separator on your platform; that may seem weird
 /// but it's because it's passed around as an environment variable.)
-/// You can optionally pass the directory into which you'd like generated
-/// files output, but normally, give None.
-pub fn build<P1: AsRef<Path>>(rs_file: P1, autocxx_inc: &str, optional_out_dir: Option<PathBuf>) -> Result<cc::Build, Error> {
-    let outdir = optional_out_dir.unwrap_or_else(out_dir);
+pub fn build<P1: AsRef<Path>>(rs_file: P1, autocxx_inc: &str) -> Result<cc::Build, Error> {
+    build_to_custom_directory(rs_file, autocxx_inc, out_dir())
+}
+
+/// Like build, but you can specify the location where files should be generated.
+/// Not generally recommended for use in build scripts.
+pub fn build_to_custom_directory<P1: AsRef<Path>>(
+    rs_file: P1,
+    autocxx_inc: &str,
+    outdir: PathBuf,
+) -> Result<cc::Build, Error> {
     let gendir = outdir.join("autocxx-build");
     let incdir = gendir.join("include");
     ensure_created(&incdir)?;

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -100,6 +100,9 @@ impl Builder {
         if counter == 0 {
             Err(Error::NoIncludeCxxMacrosFound)
         } else {
+            // Configure cargo to give the same set of include paths to autocxx
+            // when expanding the macro.
+            println!("cargo:rustc-env=AUTOCXX_INC={}", autocxx_inc);
             Ok(Builder {
                 build: builder,
                 _tdir: tdir,

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -40,101 +40,80 @@ pub enum Error {
     UnableToCreateDirectory(std::io::Error, PathBuf),
 }
 
-/// Structure for use in a build.rs file to aid with conversion
-/// of a `include_cxx!` macro into a `cc::Build`.
-/// This structure owns a temporary directory containing
-/// the generated C++ code, as well as owning the cc::Build
-/// which knows how to build it.
-/// Typically you'd use this from a build.rs file by
-/// using `new` and then using `builder` to fetch the `cc::Build`
-/// object and asking the resultant `cc::Build` to compile the code.
-/// You'll also need to set the `AUTOCXX_INC` environment variable
-/// to specify the path for finding header files.
-pub struct Builder {
-    build: cc::Build,
+/// Build autocxx C++ files and return a cc::Build you can use to build
+/// more from a build.rs file.
+pub fn build<P1: AsRef<Path>>(rs_file: P1, autocxx_inc: &str) -> Result<cc::Build, Error> {
+    let gendir = out_dir().join("autocxx-build");
+    let incdir = gendir.join("include");
+    ensure_created(&incdir)?;
+    let cxxdir = gendir.join("cxx");
+    ensure_created(&cxxdir)?;
+    // We are incredibly unsophisticated in our directory arrangement here
+    // compared to cxx. I have no doubt that we will need to replicate just
+    // about everything cxx does, in due course...
+    let mut builder = cc::Build::new();
+    builder.cpp(true);
+    // Write cxx.h to that location, as it may be needed by
+    // some of our generated code.
+    write_to_file(&incdir, "cxx.h", autocxx_engine::HEADER.as_bytes())?;
+    let autocxx_inc = append_extra_path(autocxx_inc, incdir.clone());
+    let autocxxes =
+        autocxx_engine::parse_file(rs_file, Some(&autocxx_inc)).map_err(Error::ParseError)?;
+    let mut counter = 0;
+    for include_cpp in autocxxes {
+        for inc_dir in include_cpp
+            .include_dirs()
+            .map_err(Error::IncludeDirProblem)?
+        {
+            builder.include(inc_dir);
+        }
+        let generated_code = include_cpp
+            .generate_h_and_cxx()
+            .map_err(Error::InvalidCxx)?;
+        for filepair in generated_code.0 {
+            let fname = format!("gen{}.cxx", counter);
+            counter += 1;
+            let gen_cxx_path = write_to_file(&cxxdir, &fname, &filepair.implementation)?;
+            builder.file(gen_cxx_path);
+
+            write_to_file(&incdir, &filepair.header_name, &filepair.header)?;
+        }
+    }
+    if counter == 0 {
+        Err(Error::NoIncludeCxxMacrosFound)
+    } else {
+        // Configure cargo to give the same set of include paths to autocxx
+        // when expanding the macro.
+        println!("cargo:rustc-env=AUTOCXX_INC={}", autocxx_inc);
+        Ok(builder)
+    }
 }
 
-impl Builder {
-    /// Construct a Builder.
-    pub fn new<P1: AsRef<Path>>(rs_file: P1, autocxx_inc: &str) -> Result<Self, Error> {
-        let gendir = Self::out_dir().join("autocxx-build");
-        let incdir = gendir.join("include");
-        Self::ensure_created(&incdir)?;
-        let cxxdir = gendir.join("cxx");
-        Self::ensure_created(&cxxdir)?;
-        // We are incredibly unsophisticated in our directory arrangement here
-        // compared to cxx. I have no doubt that we will need to replicate just
-        // about everything cxx does, in due course...
-        let mut builder = cc::Build::new();
-        builder.cpp(true);
-        // Write cxx.h to that location, as it may be needed by
-        // some of our generated code.
-        Self::write_to_file(&incdir, "cxx.h", autocxx_engine::HEADER.as_bytes())?;
-        let autocxx_inc = Self::append_extra_path(autocxx_inc, incdir.clone());
-        let autocxxes =
-            autocxx_engine::parse_file(rs_file, Some(&autocxx_inc)).map_err(Error::ParseError)?;
-        let mut counter = 0;
-        for include_cpp in autocxxes {
-            for inc_dir in include_cpp
-                .include_dirs()
-                .map_err(Error::IncludeDirProblem)?
-            {
-                builder.include(inc_dir);
-            }
-            let generated_code = include_cpp
-                .generate_h_and_cxx()
-                .map_err(Error::InvalidCxx)?;
-            for filepair in generated_code.0 {
-                let fname = format!("gen{}.cxx", counter);
-                counter += 1;
-                let gen_cxx_path = Self::write_to_file(&cxxdir, &fname, &filepair.implementation)?;
-                builder.file(gen_cxx_path);
+fn ensure_created(dir: &PathBuf) -> Result<(), Error> {
+    std::fs::create_dir_all(dir).map_err(|e| Error::UnableToCreateDirectory(e, dir.clone()))
+}
 
-                Self::write_to_file(&incdir, &filepair.header_name, &filepair.header)?;
-            }
-        }
-        if counter == 0 {
-            Err(Error::NoIncludeCxxMacrosFound)
-        } else {
-            // Configure cargo to give the same set of include paths to autocxx
-            // when expanding the macro.
-            println!("cargo:rustc-env=AUTOCXX_INC={}", autocxx_inc);
-            Ok(Builder { build: builder })
-        }
-    }
+fn out_dir() -> PathBuf {
+    std::env::var_os("OUT_DIR").map(PathBuf::from).unwrap()
+}
 
-    fn ensure_created(dir: &PathBuf) -> Result<(), Error> {
-        std::fs::create_dir_all(dir).map_err(|e| Error::UnableToCreateDirectory(e, dir.clone()))
-    }
+fn append_extra_path(path_list: &str, extra_path: PathBuf) -> String {
+    let mut paths = std::env::split_paths(&path_list).collect::<Vec<_>>();
+    paths.push(extra_path);
+    std::env::join_paths(paths)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string()
+}
 
-    fn out_dir() -> PathBuf {
-        std::env::var_os("OUT_DIR").map(PathBuf::from).unwrap()
-    }
+fn write_to_file(dir: &PathBuf, filename: &str, content: &[u8]) -> Result<PathBuf, Error> {
+    let path = dir.join(filename);
+    try_write_to_file(&path, content).map_err(|e| Error::FileWriteFail(e, path.clone()))?;
+    Ok(path)
+}
 
-    fn append_extra_path(path_list: &str, extra_path: PathBuf) -> String {
-        let mut paths = std::env::split_paths(&path_list).collect::<Vec<_>>();
-        paths.push(extra_path);
-        std::env::join_paths(paths)
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string()
-    }
-
-    /// Fetch the cc::Build from this.
-    pub fn builder(&mut self) -> &mut cc::Build {
-        &mut self.build
-    }
-
-    fn write_to_file(dir: &PathBuf, filename: &str, content: &[u8]) -> Result<PathBuf, Error> {
-        let path = dir.join(filename);
-        Self::try_write_to_file(&path, content)
-            .map_err(|e| Error::FileWriteFail(e, path.clone()))?;
-        Ok(path)
-    }
-
-    fn try_write_to_file(path: &PathBuf, content: &[u8]) -> std::io::Result<()> {
-        let mut f = File::create(path)?;
-        f.write_all(content)
-    }
+fn try_write_to_file(path: &PathBuf, content: &[u8]) -> std::io::Result<()> {
+    let mut f = File::create(path)?;
+    f.write_all(content)
 }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -42,8 +42,15 @@ pub enum Error {
 
 /// Build autocxx C++ files and return a cc::Build you can use to build
 /// more from a build.rs file.
-pub fn build<P1: AsRef<Path>>(rs_file: P1, autocxx_inc: &str) -> Result<cc::Build, Error> {
-    let gendir = out_dir().join("autocxx-build");
+/// You need to provide the Rust file path and the list of paths
+/// which should be used as include directories (as a string separated
+/// by the normal path separator on your platform; that may seem weird
+/// but it's because it's passed around as an environment variable.)
+/// You can optionally pass the directory into which you'd like generated
+/// files output, but normally, give None.
+pub fn build<P1: AsRef<Path>>(rs_file: P1, autocxx_inc: &str, optional_out_dir: Option<PathBuf>) -> Result<cc::Build, Error> {
+    let outdir = optional_out_dir.unwrap_or_else(out_dir);
+    let gendir = outdir.join("autocxx-build");
     let incdir = gendir.join("include");
     ensure_created(&incdir)?;
     let cxxdir = gendir.join("cxx");


### PR DESCRIPTION
We need a `make_string(&str)` function which can return a `UniquePtr<CxxString>`, which is a very common type absorbed by existing C++ APIs (specifically, since functions that take `std::string` have a wrapper created in order that they take `std::unique_ptr<std::string>` instead).

This PR is in progress. The `build.rs` in demo is broken.