### PR TITLE
Duplicated method names

### DIFF
--- a/engine/src/additional_cpp_generator.rs
+++ b/engine/src/additional_cpp_generator.rs
@@ -123,7 +123,8 @@ impl ArgumentConversion {
 }
 
 pub(crate) struct ByValueWrapper {
-    pub(crate) id: Ident,
+    pub(crate) original_function_name: Ident,
+    pub(crate) wrapper_function_name: Ident,
     pub(crate) return_conversion: Option<ArgumentConversion>,
     pub(crate) argument_conversion: Vec<ArgumentConversion>,
     pub(crate) is_a_method: bool,
@@ -286,9 +287,9 @@ impl AdditionalCppGenerator {
     }
 
     fn generate_by_value_wrapper(&mut self, details: ByValueWrapper) {
-        let ident = details.id;
+        let ident = details.original_function_name;
         let is_a_method = details.is_a_method;
-        let name = format!("{}_up_wrapper", ident.to_string());
+        let name = details.wrapper_function_name;
         let get_arg_name = |counter: usize| -> String {
             if is_a_method && counter == 0 {
                 // For method calls that we generate, the first

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -2101,9 +2101,11 @@ fn test_conflicting_methods() {
 
 #[test]
 fn test_conflicting_up_wrapper_methods() {
+    // Ensures the two names 'get' do not conflict in the flat
+    // cxx::bridge mod namespace.
     let cxx = indoc! {"
-        Bob::Bob: a(\"hello\") {}
-        Fred::Fred: b(\"goodbye\") {}
+        Bob::Bob() : a(\"hello\") {}
+        Fred::Fred() : b(\"goodbye\") {}
         std::string Bob::get() const { return a; }
         std::string Fred::get() const { return b; }
     "};
@@ -2124,8 +2126,8 @@ fn test_conflicting_up_wrapper_methods() {
     let rs = quote! {
         let a = ffi::Bob::make_unique();
         let b = ffi::Fred::make_unique();
-        assert_eq!(a.get().unwrap().as_str().unwrap(), "hello");
-        assert_eq!(b.get().unwrap().as_str().unwrap(), "goodbye");
+        assert_eq!(a.get().as_ref().unwrap().to_str().unwrap(), "hello");
+        assert_eq!(b.get().as_ref().unwrap().to_str().unwrap(), "goodbye");
     };
     run_test(cxx, hdr, rs, &["Bob", "Fred"], &[]);
 }


### PR DESCRIPTION
In the absence of #77, allows our `UniquePtr` wrapper functions to avoid conflict.