### PR TITLE
Request cargo rebuild whenever any header changes.

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -229,6 +229,7 @@ fn do_run_test(
         &rs_path,
         &[tdir.path()],
         Some(target_dir.clone()),
+        None,
     )
     .map_err(TestError::AutoCxx)?;
     let mut b = build_results.0;

--- a/engine/src/parse_callbacks.rs
+++ b/engine/src/parse_callbacks.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic::UnwindSafe;
+
+use crate::RebuildDependencyRecorder;
+use autocxx_bindgen::callbacks::ParseCallbacks;
+
+#[derive(Debug)]
+pub(crate) struct AutocxxParseCallbacks(pub Box<dyn RebuildDependencyRecorder>);
+
+impl UnwindSafe for AutocxxParseCallbacks {}
+
+impl ParseCallbacks for AutocxxParseCallbacks {
+    fn include_file(&self, filename: &str) {
+        self.0.record_header_file_dependency(filename);
+    }
+}

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -89,8 +89,10 @@ fn main() {
     let mut parsed_file = parse_file(matches.value_of("INPUT").unwrap())
         .expect("Unable to parse Rust file and interpret autocxx macro");
     let incs = matches.value_of("inc").unwrap_or("");
+    // TODO - in future, we should provide an option to write a .d file here
+    // by passing a callback into the dep_recorder parameter here.
     parsed_file
-        .resolve_all(incs)
+        .resolve_all(incs, None)
         .expect("Unable to resolve macro");
     let outdir: PathBuf = matches.value_of_os("outdir").unwrap().into();
     if let Some(matches) = matches.subcommand_matches("gen-cpp") {


### PR DESCRIPTION
We use bindgen callbacks to detect all header files
transitively 'included' within our Rust files, and
issue appropriate println!s to cargo such that it
knows to rerun the build script every time any such
file changes.

Surprisingly complex for such a simple task.

Fixes #173.