### PR TITLE
Allow passing arbitrary extra Clang arguments

### DIFF
--- a/demo/build.rs
+++ b/demo/build.rs
@@ -14,8 +14,8 @@
 
 fn main() {
     let path = std::path::PathBuf::from("src");
-    let defs: Vec<String> = Vec::new();
-    let mut b = autocxx_build::build("src/main.rs", &[&path], &defs).unwrap();
+    let clang_args: [&str; 0] = [];
+    let mut b = autocxx_build::build("src/main.rs", &[&path], &clang_args).unwrap();
     b.flag_if_supported("-std=c++14").compile("autocxx-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -65,7 +65,7 @@ pub type BuilderResult = Result<BuilderSuccess, BuilderError>;
 pub fn build<P1, I, T>(
     rs_file: P1,
     autocxx_incs: I,
-    definitions: &[impl AsRef<str>],
+    extra_clang_args: &[&str],
     dependency_recorder: Option<Box<dyn RebuildDependencyRecorder>>,
 ) -> BuilderResult
 where
@@ -76,7 +76,7 @@ where
     build_to_custom_directory(
         rs_file,
         autocxx_incs,
-        definitions,
+        extra_clang_args,
         None,
         dependency_recorder,
     )
@@ -87,7 +87,7 @@ where
 pub fn expect_build<P1, I, T>(
     rs_file: P1,
     autocxx_incs: I,
-    definitions: &[impl AsRef<str>],
+    extra_clang_args: &[&str],
     dependency_recorder: Option<Box<dyn RebuildDependencyRecorder>>,
 ) -> BuilderSuccess
 where
@@ -95,7 +95,7 @@ where
     I: IntoIterator<Item = T>,
     T: AsRef<OsStr>,
 {
-    build(rs_file, autocxx_incs, definitions, dependency_recorder).unwrap_or_else(|err| {
+    build(rs_file, autocxx_incs, extra_clang_args, dependency_recorder).unwrap_or_else(|err| {
         let _ = writeln!(io::stderr(), "\n\nautocxx error: {}\n\n", report(err));
         process::exit(1);
     })
@@ -110,7 +110,7 @@ fn report(err: BuilderError) -> String {
 pub(crate) fn build_to_custom_directory<P1, I, T>(
     rs_file: P1,
     autocxx_incs: I,
-    definitions: &[impl AsRef<str>],
+    extra_clang_args: &[&str],
     custom_gendir: Option<PathBuf>,
     dependency_recorder: Option<Box<dyn RebuildDependencyRecorder>>,
 ) -> BuilderResult
@@ -143,7 +143,7 @@ where
 
     let mut parsed_file = crate::parse_file(rs_file).map_err(BuilderError::ParseError)?;
     parsed_file
-        .resolve_all(autocxx_inc, definitions, dependency_recorder)
+        .resolve_all(autocxx_inc, extra_clang_args, dependency_recorder)
         .map_err(BuilderError::ParseError)?;
     build_with_existing_parsed_file(parsed_file, cxxdir, incdir, rsdir)
 }

--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -116,7 +116,7 @@ impl ParsedFile {
     pub fn resolve_all(
         &mut self,
         autocxx_inc: Vec<PathBuf>,
-        definitions: &[impl AsRef<str>],
+        extra_clang_args: &[&str],
         dep_recorder: Option<Box<dyn RebuildDependencyRecorder>>,
     ) -> Result<(), ParseError> {
         let inner_dep_recorder: Option<Rc<dyn RebuildDependencyRecorder>> =
@@ -130,9 +130,8 @@ impl ParsedFile {
                     inner_dep_recorder.clone(),
                 ))),
             };
-            let defs: Vec<String> = definitions.iter().map(|d| d.as_ref().to_string()).collect();
             include_cpp
-                .generate(autocxx_inc.clone(), &defs, dep_recorder)
+                .generate(autocxx_inc.clone(), extra_clang_args, dep_recorder)
                 .map_err(ParseError::AutocxxCodegenError)?
         }
         Ok(())

--- a/examples/s2/build.rs
+++ b/examples/s2/build.rs
@@ -18,8 +18,8 @@ fn main() {
     // working directories.
     let path = std::path::PathBuf::from("s2geometry/src");
     let path2 = std::path::PathBuf::from("src");
-    let defs: Vec<String> = Vec::new();
-    let mut b = autocxx_build::build("src/main.rs", &[&path, &path2], &defs).unwrap();
+    let clang_args: [&str; 0] = [];
+    let mut b = autocxx_build::build("src/main.rs", &[&path, &path2], &clang_args).unwrap();
     b.flag_if_supported("-std=c++14")
         .compile("autocxx-s2-example");
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -26,7 +26,7 @@ use std::{ffi::OsStr, path::Path};
 pub fn build<P1, I, T>(
     rs_file: P1,
     autocxx_incs: I,
-    definitions: &[impl AsRef<str>],
+    extra_clang_args: &[&str],
 ) -> Result<BuilderBuild, BuilderError>
 where
     P1: AsRef<Path>,
@@ -37,7 +37,7 @@ where
     engine_build(
         rs_file,
         autocxx_incs,
-        definitions,
+        extra_clang_args,
         Some(Box::new(CargoRebuildDependencyRecorder::new())),
     )
     .map(|r| r.0)
@@ -48,7 +48,7 @@ where
 pub fn expect_build<P1, I, T>(
     rs_file: P1,
     autocxx_incs: I,
-    definitions: &[impl AsRef<str>],
+    extra_clang_args: &[&str],
 ) -> BuilderBuild
 where
     P1: AsRef<Path>,
@@ -59,7 +59,7 @@ where
     engine_expect_build(
         rs_file,
         autocxx_incs,
-        definitions,
+        extra_clang_args,
         Some(Box::new(CargoRebuildDependencyRecorder::new())),
     )
     .0


### PR DESCRIPTION
Some build environments need this capability, for example to set up a different `-sysroot` or to specify `-iquote` and `-isystem` directories. This feature also makes it possible to specify a different C++ version -- see https://github.com/google/autocxx/issues/209.

This change makes the recently added feature for specifying preprocessor defines obsolete, so I've removed that feature.

Fixes #209
Fixes #377 