### PR TITLE
Add tests for classes with destructors and classes with static methods.

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -1892,6 +1892,49 @@ fn test_ns_func() {
     run_test(cxx, hdr, rs, &["C::give_bob"], &["A::B::Bob"]);
 }
 
+#[test]
+#[ignore]
+fn test_destructor() {
+    let hdr = indoc! {"
+        struct WithDtor {
+            ~WithDtor();
+        };
+        WithDtor make_with_dtor();
+    "};
+    let cxx = indoc! {"
+        WithDtor::~WithDtor() {}
+        WithDtor make_with_dtor() {
+            return {};
+        }
+    "};
+    let rs = quote! {
+        use ffi::*;
+        let with_dtor: cxx::UniquePtr<WithDtor> = make_with_dtor();
+        drop(with_dtor);
+    };
+    run_test(cxx, hdr, rs, &["WithDtor", "make_with_dtor"], &[]);
+}
+
+#[test]
+#[ignore]
+fn test_static_func() {
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct WithStaticMethod {
+            static uint32_t call();
+        };
+    "};
+    let cxx = indoc! {"
+        WithStaticMethod::call() {
+            return 42;
+        }
+    "};
+    let rs = quote! {
+        assert_eq!(ffi::cxx::WithStaticMethod::call(), 42);
+    };
+    run_test(cxx, hdr, rs, &["WithStaticMethod"], &[]);
+}
+
 // Yet to test:
 // 1. Make UniquePtr<CxxStrings> in Rust
 // 3. Constants


### PR DESCRIPTION
These tests marked `#[ignore]` because they're currently failing with the following errors.

`test_destructor`:
```
cargo:warning=/tmp/.tmpBrQ9U1/gen0.cxx: In function ‘void cxxbridge05$WithDtor$WithDtor_destructor(WithDtor&)’:
cargo:warning=/tmp/.tmpBrQ9U1/gen0.cxx:81:61: error: ‘WithDtor_destructor’ is not a member of ‘WithDtor’
cargo:warning=   81 |   void (::WithDtor::*WithDtor_destructor$)() = &::WithDtor::WithDtor_destructor;
cargo:warning=      |                                                             ^~~~~~~~~~~~~~~~~~~
```

`test_static_func`:
```
cargo:warning=/tmp/.tmp7YDez1/gen0.cxx: In function ‘uint32_t cxxbridge05$WithStaticMethod_call()’:
cargo:warning=/tmp/.tmp7YDez1/gen0.cxx:81:44: error: ‘::WithStaticMethod_call’ has not been declared; did you mean ‘WithStaticMethod_call$’?
cargo:warning=   81 |   uint32_t (*WithStaticMethod_call$)() = ::WithStaticMethod_call;
cargo:warning=      |                                            ^~~~~~~~~~~~~~~~~~~~~
cargo:warning=      |                                            WithStaticMethod_call$
```