### PR TITLE
Don't import nested types as top-level types.

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -289,7 +289,6 @@ impl IncludeCppEngine {
                 non_exhaustive: false,
             })
             .enable_cxx_namespaces()
-            .disable_nested_struct_naming()
             .generate_inline_functions(true)
             .layout_tests(false); // TODO revisit later
         for item in known_types::get_initial_blocklist() {


### PR DESCRIPTION
This is a breaking change; see below.

The bindgen option `disable_nested_struct_naming()` was turned on in https://github.com/google/autocxx/commit/cbbb2fb279b54edf70e3d7feb5be1c006edc9a3d

This option causes nested types to be imported as top-level types. These types can then conflict with top-level types of the same name; this is a problem I'm running into in a codebase I'm working with. I've added a test that exposes this issue, failing with the error message "the name `B` is defined multiple times".

This change removes the `disable_nested_struct_naming()` option again. With this change, it currently isn't possible to instantiate the nested types (see also comments in the test I've added), but I think this is preferable to not being able to import even the top-level type that has a name conflicting with the nested type.

The only changes I've had to make to existing tests are to remove the explicit generation of methods (which isn't necessary anyway). The tests were specifying merely the method name as the entity to generate, and this no longer works now.

This and the fact that nested types can now no longer be instantiated makes this a breaking change, but I think this is still a change in the right direction.