### PR TITLE
Detect &T<param elided by bindgen>

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "0.58.1"
+autocxx-bindgen = "0.58.2"
 itertools = "0.9"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4166,7 +4166,6 @@ fn test_ignore_dependent_qualified_type() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/416
 fn test_ignore_dependent_qualified_type_reference() {
     let hdr = indoc! {"
     #include <stddef.h>


### PR DESCRIPTION
Previously we ignored types which had type params
discarded by bindgen, but not references or pointers to those types.
We now do.

Fixes #416. Will add some follow-up notes on #124.