### PR TITLE
Add a comment on why we pass `extra_clang_args` last

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -282,6 +282,7 @@ fn do_run_test(
         .target(&target)
         .opt_level(1)
         .flag("-std=c++14");
+    // Pass extra_clang_args last so that we have a chance to override the `-std` flag.
     for f in extra_clang_args {
         b = b.flag(f);
     }


### PR DESCRIPTION
Carried over from abandoned https://github.com/google/autocxx/pull/393. I feel it may be important to point this out to future maintainers.