### PR TITLE
Add failing integration test for passing closure

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4531,6 +4531,23 @@ fn test_doc_passthru() {
     );
 }
 
+
+#[test]
+fn test_closure() {
+    let hdr = indoc! {"
+    #include <functional>
+    #include <cstdint>
+
+    bool take_closure(std::function<bool(const uint32_t number)> fn) {
+        return fn(5);
+    }
+    "};
+    let rs = quote! {
+        assert_eq!(ffi::take_closure(|number: u32| number % 2 == 0), false);
+    };
+    run_test("", hdr, rs, &["take_closure"], &[]);
+}
+
 // Yet to test:
 // 6. Ifdef
 // 7. Out param pointers


### PR DESCRIPTION
After some digging into why I still get https://github.com/google/autocxx/issues/361 after https://github.com/google/autocxx/pull/365 was merged, I discovered that the offending C++ code is not actually an array, it is a closure!

I've put together a failing integration test. The error message is (tieded up a bit):

```
/tmp/.tmplPg6rC/target/cxx/gen0.cxx:
In function ‘bool cxxbridge1$take_closure(std::array<long unsigned int, 4>*)’:
/tmp/.tmplPg6rC/target/cxx/gen0.cxx:75:63:

error: invalid conversion from ‘bool (*)(std::function<bool(unsigned int)>)’ to ‘bool (*)(std::array<long unsigned int, 4>)’ [-fpermissive] 

bool (*take_closure$)(::std::array<::std::uint64_t, 4>) = ::take_closure;
bool (*)(std::function<bool(unsigned int)>)

AUTOCXX_RS=/tmp/.tmplPg6rC/target/rs
CXX_x86_64-unknown-linux-gnu = None
CXX_x86_64_unknown_linux_gnu = None
HOST_CXX = None
CXX = None
CXXFLAGS_x86_64-unknown-linux-gnu = None
CXXFLAGS_x86_64_unknown_linux_gnu = None
HOST_CXXFLAGS = None
CXXFLAGS = None
CRATE_CC_NO_DEFAULTS = None
DEBUG = None
CARGO_CFG_TARGET_FEATURE = None
running: "c++" "-O1" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "/tmp/.tmplPg6rC" "-I" "/tmp/.tmplPg6rC/target/include" "-I" "/tmp/.tmplPg6rC" "-Wall" "-Wextra" "-std=c++14" "-o" "/tmp/.tmplPg6rC/target/cxx/gen0.o" "-c" "/tmp/.tmplPg6rC/target/cxx/gen0.cxx"
cargo:warning=
cargo:warning=
cargo:warning=
cargo:warning=
cargo:warning=
cargo:warning=
exit code: 1

thread 'integration_tests::test_closure' panicked at 'called `Result::unwrap()` on an `Err` value: CppBuild(Error { kind: ToolExecError, message: "Command "c++" "-O1" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "/tmp/.tmplPg6rC" "-I" "/tmp/.tmplPg6rC/target/include" "-I" "/tmp/.tmplPg6rC" "-Wall" "-Wextra" "-std=c++14" "-o" "/tmp/.tmplPg6rC/target/cxx/gen0.o" "-c" "/tmp/.tmplPg6rC/target/cxx/gen0.cxx" with args "c++" did not execute successfully (status code exit code: 1)." })'
```

As we can see from the error message, the `std::function` part gets converted into an array for some reason. Not sure which part of the toolchain is failing here.