### PR TITLE
First part of namespace work.

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -177,7 +177,6 @@ fn do_run_test(
         }
     });
 
-
     // After this point we start taking liberties for speed
     // unless we're testing the full pipeline explicitly.
     let be_quick = match method {
@@ -188,7 +187,9 @@ fn do_run_test(
     let include_bit = if be_quick {
         quote!()
     } else {
-        quote!(use autocxx::include_cxx;)
+        quote!(
+            use autocxx::include_cxx;
+        )
     };
     let unexpanded_rust = quote! {
         #include_bit
@@ -207,7 +208,6 @@ fn do_run_test(
         extern {}
     };
     info!("Unexpanded Rust: {}", unexpanded_rust);
-
 
     let mut expanded_rust;
     let rs_path: PathBuf;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -20,7 +20,7 @@ mod preprocessor_parse_callbacks;
 mod rust_pretty_printer;
 mod types;
 
-#[cfg(any(test,feature = "build"))]
+#[cfg(any(test, feature = "build"))]
 mod builder;
 
 #[cfg(test)]
@@ -42,7 +42,7 @@ use std::rc::Rc;
 use std::sync::Mutex;
 use types::TypeName;
 
-#[cfg(any(test,feature = "build"))]
+#[cfg(any(test, feature = "build"))]
 pub use builder::{build, BuilderError};
 pub use parse::{parse_file, parse_token_stream, ParseError, ParsedFile};
 
@@ -139,7 +139,7 @@ impl IncludeCpp {
                 let allow: syn::LitStr = args.parse()?;
                 allowlist.push(allow.value());
                 if ident == "AllowPOD" {
-                    pod_types.push(TypeName::new(&allow.value()));
+                    pod_types.push(TypeName::new_from_user_input(&allow.value()));
                 }
             } else if ident == "ParseOnly" {
                 parse_only = true;
@@ -221,6 +221,7 @@ impl IncludeCpp {
             .default_enum_style(bindgen::EnumVariation::Rust {
                 non_exhaustive: false,
             })
+            .enable_cxx_namespaces()
             .layout_tests(false); // TODO revisit later
         for item in types::get_initial_blocklist() {
             builder = builder.blacklist_item(item);
@@ -436,18 +437,5 @@ impl IncludeCpp {
     /// Get the configured include directories.
     pub fn include_dirs(&self) -> Result<Vec<PathBuf>> {
         self.determine_incdirs()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::TypeName;
-
-    #[test]
-    fn test_typename() {
-        let s = proc_macro2::Span::call_site();
-        let id = syn::Ident::new("Bob", s);
-        let tn = TypeName::from_ident(&id);
-        assert_eq!(tn.to_ident(), id);
     }
 }

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -17,79 +17,145 @@ use lazy_static::lazy_static;
 use proc_macro2::Span;
 use std::collections::HashMap;
 use std::fmt::Display;
-use syn::{Ident, Type, TypePath};
+use std::iter::Peekable;
+use syn::parse_quote;
+use syn::{Ident, PathSegment, Type, TypePath};
 
-/// Any time we store a type name, we should use this.
-/// At the moment it's just a string, but one day it will need to become
-/// sufficiently intelligent to handle namespaces.
-/// This should store the canonical Rust-side name, e.g.
-/// u32, or CxxString. Not uint32_t, nor std_string, etc.
+/// Any time we store a type name, we should use this. Stores the type
+/// and its namespace. Namespaces should be stored without any
+/// 'bindgen::root' prefix; that means a type not in any C++
+/// namespace should have an empty namespace segment list.
+/// Some types have names that change as they flow through the
+/// autocxx pipeline. e.g. you start with std::string
+/// and end up with CxxString. This TypeName type can store
+/// either. It doesn't directly have functionality to convert
+/// from one to the other; `replace_type_path_without_arguments`
+/// does that.
 #[derive(Debug, PartialEq, PartialOrd, Eq, Hash, Clone)]
-pub struct TypeName(String);
+pub struct TypeName(Vec<String>, String);
 
 impl TypeName {
     pub(crate) fn from_ident(id: &Ident) -> Self {
-        TypeName::new(&id.to_string())
+        Self(Vec::new(), id.to_string())
     }
 
-    pub(crate) fn from_type_path(p: &TypePath) -> Self {
-        // TODO better handle generics, multi-segment paths, etc.
-        TypeName::from_ident(TypeName::parse_type_path(p))
+    /// From a TypePath which does not start with 'root'.
+    pub(crate) fn from_cxx_type_path(typ: &TypePath) -> Self {
+        let seg_iter = typ.path.segments.iter().peekable();
+        Self::from_segments(seg_iter)
     }
 
-    pub(crate) fn from_type(ty: &Type) -> Self {
+    /// From a TypePath which starts with 'root'
+    pub(crate) fn from_bindgen_type_path(typ: &TypePath) -> Self {
+        let mut seg_iter = typ.path.segments.iter().peekable();
+        let first_seg = seg_iter.next().unwrap().ident.clone();
+        if first_seg.to_string() == "root" {
+            // This is a C++ type prefixed with a namespace,
+            // e.g. std::string or something the user has defined.
+            Self::from_segments(seg_iter) // all but 'root'
+        } else {
+            // This is a primitive e.g. u32
+            assert!(seg_iter.next().is_none());
+            Self::from_ident(&first_seg)
+        }
+    }
+
+    fn from_segments<'a, T: Iterator<Item = &'a PathSegment>>(mut seg_iter: Peekable<T>) -> Self {
+        let mut ns = Vec::new();
+        while let Some(seg) = seg_iter.next() {
+            if seg_iter.peek().is_some() {
+                ns.push(seg.ident.to_string());
+            } else {
+                return Self(ns, seg.ident.to_string());
+            }
+        }
+        unreachable!()
+    }
+
+    fn from_type<F>(ty: &Type, func: F) -> Self
+    where
+        F: FnOnce(&TypePath) -> Self,
+    {
         match ty {
-            Type::Path(typ) => TypeName::from_type_path(typ),
+            Type::Path(typ) => func(typ),
             _ => panic!("Stringifying unknown type, not yet supported"), // TODO
         }
     }
 
-    pub(crate) fn new(id: &str) -> Self {
-        let canonical_name = KNOWN_TYPES.by_deadname.get(id);
-        if let Some(canonical_name) = canonical_name {
-            // This is already a cxx replacement name, e.g. CxxString.
-            TypeName::new_unchecked(canonical_name)
+    /// From a Type found in bindgen-generated Rust code.
+    /// The Type starts with 'root' typically.
+    pub(crate) fn from_bindgen_type(ty: &Type) -> Self {
+        Self::from_type(ty, Self::from_bindgen_type_path)
+    }
+
+    /// From a Type found in code we've already generated.
+    pub(crate) fn from_cxx_type(ty: &Type) -> Self {
+        Self::from_type(ty, Self::from_cxx_type_path)
+    }
+
+    /// Create from a type encountered in the code.
+    pub(crate) fn new(ns: &Vec<String>, id: &str) -> Self {
+        Self(ns.clone(), id.to_string())
+    }
+
+    /// Create from user input, e.g. a name in an AllowPOD directive.
+    pub(crate) fn new_from_user_input(id: &str) -> Self {
+        let mut seg_iter = id.split("::").peekable();
+        let mut ns = Vec::new();
+        while let Some(seg) = seg_iter.next() {
+            if seg_iter.peek().is_some() {
+                ns.push(seg.to_string());
+            } else {
+                return Self(ns, seg.to_string());
+            }
+        }
+        unreachable!()
+    }
+
+    /// Return the actual type name, without any namespace
+    /// qualification. Avoid unless you have a good reason.
+    pub(crate) fn get_final_ident(&self) -> &str {
+        &self.1
+    }
+
+    /// Output the fully-qualified C++ name of this type.
+    pub(crate) fn to_cpp_name(&self) -> String {
+        let td = KNOWN_TYPES.by_rs_name.get(&self);
+        if let Some(td) = td {
+            td.cpp_name.to_string()
         } else {
-            TypeName::new_unchecked(id)
-        }
-    }
-    fn new_unchecked(id: &str) -> Self {
-        TypeName(id.into())
-    }
-
-    pub(crate) fn to_ident(&self) -> Ident {
-        Ident::new(&self.0, Span::call_site())
-    }
-
-    pub(crate) fn to_cpp_name(&self) -> &str {
-        match KNOWN_TYPES.by_cxx_name.get(&self) {
-            None => &self.0,
-            Some(replacement) => &replacement.cpp_name.as_str(),
+            let mut s = String::new();
+            for seg in &self.0 {
+                s.push_str(&seg);
+                s.push_str("::");
+            }
+            s.push_str(&self.1);
+            s
         }
     }
 
-    /// Whether the given function name is prefixed by this type name
-    /// and an underscore.
-    /// If so, returns the suffix after that point.
-    pub(crate) fn prefixes<'a>(&self, func_name: &'a str) -> Option<&'a str> {
-        if func_name.starts_with(&self.0) {
-            Some(&func_name[self.0.len() + 1..])
-        } else {
-            None
-        }
+    /// Iterator over segments in the namespace of this type.
+    pub(crate) fn ns_segment_iter(&self) -> impl Iterator<Item = &String> {
+        self.0.iter()
     }
+}
 
-    fn parse_type_path(p: &TypePath) -> &Ident {
-        &p.path.segments.last().unwrap().ident
-    }
+fn make_ident(id: &str) -> Ident {
+    Ident::new(id, Span::call_site())
 }
 
 impl Display for TypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        for seg in &self.0 {
+            f.write_str(&seg)?;
+            f.write_str("::")?;
+        }
+        f.write_str(&self.1)
     }
 }
 
+/// Whether this type should be included in the 'prelude'
+/// passed to bindgen, and if so, how.
 #[derive(Debug)]
 enum PreludePolicy {
     Exclude,
@@ -97,30 +163,36 @@ enum PreludePolicy {
     IncludeTemplated,
 }
 
+/// Details about known special types, mostly primitives.
 #[derive(Debug)]
-pub(crate) struct TypeDetails {
-    /// The name used by cxx for this type.
-    cxx_name: String,
+struct TypeDetails {
+    /// The name used by cxx (in Rust code) for this type.
+    rs_name: String,
     /// C++ equivalent name for a Rust type.
-    pub(crate) cpp_name: String,
+    cpp_name: String,
     /// Whether this can be safely represented by value.
-    pub(crate) by_value_safe: bool,
+    by_value_safe: bool,
     /// Whether and how to include this in the prelude given to bindgen.
     prelude_policy: PreludePolicy,
+    /// Whether this is a & on the Rust side but a value on the C++
+    /// side. Only applies to &str.
+    de_referencicate: bool,
 }
 
 impl TypeDetails {
     fn new(
-        cxx_name: String,
+        rs_name: String,
         cpp_name: String,
         by_value_safe: bool,
         prelude_policy: PreludePolicy,
+        de_referencicate: bool,
     ) -> Self {
         TypeDetails {
-            cxx_name,
+            rs_name,
             cpp_name,
             by_value_safe,
             prelude_policy,
+            de_referencicate,
         }
     }
 
@@ -128,8 +200,7 @@ impl TypeDetails {
         match self.prelude_policy {
             PreludePolicy::Exclude => None,
             PreludePolicy::IncludeNormal | PreludePolicy::IncludeTemplated => {
-                let proper_cpp_name = &self.cpp_name;
-                let cxx_name = &self.cxx_name;
+                let cxx_name = &self.rs_name;
                 let (templating, payload) = match self.prelude_policy {
                     PreludePolicy::IncludeNormal => ("", "char* ptr"),
                     PreludePolicy::IncludeTemplated => ("template<typename T> ", "T* ptr"),
@@ -145,60 +216,57 @@ impl TypeDetails {
                     }};
 
                     "},
-                    proper_cpp_name, templating, cxx_name, payload
+                    self.cpp_name, templating, cxx_name, payload
                 ))
             }
         }
     }
-
-    fn deadname(&self) -> Option<String> {
-        let deadname = self.cpp_name.replace("::", "_");
-        if deadname != self.cpp_name {
-            Some(deadname)
-        } else {
-            None
-        }
-    }
 }
 
+/// Database of known types.
 struct TypeDatabase {
-    by_cxx_name: HashMap<TypeName, TypeDetails>,
-    by_deadname: HashMap<String, String>,
+    by_rs_name: HashMap<TypeName, TypeDetails>,
+    by_cppname: HashMap<String, String>,
 }
 
 lazy_static! {
+    /// Database of known types.
     static ref KNOWN_TYPES: TypeDatabase = create_type_database();
 }
 
 fn create_type_database() -> TypeDatabase {
-    let mut by_cxx_name = HashMap::new();
+    let mut by_rs_name = HashMap::new();
 
     let mut do_insert =
-        |td: TypeDetails| by_cxx_name.insert(TypeName::new_unchecked(&td.cxx_name), td);
+        |td: TypeDetails| by_rs_name.insert(TypeName::new_from_user_input(&td.rs_name), td);
 
     do_insert(TypeDetails::new(
         "UniquePtr".into(),
         "std::unique_ptr".into(),
         true,
         PreludePolicy::IncludeTemplated,
+        false,
     ));
     do_insert(TypeDetails::new(
         "CxxString".into(),
         "std::string".into(),
         false,
         PreludePolicy::IncludeNormal,
+        false,
     ));
     do_insert(TypeDetails::new(
         "str".into(),
         "rust::Str".into(),
         true,
         PreludePolicy::IncludeNormal,
+        true,
     ));
     do_insert(TypeDetails::new(
         "String".into(),
         "rust::String".into(),
         true,
         PreludePolicy::IncludeNormal,
+        false,
     ));
     for (cpp_type, rust_type) in (3..7)
         .map(|x| 2i32.pow(x))
@@ -215,22 +283,28 @@ fn create_type_database() -> TypeDatabase {
             cpp_type,
             true,
             PreludePolicy::Exclude,
+            false,
         ));
     }
 
-    let mut by_deadname = HashMap::new();
-    for td in by_cxx_name.values() {
-        if let Some(deadname) = td.deadname() {
-            by_deadname.insert(deadname, td.cxx_name.clone());
-        }
+    let mut by_cppname = HashMap::new();
+    for td in by_rs_name.values() {
+        by_cppname.insert(td.cpp_name.clone(), td.rs_name.clone());
     }
 
     TypeDatabase {
-        by_cxx_name,
-        by_deadname,
+        by_rs_name,
+        by_cppname,
     }
 }
 
+/// This is worked out basically using trial and error.
+/// Excluding std* and rust* is obvious, but the other items...
+/// in theory bindgen ought to be smart enough to work out that
+/// they're not used and therefore not generate code for them.
+/// But it doesm unless we blocklist them. This is obviously
+/// a bit sensitive to the particular STL in use so one day
+/// it would be good to dig into bindgen's behavior here - TODO.
 const BINDGEN_BLOCKLIST: &[&str] = &["std.*", "__gnu.*", ".*mbstate_t.*", "rust.*"];
 
 /// Prelude of C++ for squirting into bindgen. This configures
@@ -244,43 +318,63 @@ const BINDGEN_BLOCKLIST: &[&str] = &["std.*", "__gnu.*", ".*mbstate_t.*", "rust.
 pub(crate) fn get_prelude() -> String {
     itertools::join(
         KNOWN_TYPES
-            .by_cxx_name
+            .by_rs_name
             .values()
             .filter_map(|t| t.get_prelude_entry()),
         "\n",
     )
 }
 
+/// Types which are known to be safe (or unsafe) to hold and pass by
+/// value in Rust.
 pub(crate) fn get_pod_safe_types() -> Vec<(TypeName, bool)> {
     KNOWN_TYPES
-        .by_cxx_name
+        .by_rs_name
         .iter()
-        .map(|(tn, td)| (tn.clone(), td.by_value_safe))
+        .map(|(_, td)| {
+            (
+                TypeName::from_ident(&make_ident(&td.rs_name)),
+                td.by_value_safe,
+            )
+        })
         .collect()
 }
 
-pub(crate) fn to_cpp_name(typ: &Type) -> String {
-    match typ {
-        Type::Path(ref typ) => TypeName::from_type_path(typ).to_cpp_name().to_string(),
-        Type::Reference(ref typr) => {
-            let const_bit = match typr.mutability {
-                None => "const ",
-                Some(_) => "",
-            };
-            format!(
-                "{}{}&",
-                const_bit,
-                TypeName::from_type(typr.elem.as_ref())
-                    .to_cpp_name()
-                    .to_string()
-            )
-        }
-        _ => unimplemented!(),
+/// Get the list of types to give to bindgen to ask it _not_ to
+/// generate code for.
+pub(crate) fn get_initial_blocklist() -> Vec<String> {
+    BINDGEN_BLOCKLIST.iter().map(|s| s.to_string()).collect()
+}
+
+/// Whether this TypePath should be treated as a value in C++
+/// but a reference in Rust. This only applies to rust::Str
+/// (C++ name) which is &str in Rust.
+pub(crate) fn should_dereference_in_cpp(typ: &TypePath) -> bool {
+    let tn = TypeName::from_cxx_type_path(typ);
+    let td = KNOWN_TYPES.by_rs_name.get(&tn);
+    if let Some(td) = td {
+        td.de_referencicate
+    } else {
+        false
     }
 }
 
-pub(crate) fn get_initial_blocklist() -> Vec<String> {
-    BINDGEN_BLOCKLIST.iter().map(|s| s.to_string()).collect()
+/// Here we substitute any names which we know are Special from
+/// our type database, e.g. std::unique_ptr -> UniquePtr.
+/// The 'without_arguments' bit means we strip off and ignore
+/// any PathArguments within this TypePath - callers should
+/// put them back again if needs be.
+pub(crate) fn replace_type_path_without_arguments(typ: TypePath) -> TypePath {
+    let name = TypeName::from_cxx_type_path(&typ).to_cpp_name();
+    match KNOWN_TYPES.by_cppname.get(&name) {
+        Some(replacement_name) => {
+            let id = make_ident(replacement_name);
+            parse_quote! {
+                #id
+            }
+        }
+        None => typ.clone(),
+    }
 }
 
 #[cfg(test)]
@@ -289,7 +383,10 @@ mod tests {
 
     #[test]
     fn test_ints() {
-        assert_eq!(TypeName::new("i8").to_cpp_name(), "int8_t");
-        assert_eq!(TypeName::new("u64").to_cpp_name(), "uint64_t");
+        assert_eq!(TypeName::new_from_user_input("i8").to_cpp_name(), "int8_t");
+        assert_eq!(
+            TypeName::new_from_user_input("u64").to_cpp_name(),
+            "uint64_t"
+        );
     }
 }


### PR DESCRIPTION
This change asks `bindgen` to generate information about C++ namespaces.
`bindgen` does this by outputting a hierarchic structure of 'mods'. This change
contains all the changes required to autocxx to be able to handle the bindgen
input when it's generated in that mode.

It doesn't yet actually pass that namespace information across to cxx,
and therefore this is useless at actually working with namespaces. That
will come in the future.

Works towards #50.