### PR TITLE
Support use in environments that run build scripts with panic=abort.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ pointers = []
 
 [dependencies]
 log = "0.4"
-proc-macro2 = "1.0"
+proc-macro2 = "1.0.11"
 quote = "1.0"
 lazy_static = "1.4"
 indoc = "1.0"

--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -58,6 +58,7 @@ pub fn parse_file<P1: AsRef<Path>>(rs_file: P1) -> Result<ParsedFile, ParseError
     let mut file = std::fs::File::open(rs_file).map_err(ParseError::FileOpen)?;
     file.read_to_string(&mut source)
         .map_err(ParseError::FileRead)?;
+    proc_macro2::fallback::force();
     let source = syn::parse_file(&source).map_err(ParseError::Syntax)?;
     parse_file_contents(source)
 }


### PR DESCRIPTION
Cargo always runs build scripts with panic=unwind, but other build
environments might not -- see here for a similar issue in cxx:

https://github.com/dtolnay/cxx/issues/130

And the corresponding fix:

https://github.com/dtolnay/cxx/pull/184