### PR TITLE
Ensure bindgen blocklist is not overly broad

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4630,8 +4630,8 @@ fn test_blocklist_not_overly_broad() {
     // not just items in the "rust" and "std" namespaces. We therefore test that functions starting
     // with "rust" or "std" get imported.
     let hdr = indoc! {"
-    inline double rust_func() { }
-    inline double std_func() { }
+    inline void rust_func() { }
+    inline void std_func() { }
     "};
     let rs = quote! {
         ffi::rust_func();

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4624,6 +4624,22 @@ fn test_closure() {
     run_test("", hdr, rs, &["get_a"], &[]);
 }
 
+#[test]
+fn test_blocklist_not_overly_broad() {
+    // This is a regression test. We used to block anything that starts with "rust" or "std",
+    // not just items in the "rust" and "std" namespaces. We therefore test that functions starting
+    // with "rust" or "std" get imported.
+    let hdr = indoc! {"
+    inline double rust_func() { }
+    inline double std_func() { }
+    "};
+    let rs = quote! {
+        ffi::rust_func();
+        ffi::std_func();
+    };
+    run_test("", hdr, rs, &["rust_func", "std_func"], &[]);
+}
+
 // Yet to test:
 // 6. Ifdef
 // 7. Out param pointers

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -371,7 +371,7 @@ fn create_type_database() -> TypeDatabase {
 /// But it doesm unless we blocklist them. This is obviously
 /// a bit sensitive to the particular STL in use so one day
 /// it would be good to dig into bindgen's behavior here - TODO.
-const BINDGEN_BLOCKLIST: &[&str] = &["std.*", "__gnu.*", ".*mbstate_t.*", "rust.*"];
+const BINDGEN_BLOCKLIST: &[&str] = &["std::.*", "__gnu.*", ".*mbstate_t.*", "rust::.*"];
 
 /// Get the list of types to give to bindgen to ask it _not_ to
 /// generate code for.


### PR DESCRIPTION
Currently, the blocklist is blocking anything that starts with "std" and "rust". Add a "::" to the blocklist entries to make sure we block only items in the "std" and "rust" namespaces.