### PR TITLE
Support returning references.

### DIFF
--- a/engine/src/additional_cpp_generator.rs
+++ b/engine/src/additional_cpp_generator.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::types::TypeName;
+use crate::types::{type_to_cpp, TypeName};
 use itertools::Itertools;
 use std::collections::HashSet;
 use syn::{parse_quote, Ident, Type};
@@ -95,21 +95,9 @@ impl ArgumentConversion {
     }
 
     fn unwrapped_type_as_string(&self) -> String {
-        match self.unwrapped_type {
-            Type::Path(ref typ) => TypeName::from_bindgen_type_path(typ).to_cpp_name(),
-            Type::Reference(ref typr) => {
-                let const_bit = match typr.mutability {
-                    None => "const ",
-                    Some(_) => "",
-                };
-                format!(
-                    "{}{}&",
-                    const_bit,
-                    TypeName::from_bindgen_type(typr.elem.as_ref()).to_cpp_name()
-                )
-            }
-            _ => unimplemented!(),
-        }
+        // TODO it's not clear why I'm using from_bindgen_type_path
+        // not from_cxx_type_path. May be a bug.
+        type_to_cpp(&self.unwrapped_type, TypeName::from_bindgen_type_path)
     }
 
     fn wrapped_type(&self) -> String {

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -1892,6 +1892,28 @@ fn test_ns_func() {
     run_test(cxx, hdr, rs, &["C::give_bob"], &["A::B::Bob"]);
 }
 
+#[test]
+fn test_return_reference() {
+    let cxx = indoc! {"
+        const Bob& give_bob(const Bob& input_bob) {
+            return input_bob;
+        }
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct Bob {
+            uint32_t a;
+            uint32_t b;
+        };
+        const Bob& give_bob(const Bob& input_bob);
+    "};
+    let rs = quote! {
+        let b = ffi::Bob { a: 3, b: 4 };
+        assert_eq!(ffi::give_bob(&b).b, 4);
+    };
+    run_test(cxx, hdr, rs, &["give_bob"], &["Bob"]);
+}
+
 // Yet to test:
 // 1. Make UniquePtr<CxxStrings> in Rust
 // 3. Constants


### PR DESCRIPTION
Fixes a bug where we tried to shoehorn a reference type into a `TypeName`. No test added, yet.