### PR TITLE
Typedefs phase 1

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -1956,6 +1956,97 @@ fn test_static_func() {
     run_test(cxx, hdr, rs, &["WithStaticMethod"], &[]);
 }
 
+#[test]
+fn test_give_pod_typedef_by_value() {
+    let cxx = indoc! {"
+        Horace give_bob() {
+            Horace a;
+            a.a = 3;
+            a.b = 4;
+            return a;
+        }
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct Bob {
+            uint32_t a;
+            uint32_t b;
+        };
+        using Horace = Bob;
+        Horace give_bob();
+    "};
+    let rs = quote! {
+        assert_eq!(ffi::give_bob().b, 4);
+    };
+    run_test(cxx, hdr, rs, &["give_bob"], &["Bob"]);
+}
+
+#[ignore] // because we need to put some aliases in the output ffi mod.
+#[test]
+fn test_use_pod_typedef() {
+    let cxx = indoc! {"
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct Bob {
+            uint32_t a;
+            uint32_t b;
+        };
+        using Horace = Bob;
+    "};
+    let rs = quote! {
+        let h = Horace { a: 3, b: 4 };
+        assert_eq!(h.b, 4);
+    };
+    run_test(cxx, hdr, rs, &[], &["Bob"]);
+}
+
+#[ignore] // we don't yet allow typedefs to be listed in allow_pod
+#[test]
+fn test_use_pod_typedef_with_allowpod() {
+    let cxx = indoc! {"
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct Bob {
+            uint32_t a;
+            uint32_t b;
+        };
+        using Horace = Bob;
+    "};
+    let rs = quote! {
+        let h = Horace { a: 3, b: 4 };
+        assert_eq!(h.b, 4);
+    };
+    run_test(cxx, hdr, rs, &[], &["Horace"]);
+}
+
+#[test]
+fn test_give_nonpod_typedef_by_value() {
+    let cxx = indoc! {"
+        Horace give_bob() {
+            Horace a;
+            a.a = 3;
+            a.b = 4;
+            return a;
+        }
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct Bob {
+            uint32_t a;
+            uint32_t b;
+        };
+        using Horace = Bob;
+        Horace give_bob();
+        inline uint32_t take_horace(const Horace& horace) { return horace.b; }
+    "};
+    let rs = quote! {
+        assert_eq!(ffi::take_horace(ffi::give_bob().as_ref().unwrap()), 4);
+    };
+    run_test(cxx, hdr, rs, &["give_bob", "take_horace"], &[]);
+}
+
 // Yet to test:
 // 1. Make UniquePtr<CxxStrings> in Rust
 // 3. Constants
@@ -1963,7 +2054,6 @@ fn test_static_func() {
 // 6. Ifdef
 // 7. Out params
 // 8. Opaque type handling
-// 9. Multiple functions in one header
 // 10. ExcludeUtilities
 // Stuff which requires much more thought:
 // 1. Shared pointers

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -158,6 +158,13 @@ fn create_type_database() -> TypeDatabase {
         PreludePolicy::Exclude,
         false,
     ));
+    do_insert(TypeDetails::new(
+        "std::os::raw::c_ulong".into(),
+        "ulong".into(),
+        true,
+        PreludePolicy::Exclude,
+        false,
+    ));
 
     let mut by_cppname = HashMap::new();
     for td in by_rs_name.values() {
@@ -203,12 +210,7 @@ pub(crate) fn get_pod_safe_types() -> Vec<(TypeName, bool)> {
     KNOWN_TYPES
         .by_rs_name
         .iter()
-        .map(|(_, td)| {
-            (
-                TypeName::from_ident(&make_ident(&td.rs_name)),
-                td.by_value_safe,
-            )
-        })
+        .map(|(_, td)| (TypeName::new_from_user_input(&td.rs_name), td.by_value_safe))
         .collect()
 }
 

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -158,13 +158,22 @@ fn create_type_database() -> TypeDatabase {
         PreludePolicy::Exclude,
         false,
     ));
-    do_insert(TypeDetails::new(
-        "std::os::raw::c_ulong".into(),
-        "ulong".into(),
-        true,
-        PreludePolicy::Exclude,
-        false,
-    ));
+
+    let mut insert_ctype = |cname: &str| {
+        let td = TypeDetails::new(
+            format!("std::os::raw::c_{}", cname),
+            cname.into(),
+            true,
+            PreludePolicy::Exclude,
+            false,
+        );
+        by_rs_name.insert(TypeName::new_from_user_input(&td.rs_name), td);
+    };
+
+    insert_ctype("ulong");
+    insert_ctype("uint");
+    insert_ctype("long");
+    insert_ctype("int");
 
     let mut by_cppname = HashMap::new();
     for td in by_rs_name.values() {

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -94,6 +94,10 @@ impl TypeName {
             // This is a C++ type prefixed with a namespace,
             // e.g. std::string or something the user has defined.
             Self::from_segments(seg_iter) // all but 'root'
+        } else if first_seg == "std" {
+            // This is actually a Rust type e.g.
+            // std::os::raw::c_ulong. Start iterating from the beginning again.
+            Self::from_segments(typ.path.segments.iter().peekable())
         } else {
             // This is a primitive e.g. u32
             assert!(seg_iter.next().is_none());


### PR DESCRIPTION
From one concrete type to another.

This doesn't support the types being specified in allow_pod nor
does it yet suport typedefs to parameterized types or anything
else fancy. Nor does it support actual usage of the typedeffed
types in Rust code. There is much to do.

First step towards #85.