### PR TITLE
Adjust unsafety policy.

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -15,8 +15,8 @@
 use autocxx::include_cpp;
 
 include_cpp! {
-    unsafe
     #include "input.h"
+    safety!(unsafe_ffi)
     generate!("DoMath")
 }
 

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -22,7 +22,9 @@ mod utilities;
 pub(crate) use api::ConvertError;
 use syn::{Item, ItemMod};
 
-use crate::{byvalue_scanner::identify_byvalue_safe_types, type_database::TypeDatabase};
+use crate::{
+    byvalue_scanner::identify_byvalue_safe_types, type_database::TypeDatabase, UnsafePolicy,
+};
 
 use self::{
     codegen::{CodeGenerator, CodegenResults},
@@ -61,6 +63,7 @@ impl<'a> BridgeConverter<'a> {
         &mut self,
         mut bindgen_mod: ItemMod,
         exclude_utilities: bool,
+        unsafe_policy: UnsafePolicy,
     ) -> Result<CodegenResults, ConvertError> {
         match &mut bindgen_mod.content {
             None => Err(ConvertError::NoContent),
@@ -75,7 +78,7 @@ impl<'a> BridgeConverter<'a> {
                 let byvalue_checker =
                     identify_byvalue_safe_types(&items_in_root, &self.type_database)?;
                 // Parse the bindgen mod.
-                let parser = ParseBindgen::new(byvalue_checker, &self.type_database);
+                let parser = ParseBindgen::new(byvalue_checker, &self.type_database, unsafe_policy);
                 let parse_results = parser.convert_items(items_in_root, exclude_utilities)?;
                 // The code above will have contributed lots of Apis to self.apis.
                 // We now garbage collect the ones we don't need...

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -216,8 +216,8 @@ fn do_run_test(
         #include_bit
 
         include_cpp!(
-            unsafe
             #hexathorpe include "input.h"
+            safety!(unsafe_ffi)
             #(#generate)*
             #(#generate_pods)*
             #extra_directives

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,14 +199,12 @@
 #[macro_export]
 macro_rules! include_cpp {
     (
-        unsafe
         $(#$include:ident $lit:literal)*
         $($mac:ident!($($arg:tt)*))*
     ) => {
         $($crate::$include!{__docs})*
         $($crate::$mac!{__docs})*
         $crate::include_cpp_impl! {
-            unsafe
             $(#include $lit)*
             $($mac!($($arg)*))*
         }
@@ -289,6 +287,42 @@ macro_rules! nested_type {
 /// [include_cpp] - see [include_cpp] for general information.
 #[macro_export]
 macro_rules! block {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
+/// Specifies a global safety policy for functions generated
+/// from these headers. By default (without such a `safety!`
+/// directive) all such functions are marked as `unsafe` and
+/// therefore can only be called within an `unsafe {}` block
+/// or some `unsafe` function which you create.
+///
+/// Alternatively, by specifying a `safety!` block you can
+/// declare that all generated functions are in fact safe.
+/// Specifically, you'd specify:
+/// `safety!(unsafe)`
+/// or
+/// `safety!(unsafe_ffi)`
+/// These two options are functionally identical. If you're
+/// unsure, simply use `unsafe`. The reason for the
+/// latter option is if you have code review policies which
+/// might want to give a different level of scrutiny to
+/// C++ interop as opposed to other types of unsafe Rust code.
+/// Maybe in your organization, C++ interop is less scary than
+/// a low-level Rust data structure using pointer manipulation.
+/// Or maybe it's more scary. Either way, using `unsafe` for
+/// the data structure and using `unsafe_ffi` for the C++
+/// interop allows you to apply different linting tools and
+/// policies to the different options.
+///
+/// Irrespective, C++ code is of course unsafe. It's worth
+/// noting that use of C++ can cause unexpected unsafety at
+/// a distance in faraway Rust code. As with any use of the
+/// `unsafe` keyword in Rust, *you the human* are declaring
+/// that you've analyzed all possible ways that the code
+/// can be used and you are guaranteeing to the compiler that
+/// no badness can occur. Good luck.
+#[macro_export]
+macro_rules! safety {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@
 /// ```
 /// # use autocxx_macro::include_cpp_impl as include_cpp;
 /// include_cpp!(
-///     unsafe
 /// #   parse_only
 ///     #include "input.h"
 ///     generate!("do_math")
+///     safety!(unsafe)
 /// );
 ///
 /// # mod ffi { pub fn do_math(a: u32) -> u32 { a+3 } }
@@ -64,10 +64,10 @@
 /// Within the brackets of the `include_cxx!(...)` macro, you should provide
 /// a list of at least the following:
 ///
-/// * the `unsafe` keyword (must always come first)
 /// * `#include "cpp_header.h"`: a header filename to parse and include
 /// * `generate!("type_or_function_name")`: a type or function name whose declaration
 ///   should be made available to C++.
+/// * Possibly, `safety!(unsafe)` - see discussion of [unsafe] later.
 ///
 /// Other directives are possible as documented in this crate.
 ///


### PR DESCRIPTION
Allow either:
  safety!(unsafe)
  safety!(unsafe_ffi)
or neither, in which case generated functions are unsafe.

Fixes half of #166.