### PR TITLE
Ignore vtables generated by bindgen

### DIFF
--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -31,6 +31,7 @@ pub enum ConvertError {
     UnexpectedItemInMod,
     ComplexTypedefTarget(String),
     UnexpectedThisType,
+    UnsupportedBuiltInType(TypeName),
 }
 
 impl Display for ConvertError {
@@ -43,6 +44,7 @@ impl Display for ConvertError {
             ConvertError::UnexpectedItemInMod => write!(f, "Bindgen generated some unexpected code in an inner namespace mod. You may have specified something in a 'generate' directive which is not currently compatible with autocxx.")?,
             ConvertError::ComplexTypedefTarget(ty) => write!(f, "autocxx was unable to produce a typdef pointing to the complex type {}.", ty)?,
             ConvertError::UnexpectedThisType => write!(f, "Unexpected type for 'this'")?, // TODO give type/function
+            ConvertError::UnsupportedBuiltInType(ty) => write!(f, "autocxx does not yet know how to support the built-in C++ type {} - please raise an issue on github", ty.to_cpp_name())?,
         }
         Ok(())
     }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -30,8 +30,9 @@ pub enum ConvertError {
     UnexpectedOuterItem,
     UnexpectedItemInMod,
     ComplexTypedefTarget(String),
-    UnexpectedThisType,
+    UnexpectedThisType(Namespace, String),
     UnsupportedBuiltInType(TypeName),
+    VirtualThisType(Namespace, String),
 }
 
 impl Display for ConvertError {
@@ -43,10 +44,23 @@ impl Display for ConvertError {
             ConvertError::UnexpectedOuterItem => write!(f, "Bindgen generated some unexpected code in its outermost mod section. You may have specified something in a 'generate' directive which is not currently compatible with autocxx.")?,
             ConvertError::UnexpectedItemInMod => write!(f, "Bindgen generated some unexpected code in an inner namespace mod. You may have specified something in a 'generate' directive which is not currently compatible with autocxx.")?,
             ConvertError::ComplexTypedefTarget(ty) => write!(f, "autocxx was unable to produce a typdef pointing to the complex type {}.", ty)?,
-            ConvertError::UnexpectedThisType => write!(f, "Unexpected type for 'this'")?, // TODO give type/function
+            ConvertError::UnexpectedThisType(ns, fn_name) => write!(f, "Unexpected type for 'this' in the function {}{}.", fn_name, ns.to_display_suffix())?,
             ConvertError::UnsupportedBuiltInType(ty) => write!(f, "autocxx does not yet know how to support the built-in C++ type {} - please raise an issue on github", ty.to_cpp_name())?,
+            ConvertError::VirtualThisType(ns, fn_name) => write!(f, "Member function encountered where the 'this' type is 'void*'. This is usually because it's a virtual function that may be overridden, which is not supported. Function {}{}.", fn_name, ns.to_display_suffix())?,
         }
         Ok(())
+    }
+}
+
+impl ConvertError {
+    /// Whether we should ignore this error and simply skip over such items.
+    /// In the future we need to use this to provide diagnostics or logging to the user,
+    /// which ideally we'd somehow winkle into the generated bindings
+    /// in a way that causes them a compile-time problem only if they try to
+    /// _use_ the affects functions. I don't know a way to do that. Otherwise,
+    /// we should output these things as warnings during the codegen phase. TODO.
+    pub(crate) fn is_ignorable(&self) -> bool {
+        matches!(self, ConvertError::VirtualThisType(_, _) | ConvertError::UnsupportedBuiltInType(_))
     }
 }
 

--- a/engine/src/conversion/conversion_tests.rs
+++ b/engine/src/conversion/conversion_tests.rs
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use autocxx_parser::{TypeDatabase, UnsafePolicy};
+#[allow(unused_imports)]
+use syn::parse_quote;
+use syn::ItemMod;
+
+use super::BridgeConverter;
+
+// This mod is for tests which take bindgen output directly.
+// This should be avoided where possible, since these tests will
+// become obsolete or have to change if and when we update
+// bindgen. Instead, please add tests working directly from
+// the original C++ in integration_tests.rs if possible.
+// Also, if you're pasting in code from github issues, it's
+// important to make sure that the underlying code has an
+// acceptable license. That's why this file is currently blank.
+
+#[allow(dead_code)]
+fn do_test(input: ItemMod) {
+    let td = TypeDatabase::new();
+    let bc = BridgeConverter::new(&[], &td);
+    bc.convert(input, true, UnsafePolicy::AllFunctionsSafe)
+        .unwrap();
+}
+
+// How to add a test here
+//
+// #[test]
+// fn test_xyz() {
+//      do_test(parse_quote!{ /* paste bindgen output here */})
+// }

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -14,6 +14,8 @@
 
 mod api;
 mod codegen;
