### PR TITLE
use 0.1 semver for aquamarine dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ autocxx-macro = { path="macro", version="0.5.4" }
 autocxx-engine = { path="engine", version="0.5.4" } # so that
   # we can refer to autocxx_engine::cxx. But even that isn't sufficient...
 cxx = "1.0.42" # ... also needed because expansion of type_id refers to ::cxx
-aquamarine = "0.1.5" # docs
+aquamarine = "0.1" # docs
 
 [workspace]
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce"]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -40,7 +40,7 @@ cxx-gen = "0.7.38"
 cxx = "1.0.42"
 autocxx-parser = { version = "0.5.4", path="../parser" }
 version_check = "0.9"
-aquamarine = "0.1.5" # docs
+aquamarine = "0.1" # docs
 
 [dependencies.syn]
 version = "1.0.39"


### PR DESCRIPTION
Aquamarine has been updated to support offline mode in 0.1.8, and doesn't require internet connection to build and view the rendered diagrams anymore.

This change switches from pinned patch version to a the 0.1 branch in order to include the offline more feature and other backward-compatible improvements coming in future