### PR TITLE
Make POD analysis phase self-contained

### DIFF
--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -206,7 +206,11 @@ impl ByValueChecker {
 mod tests {
     use super::ByValueChecker;
     use crate::types::{Namespace, TypeName};
-    use syn::{parse_quote, ItemStruct};
+    use syn::{parse_quote, Ident, ItemStruct};
+
+    fn ty_from_ident(id: &Ident) -> TypeName {
+        TypeName::new_from_user_input(&id.to_string())
+    }
 
     #[test]
     fn test_primitive_by_itself() {
@@ -224,7 +228,7 @@ mod tests {
                 b: i64,
             }
         };
-        let t_id = TypeName::from_ident(&t.ident);
+        let t_id = ty_from_ident(&t.ident);
         bvc.ingest_struct(&t, &Namespace::new());
         bvc.satisfy_requests(vec![t_id.clone()]).unwrap();
         assert!(bvc.is_pod(&t_id));
@@ -246,7 +250,7 @@ mod tests {
                 b: i64,
             }
         };
-        let t_id = TypeName::from_ident(&t.ident);
+        let t_id = ty_from_ident(&t.ident);
         bvc.ingest_struct(&t, &Namespace::new());
         bvc.satisfy_requests(vec![t_id.clone()]).unwrap();
         assert!(bvc.is_pod(&t_id));
@@ -261,7 +265,7 @@ mod tests {
                 b: i64,
             }
         };
-        let t_id = TypeName::from_ident(&t.ident);
+        let t_id = ty_from_ident(&t.ident);
         bvc.ingest_struct(&t, &Namespace::new());
         bvc.satisfy_requests(vec![t_id.clone()]).unwrap();
         assert!(bvc.is_pod(&t_id));
@@ -276,7 +280,7 @@ mod tests {
                 b: i64,
             }
         };
-        let t_id = TypeName::from_ident(&t.ident);
+        let t_id = ty_from_ident(&t.ident);
         bvc.ingest_struct(&t, &Namespace::new());
         assert!(bvc.satisfy_requests(vec![t_id]).is_err());
     }

--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -60,7 +60,7 @@ impl ByValueChecker {
             } else {
                 PodState::UnsafeToBePod(format!("type {} is not safe for POD", tn))
             };
-            results.insert(tn, StructDetails::new(safety));
+            results.insert(tn.clone(), StructDetails::new(safety));
         }
         ByValueChecker { results }
     }

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -18,7 +18,7 @@ mod byvalue_scanner;
 use std::collections::HashSet;
 
 use autocxx_parser::TypeConfig;
-pub(crate) use byvalue_checker::ByValueChecker;
+use byvalue_checker::ByValueChecker;
 use byvalue_scanner::identify_byvalue_safe_types;
 use syn::{Item, ItemStruct};
 
@@ -48,7 +48,7 @@ pub(crate) fn analyze_pod_apis(
     apis: Vec<UnanalyzedApi>,
     type_config: &TypeConfig,
     type_converter: &mut TypeConverter,
-) -> Result<(Vec<Api<PodAnalysis>>, ByValueChecker), ConvertError> {
+) -> Result<Vec<Api<PodAnalysis>>, ConvertError> {
     let byvalue_checker = identify_byvalue_safe_types(&apis, type_config)?;
     let mut extra_apis = Vec::new();
     let mut results: Vec<_> = apis
@@ -64,7 +64,7 @@ pub(crate) fn analyze_pod_apis(
         .collect::<Result<Vec<_>, ConvertError>>()?;
     assert!(more_extra_apis.is_empty());
     results.append(&mut more_results);
-    Ok((results, byvalue_checker))
+    Ok(results)
 }
 
 fn analyze_pod_api(

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -100,7 +100,7 @@ impl<'a> BridgeConverter<'a> {
                 // This returns a new list of `Api`s, which will be parameterized with
                 // the analysis results. It also returns an object which can be used
                 // by subsequent phases to work out which objects are POD.
-                let (analyzed_apis, pod_list) =
+                let analyzed_apis =
                     analyze_pod_apis(parse_results.apis, &self.type_config, &mut type_converter)?;
                 // Next, figure out how we materialize different functions.
                 // Some will be simple entries in the cxx::bridge module; others will
@@ -111,7 +111,6 @@ impl<'a> BridgeConverter<'a> {
                     analyzed_apis,
                     unsafe_policy,
                     &mut type_converter,
-                    &pod_list,
                     self.type_config,
                 )?;
                 // We now garbage collect the ones we don't need...

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -149,11 +149,12 @@ impl TypeDatabase {
 
     /// Types which are known to be safe (or unsafe) to hold and pass by
     /// value in Rust.
-    pub(crate) fn get_pod_safe_types(&self) -> Vec<(TypeName, bool)> {
+    pub(crate) fn get_pod_safe_types<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = (&'a TypeName, bool)> + 'a {
         self.by_rs_name
             .iter()
-            .map(|(tn, td)| (tn.clone(), td.by_value_safe))
-            .collect()
+            .map(|(tn, td)| (tn, td.by_value_safe))
     }
 
     /// Whether this TypePath should be treated as a value in C++

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -225,13 +225,10 @@ pub trait RebuildDependencyRecorder: std::fmt::Debug {
 ///     tc -.-> pod
 ///     apis ==> pod
 ///     podapis(APIs with POD analysis)
-///     podlist(ByValueChecker)
 ///     pod ==> podapis
-///     pod -.-> podlist
 ///     fun[Function materialization analysis]
 ///     tc -.-> fun
 ///     podapis ==> fun
-///     podlist -.-> fun
 ///     funapis(APIs with function analysis)
 ///     fun ==> funapis
 ///     gc[Garbage collection]

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -96,11 +96,6 @@ impl<'a> IntoIterator for &'a Namespace {
 pub struct TypeName(Namespace, String);
 
 impl TypeName {
-    #[cfg(test)]
-    pub(crate) fn from_ident(id: &Ident) -> Self {
-        Self(Namespace::new(), id.to_string())
-    }
-
     /// From a TypePath which starts with 'root'
     pub(crate) fn from_type_path(typ: &TypePath) -> Self {
         let mut seg_iter = typ.path.segments.iter().peekable();


### PR DESCRIPTION
Its types no longer spill over into a subsequent phase. Fixes #221.