### PR TITLE
Upgrade autocxx-bindgen.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -32,7 +32,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 lazy_static = "1.4"
 indoc = "1.0"
-autocxx-bindgen = "0.56.1"
+autocxx-bindgen = "0.57.0"
 itertools = "0.9"
 dunce = "1.0.1"
 cc = { version = "1.0", optional = true }


### PR DESCRIPTION
This brings in a version which adds extra annotations for references
vs pointers which we will use in a subsequent PR.

Works towards #102.