### PR TITLE
Import `std` types as opaque

### DIFF
--- a/engine/src/conversion/analysis/mod.rs
+++ b/engine/src/conversion/analysis/mod.rs
@@ -17,3 +17,4 @@ pub(crate) mod ctypes;
 pub(crate) mod fun;
 pub(crate) mod gc;
 pub(crate) mod pod; // hey, that rhymes
+pub(crate) mod remove_ignored;

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use super::fun::FnAnalysis;
+use crate::conversion::api::{Api, ApiDetail};
+use crate::conversion::convert_error::ErrorContext;
+
+/// Remove any APIs which depend on other items which have been ignored.
+pub(crate) fn filter_apis_by_ignored_dependents(
+    mut apis: Vec<Api<FnAnalysis>>,
+) -> Vec<Api<FnAnalysis>> {
+    let mut ignored_items: HashSet<_> = apis
+        .iter()
+        .filter_map(|api| {
+            if matches!(
+                api.detail,
+                ApiDetail::IgnoredItem {
+                    ctx: ErrorContext::Item(..),
+                    ..
+                }
+            ) {
+                Some(api.typename())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let mut iterate_again = true;
+    while iterate_again {
+        iterate_again = false;
+        apis = apis
+            .into_iter()
+            .filter(|api| {
+                if api.deps.iter().any(|dep| ignored_items.contains(dep)) {
+                    iterate_again = true;
+                    ignored_items.insert(api.typename());
+                    eprintln!(
+                        "Skipping item {} because it depends on another item we skipped.",
+                        api.typename().to_string()
+                    );
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
+    }
+    apis
+}

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -35,7 +35,7 @@ use crate::UnsafePolicy;
 use self::{
     analysis::{
         abstract_types::mark_types_abstract, gc::filter_apis_by_following_edges_from_allowlist,
-        pod::analyze_pod_apis,
+        pod::analyze_pod_apis, remove_ignored::filter_apis_by_ignored_dependents,
     },
     codegen_rs::RsCodeGenerator,
     parse::ParseBindgen,
@@ -120,6 +120,11 @@ impl<'a> BridgeConverter<'a> {
                 // to generate UniquePtr implementations for the type, since it can't
                 // be instantiated.
                 mark_types_abstract(&mut analyzed_apis);
+                // During parsing or subsequent processing we might have encountered
+                // items which we couldn't process due to as-yet-unsupported features.
+                // There might be other items depending on such things. Let's remove them
+                // too.
+                let analyzed_apis = filter_apis_by_ignored_dependents(analyzed_apis);
                 // We now garbage collect the ones we don't need...
                 let mut analyzed_apis =
                     filter_apis_by_following_edges_from_allowlist(analyzed_apis, &self.type_config);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -291,8 +291,14 @@ impl IncludeCppEngine {
             .enable_cxx_namespaces()
             .generate_inline_functions(true)
             .layout_tests(false); // TODO revisit later
-        for item in known_types::get_initial_blocklist() {
+        for item in known_types::get_bindgen_blocklist() {
             builder = builder.blocklist_item(item);
+        }
+        for item in known_types::get_bindgen_function_blocklist() {
+            builder = builder.blocklist_function(item);
+        }
+        for item in known_types::get_bindgen_opaque_types() {
+            builder = builder.opaque_type(item);
         }
 
         // 3. Passes allowlist and other options to the bindgen::Builder equivalent


### PR DESCRIPTION
Previously, when types from `std` were blocklisted, bindgen would not generate a definition for them at all. However, we would still attempt to import APIs that used these types. This caused cxx to error out because it didn't have a definition for these types.

Instead, we import types from `std` as opaque types, which is also what the bindgen docs recommend:

https://rust-lang.github.io/rust-bindgen/cpp.html

We still can't import APIs that use these types, but now they are just ignored instead of causing a fatal error.

This is a draft pull request as a basis for discussion as I'm not sure about the wider implications of what I'm doing here.