### PR TITLE
Better support forward declarations

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -654,9 +654,6 @@ impl<'a> FnAnalyzer<'a> {
         )))
     }
 
-    /// Returns additionally a Boolean indicating whether an argument was
-    /// 'this' and another one indicating whether we took a type by value
-    /// and that type was non-trivial.
     fn convert_fn_arg(
         &mut self,
         arg: &FnArg,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -164,11 +164,7 @@ impl<'a> FnAnalyzer<'a> {
     fn build_incomplete_type_set(apis: &[Api<PodAnalysis>]) -> HashSet<QualifiedName> {
         apis.iter()
             .filter_map(|api| match api.detail {
-                ApiDetail::Type {
-                    is_forward_declaration: true,
-                    bindgen_mod_item: _,
-                    analysis: _,
-                } => Some(api.typename()),
+                ApiDetail::ForwardDeclaration => Some(api.typename()),
                 _ => None,
             })
             .collect()
@@ -178,7 +174,6 @@ impl<'a> FnAnalyzer<'a> {
         apis.iter()
             .filter_map(|api| match api.detail {
                 ApiDetail::Type {
-                    is_forward_declaration: _,
                     bindgen_mod_item: _,
                     analysis: TypeKind::Pod,
                 } => Some(api.typename()),
@@ -241,14 +236,13 @@ impl<'a> FnAnalyzer<'a> {
             ApiDetail::CType { typename } => ApiDetail::CType { typename },
             // Just changes to this one...
             ApiDetail::Type {
-                is_forward_declaration,
                 bindgen_mod_item,
                 analysis,
             } => ApiDetail::Type {
-                is_forward_declaration,
                 bindgen_mod_item,
                 analysis,
             },
+            ApiDetail::ForwardDeclaration => ApiDetail::ForwardDeclaration,
             ApiDetail::OpaqueTypedef => ApiDetail::OpaqueTypedef,
             ApiDetail::IgnoredItem { err, ctx } => ApiDetail::IgnoredItem { err, ctx },
         };
@@ -265,9 +259,12 @@ impl<'a> FnAnalyzer<'a> {
         ns: &Namespace,
         convert_ptrs_to_reference: bool,
     ) -> Result<(Box<Type>, HashSet<QualifiedName>, bool), ConvertError> {
-        let annotated =
-            self.type_converter
-                .convert_boxed_type(ty, ns, convert_ptrs_to_reference)?;
+        let annotated = self.type_converter.convert_boxed_type(
+            ty,
+            ns,
+            convert_ptrs_to_reference,
+            &self.incomplete_types,
+        )?;
         self.extra_apis.extend(annotated.extra_apis);
         Ok((
             annotated.ty,
@@ -296,7 +293,6 @@ impl<'a> FnAnalyzer<'a> {
 
     fn avoid_generating_type(&self, type_name: &QualifiedName) -> bool {
         self.type_config.is_on_blocklist(&type_name.to_cpp_name())
-            || self.incomplete_types.contains(type_name)
     }
 
     fn should_be_unsafe(&self) -> bool {

--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -116,7 +116,6 @@ impl ByValueChecker {
                     }
                 }
                 ApiDetail::Type {
-                    is_forward_declaration: _,
                     bindgen_mod_item,
                     analysis: _,
                 } => match bindgen_mod_item {

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -20,9 +20,8 @@ use super::{convert_error::ErrorContext, parse::type_converter::TypeConverter, C
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum TypeKind {
-    Pod,                // trivial. Can be moved and copied in Rust.
-    NonPod, // has destructor or non-trivial move constructors. Can only hold by UniquePtr
-    ForwardDeclaration, // no full C++ declaration available - can't even generate UniquePtr
+    Pod,      // trivial. Can be moved and copied in Rust.
+    NonPod,   // has destructor or non-trivial move constructors. Can only hold by UniquePtr
     Abstract, // has pure virtual members - can't even generate UniquePtr
 }
 
@@ -30,7 +29,7 @@ impl TypeKind {
     pub(crate) fn can_be_instantiated(&self) -> bool {
         match self {
             TypeKind::Pod | TypeKind::NonPod => true,
-            TypeKind::ForwardDeclaration | TypeKind::Abstract => false,
+            TypeKind::Abstract => false,
         }
     }
 }
@@ -71,6 +70,8 @@ pub(crate) enum TypedefKind {
 
 /// Different types of API we might encounter.
 pub(crate) enum ApiDetail<T: ApiAnalysis> {
+    /// A forward declared type for which no definition is available.
+    ForwardDeclaration,
     /// A synthetic type we've manufactured in order to
     /// concretize some templated C++ type.
     ConcreteType { rs_definition: Box<Type> },
@@ -90,7 +91,6 @@ pub(crate) enum ApiDetail<T: ApiAnalysis> {
     /// A type (struct or enum) encountered in the
     /// `bindgen` output.
     Type {
-        is_forward_declaration: bool,
         bindgen_mod_item: Option<Item>,
         analysis: T::TypeAnalysis,
     },

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -402,6 +402,16 @@ impl<'a> RsCodeGenerator<'a> {
                     materialization: Use::Unused,
                 }
             }
+            ApiDetail::ForwardDeclaration => RsCodegenResult {
+                extern_c_mod_item: Some(ForeignItem::Type(parse_quote! {
+                    type #id;
+                })),
+                bridge_items: Vec::new(),
+                global_items: Vec::new(),
+                bindgen_mod_item: None,
+                impl_entry: None,
+                materialization: Use::UsedFromCxxBridge,
+            },
             ApiDetail::Function { fun, analysis } => {
                 gen_function(name.get_namespace(), fun, analysis)
             }
@@ -425,7 +435,6 @@ impl<'a> RsCodeGenerator<'a> {
                 materialization: Use::UsedFromBindgen,
             },
             ApiDetail::Type {
-                is_forward_declaration: _,
                 bindgen_mod_item,
                 analysis,
             } => RsCodegenResult {

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -42,6 +42,7 @@ pub enum ConvertError {
     InvalidPointee,
     DidNotGenerateAnything(String),
     UnacceptableStdType(QualifiedName),
+    TypeContainingForwardDeclaration(QualifiedName),
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -76,6 +77,7 @@ impl Display for ConvertError {
             ConvertError::InvalidPointee => write!(f, "Pointer pointed to something unsupported")?,
             ConvertError::DidNotGenerateAnything(directive) => write!(f, "The 'generate' or 'generate_pod' directive for '{}' did not result in any code being generated. Perhaps this was mis-spelled or you didn't qualify the name with any namespaces? Otherwise please report a bug.", directive)?,
             ConvertError::UnacceptableStdType(tn) => write!(f, "The std type '{}' is not yet supported", tn.to_cpp_name())?,
+            ConvertError::TypeContainingForwardDeclaration(tn) => write!(f, "Found an attempt at using a forward declaration ({}) inside a templated cxx type such as UniquePtr or CxxVector", tn.to_cpp_name())?,
         }
         Ok(())
     }

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -235,7 +235,9 @@ impl<'a> ParseBindgen<'a> {
             Item::Type(mut ity) => {
                 let tyname = QualifiedName::new(ns, ity.ident.clone());
                 let type_conversion_results =
-                    self.results.type_converter.convert_type(*ity.ty, ns, false);
+                    self.results
+                        .type_converter
+                        .convert_type(*ity.ty, ns, false, &HashSet::new());
                 match type_conversion_results {
                     Err(ConvertError::OpaqueTypeFound) => {
                         self.add_opaque_type(tyname);
@@ -311,10 +313,13 @@ impl<'a> ParseBindgen<'a> {
         let api = UnanalyzedApi {
             name: name.clone(),
             deps,
-            detail: ApiDetail::Type {
-                is_forward_declaration,
-                bindgen_mod_item,
-                analysis: (),
+            detail: if is_forward_declaration {
+                ApiDetail::ForwardDeclaration
+            } else {
+                ApiDetail::Type {
+                    bindgen_mod_item,
+                    analysis: (),
+                }
             },
         };
         self.results.apis.push(api);

--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -331,16 +331,6 @@ impl TypeConverter {
         }))
     }
 
-    fn add_concrete_type(&self, name: &QualifiedName, rs_definition: &Type) -> UnanalyzedApi {
-        UnanalyzedApi {
-            name: name.clone(),
-            deps: HashSet::new(),
-            detail: crate::conversion::api::ApiDetail::ConcreteType {
-                rs_definition: Box::new(rs_definition.clone()),
-            },
-        }
-    }
-
     fn get_templated_typename(
         &mut self,
         rs_definition: &Type,
@@ -352,14 +342,20 @@ impl TypeConverter {
         match e {
             Some(tn) => Ok((tn.clone(), None)),
             None => {
-                let tn = QualifiedName::new(
+                let name = QualifiedName::new(
                     &Namespace::new(),
                     make_ident(&format!("AutocxxConcrete{}", count)),
                 );
                 self.concrete_templates
-                    .insert(cpp_definition.clone(), tn.clone());
-                let api = self.add_concrete_type(&tn, rs_definition);
-                Ok((tn, Some(api)))
+                    .insert(cpp_definition.clone(), name.clone());
+                let api = UnanalyzedApi {
+                    name: name.clone(),
+                    deps: HashSet::new(),
+                    detail: crate::conversion::api::ApiDetail::ConcreteType {
+                        rs_definition: Box::new(rs_definition.clone()),
+                    },
+                };
+                Ok((name, Some(api)))
             }
         }
     }

--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -100,9 +100,15 @@ impl TypeConverter {
         ty: Box<Type>,
         ns: &Namespace,
         convert_ptrs_to_reference: bool,
+        types_to_allow_only_in_references_and_ptrs: &HashSet<QualifiedName>,
     ) -> Result<Annotated<Box<Type>>, ConvertError> {
         Ok(self
-            .convert_type(*ty, ns, convert_ptrs_to_reference)?
+            .convert_type(
+                *ty,
+                ns,
+                convert_ptrs_to_reference,
+                types_to_allow_only_in_references_and_ptrs,
+            )?
             .map(Box::new))
     }
 
@@ -111,10 +117,12 @@ impl TypeConverter {
         ty: Type,
         ns: &Namespace,
         convert_ptrs_to_reference: bool,
+        types_to_allow_only_in_references_and_ptrs: &HashSet<QualifiedName>,
     ) -> Result<Annotated<Type>, ConvertError> {
         let result = match ty {
             Type::Path(p) => {
-                let newp = self.convert_type_path(p, ns)?;
+                let newp =
+                    self.convert_type_path(p, ns, types_to_allow_only_in_references_and_ptrs)?;
                 if let Type::Path(newpp) = &newp.ty {
                     // Special handling because rust_Str (as emitted by bindgen)
                     // doesn't simply get renamed to a different type _identifier_.
@@ -137,7 +145,7 @@ impl TypeConverter {
                 }
             }
             Type::Reference(mut r) => {
-                let innerty = self.convert_boxed_type(r.elem, ns, false)?;
+                let innerty = self.convert_boxed_type(r.elem, ns, false, &HashSet::new())?;
                 r.elem = innerty.ty;
                 Annotated::new(
                     Type::Reference(r),
@@ -151,7 +159,7 @@ impl TypeConverter {
             }
             Type::Ptr(mut ptr) => {
                 crate::known_types::ensure_pointee_is_valid(&ptr)?;
-                let innerty = self.convert_boxed_type(ptr.elem, ns, false)?;
+                let innerty = self.convert_boxed_type(ptr.elem, ns, false, &HashSet::new())?;
                 ptr.elem = innerty.ty;
                 Annotated::new(
                     Type::Ptr(ptr),
@@ -169,6 +177,7 @@ impl TypeConverter {
         &mut self,
         mut typ: TypePath,
         ns: &Namespace,
+        types_to_allow_only_in_references_and_ptrs: &HashSet<QualifiedName>,
     ) -> Result<Annotated<Type>, ConvertError> {
         // First, qualify any unqualified paths.
         if typ.path.segments.iter().next().unwrap().ident != "root" {
@@ -243,6 +252,7 @@ impl TypeConverter {
                 crate::known_types::confirm_inner_type_is_acceptable_generic_payload(
                     &last_seg.arguments,
                     &tn,
+                    types_to_allow_only_in_references_and_ptrs,
                 )?;
                 if let PathArguments::AngleBracketed(ref mut ab) = last_seg.arguments {
                     let mut innerty = self.convert_punctuated(ab.args.clone(), ns)?;
@@ -284,7 +294,7 @@ impl TypeConverter {
         for arg in pun.into_iter() {
             new_pun.push(match arg {
                 GenericArgument::Type(t) => {
-                    let mut innerty = self.convert_type(t, ns, false)?;
+                    let mut innerty = self.convert_type(t, ns, false, &HashSet::new())?;
                     types_encountered.extend(innerty.types_encountered.drain());
                     extra_apis.extend(innerty.extra_apis.drain(..));
                     GenericArgument::Type(innerty.ty)
@@ -316,7 +326,7 @@ impl TypeConverter {
         ns: &Namespace,
     ) -> Result<Annotated<Type>, ConvertError> {
         let mutability = ptr.mutability;
-        let elem = self.convert_boxed_type(ptr.elem, ns, false)?;
+        let elem = self.convert_boxed_type(ptr.elem, ns, false, &HashSet::new())?;
         // TODO - in the future, we should check if this is a rust::Str and throw
         // a wobbler if not. rust::Str should only be seen _by value_ in C++
         // headers; it manifests as &str in Rust but on the C++ side it must

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use indoc::indoc;
 use once_cell::sync::OnceCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use syn::{parse_quote, GenericArgument, PathArguments, Type, TypePath, TypePtr};
 
 //// The behavior of the type.
@@ -412,6 +412,7 @@ pub(crate) fn type_lacks_copy_constructor(ty: &Type) -> bool {
 pub(crate) fn confirm_inner_type_is_acceptable_generic_payload(
     path_args: &PathArguments,
     desc: &QualifiedName,
+    unacceptable_types: &HashSet<QualifiedName>,
 ) -> Result<(), ConvertError> {
     // For now, all supported generics accept the same payloads. This
     // may change in future in which case we'll need to accept more arguments here.
@@ -424,10 +425,15 @@ pub(crate) fn confirm_inner_type_is_acceptable_generic_payload(
             for inner in &ab.args {
                 match inner {
                     GenericArgument::Type(Type::Path(typ)) => {
+                        let inner_qn = QualifiedName::from_type_path(&typ);
+                        if unacceptable_types.contains(&inner_qn) {
+                            return Err(ConvertError::TypeContainingForwardDeclaration(inner_qn));
+                        }
                         if let Some(more_generics) = typ.path.segments.last() {
                             confirm_inner_type_is_acceptable_generic_payload(
                                 &more_generics.arguments,
                                 desc,
+                                &HashSet::new(),
                             )?;
                         }
                     }


### PR DESCRIPTION
We no longer reject all APIs which refer to forward-declared types, but instead we'll allow them in pointers and references.

Works towards #401.