+#[cfg(test)]
+mod conversion_tests;
 mod gc;
 mod namespace_organizer;
 mod parse;

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -59,7 +59,7 @@ impl<'a> BridgeConverter<'a> {
     /// Convert a TokenStream of bindgen-generated bindings to a form
     /// suitable for cxx.
     pub(crate) fn convert(
-        &mut self,
+        &self,
         mut bindgen_mod: ItemMod,
         exclude_utilities: bool,
         unsafe_policy: UnsafePolicy,

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -122,6 +122,9 @@ impl<'a> ParseBindgen<'a> {
                     mod_converter.convert_foreign_mod_items(items)?;
                 }
                 Item::Struct(mut s) => {
+                    if s.ident.to_string().ends_with("__bindgen_vtable") {
+                        continue;
+                    }
                     let tyname = TypeName::new(&ns, &s.ident.to_string());
                     let type_kind = if Self::spot_forward_declaration(&s.fields) {
                         self.incomplete_types.insert(tyname.clone());

--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -141,15 +141,21 @@ impl TypeConverter {
             // already, and if not, qualify it according to the current
             // namespace. This is a bit of a shortcut compared to having a full
             // resolution pass which can search all known namespaces.
-            if !self.types_found.contains(&ty) && !KNOWN_TYPES.is_known_type(&ty) {
-                typ.path.segments = std::iter::once(&"root".to_string())
-                    .chain(ns.iter())
-                    .map(|s| {
-                        let i = make_ident(s);
-                        parse_quote! { #i }
-                    })
-                    .chain(typ.path.segments.into_iter())
-                    .collect();
+            if !KNOWN_TYPES.is_known_type(&ty) {
+                let num_segments = typ.path.segments.len();
+                if num_segments > 1 {
+                    return Err(ConvertError::UnsupportedBuiltInType(ty));
+                }
+                if !self.types_found.contains(&ty) {
+                    typ.path.segments = std::iter::once(&"root".to_string())
+                        .chain(ns.iter())
+                        .map(|s| {
+                            let i = make_ident(s);
+                            parse_quote! { #i }
+                        })
+                        .chain(typ.path.segments.into_iter())
+                        .collect();
+                }
             }
         }
 

--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -142,10 +142,12 @@ impl TypeConverter {
             // namespace. This is a bit of a shortcut compared to having a full
             // resolution pass which can search all known namespaces.
             if !self.types_found.contains(&ty) && !KNOWN_TYPES.is_known_type(&ty) {
-                log::info!("Converting {:?}", ty.to_string());
                 typ.path.segments = std::iter::once(&"root".to_string())
                     .chain(ns.iter())
-                    .map(|s| parse_quote! { #s })
+                    .map(|s| {
+                        let i = make_ident(s);
+                        parse_quote! { #i }
+                    })
                     .chain(typ.path.segments.into_iter())
                     .collect();
             }

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -3283,6 +3283,36 @@ fn test_generic_type() {
     run_test("", hdr, rs, &["Secondary"], &[]);
 }
 
+#[test]
+fn test_virtual_fns() {
+    let hdr = indoc! {"
+        #include <cstdint>
+        class A {
+        public:
+            A(uint32_t num) : b(num) {}
+            virtual uint32_t foo(uint32_t a) { return a+1; };
+            virtual ~A() {}
+            uint32_t b;
+        };
+        class B: public A {
+        public:
+            B() : A(3), c(4) {}
+            virtual uint32_t foo(uint32_t a) { return a+2; };
+            uint32_t c;
+        };
+    "};
+    let rs = quote! {
+        // We can't call virtual functions...
+        //let a = ffi::A::make_unique(12);
+        //assert_eq!(a.pin_mut().foo(2), 3);
+        let _b = ffi::B::make_unique();
+        // ... even on derived classes where the resolution
+        // would be fixed.
+        //assert_eq!(b_.pin_mut().foo(2), 4);
+    };
+    run_test("", hdr, rs, &["B"], &[]);
+}
+
 // Yet to test:
 // 5. Using templated types.
 // 6. Ifdef

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -298,7 +298,7 @@ impl IncludeCppEngine {
         let bindings = self.parse_bindings(bindings)?;
 
         let include_list = self.generate_include_list();
-        let mut converter = BridgeConverter::new(&include_list, &self.config.type_database);
+        let converter = BridgeConverter::new(&include_list, &self.config.type_database);
 
         let conversion = converter
             .convert(

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -57,6 +57,14 @@ impl Namespace {
     pub(crate) fn depth(&self) -> usize {
         self.0.len()
     }
+
+    pub(crate) fn to_display_suffix(&self) -> String {
+        if self.is_empty() {
+            String::new()
+        } else {
+            format!(" (in namespace {})", self)
+        }
+    }
 }
 
 impl Display for Namespace {
@@ -204,6 +212,10 @@ impl TypeName {
     /// Iterator over segments in the namespace of this type.
     pub(crate) fn ns_segment_iter(&self) -> impl Iterator<Item = &String> {
         self.0.iter()
+    }
+
+    pub(crate) fn is_cvoid(&self) -> bool {
+        self.to_cpp_name() == "std::os::raw::c_void"
     }
 }
 

--- a/parser/src/type_database.rs
+++ b/parser/src/type_database.rs
@@ -23,7 +23,7 @@ pub struct TypeDatabase {
 }
 
 impl TypeDatabase {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self::default()
     }
 


### PR DESCRIPTION
We can't support classes with virtual functions, but at least they shouldn't break anything any longer and prevent us handling other code in the same headers.

Fixes #177. Fixes #176. Fixes #174.