### PR TITLE
Redo autocxx-gen syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ variable such that the macro can discover the location of the .rs file which was
 If you use the `build.rs` cargo integration, this happens automatically. You'll also need
 to ensure that you build and link against the C++ code. Again, if you use the Cargo integrationm
 and follow the pattern of the `demo` example, this is fairly automatic because we use
-`cc` for this.
+`cc` for this. (There's also the option of `AUTOCXX_RS_FILE` if your build system needs to
+specify the precise file name used for the `.rs` file which is `include!`ed).
 
 You'll also want to ensure that the code generation (both Rust and C++ code) happens whenever
 any included header file changes. This is now handled automatically by our

--- a/gen/cmd/src/cmd_test.rs
+++ b/gen/cmd/src/cmd_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{convert::TryInto, fs::File, io::Write, path::PathBuf};
 
 use assert_cmd::Command;
 use tempdir::TempDir;
@@ -41,9 +41,41 @@ fn test_gen() -> Result<(), Box<dyn std::error::Error>> {
         .arg(demo_rs)
         .arg("--outdir")
         .arg(tmp_dir.path().to_str().unwrap())
-        .arg("gen-cpp")
+        .arg("--gen-cpp")
+        .arg("--gen-rs-include")
         .assert()
         .success();
+    assert_contentful(&tmp_dir, "gen0.cc");
+    Ok(())
+}
+
+#[test]
+fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = TempDir::new("example")?;
+    let demo_code_dir = tmp_dir.path().join("demo");
+    std::fs::create_dir(&demo_code_dir).unwrap();
+    write_to_file(&demo_code_dir, "input.h", INPUT_H.as_bytes());
+    write_to_file(&demo_code_dir, "main.rs", MAIN_RS.as_bytes());
+    let demo_rs = demo_code_dir.join("main.rs");
+    let mut cmd = Command::cargo_bin("autocxx-gen")?;
+    cmd.arg("-I")
+        .arg(demo_code_dir.to_str().unwrap())
+        .arg(demo_rs)
+        .arg("--outdir")
+        .arg(tmp_dir.path().to_str().unwrap())
+        .arg("--gen-cpp")
+        .arg("--gen-rs-include")
+        .arg("--generate-exact")
+        .arg("3")
+        .arg("--fix-rs-include-name")
+        .assert()
+        .success();
+    assert_contentful(&tmp_dir, "gen0.cc");
+    assert_contentful(&tmp_dir, "gen1.cc");
+    assert_exists(&tmp_dir, "gen2.cc");
+    assert_contentful(&tmp_dir, "gen0.include.rs");
+    assert_exists(&tmp_dir, "gen1.include.rs");
+    assert_exists(&tmp_dir, "gen2.include.rs");
     Ok(())
 }
 
@@ -51,4 +83,19 @@ fn write_to_file(dir: &PathBuf, filename: &str, content: &[u8]) {
     let path = dir.join(filename);
     let mut f = File::create(&path).expect("Unable to create file");
     f.write_all(content).expect("Unable to write file");
+}
+
+fn assert_contentful(outdir: &TempDir, fname: &str) {
+    let p = outdir.path().join(fname);
+    if !p.exists() {
+        panic!("File {} didn't exist", p.to_string_lossy());
+    }
+    assert!(p.metadata().unwrap().len() > super::BLANK.len().try_into().unwrap());
+}
+
+fn assert_exists(outdir: &TempDir, fname: &str) {
+    let p = outdir.path().join(fname);
+    if !p.exists() {
+        panic!("File {} didn't exist", p.to_string_lossy());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,10 @@ use autocxx_engine::IncludeCppEngine;
 ///   implementation files. This will also generate `.rs` side bindings.
 /// * Educate the procedural macro about where to find the generated `.rs` bindings. Set the
 ///   `AUTOCXX_RS` environment variable to a list of directories to search.
-///   If you use `autocxx-build`, this happens automatically.
+///   If you use `autocxx-build`, this happens automatically. (You can alternatively
+///   specify `AUTOCXX_RS_FILE` to give a precise filename as opposed to a directory to search,
+///   though this isn't recommended unless your build system specifically requires it
+///   because it allows only a single `include_cpp!` block per `.rs` file.)
 ///
 /// ```mermaid
 /// flowchart TB


### PR DESCRIPTION
This allows us to generate the include! files required by autocxx_macro.
It introduces an AUTOCXX_RS_FILE to educate the macro about how to find
such files.

This is necessary for build systems which rely on tracking completely
fixed input and output file names for each build action.

Fixes #248.