### PR TITLE
Failing test: Multiple ignored overloads cause duplicate definition

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4938,6 +4938,34 @@ fn test_include_cpp_in_path() {
     do_run_test_manual("", hdr, rs, &[], None).unwrap();
 }
 
+#[test]
+#[ignore] // https://github.com/google/autocxx/issues/428
+fn test_overloaded_ignored_function() {
+    // When overloaded functions are ignored during import, the placeholder
+    // functions generated for them should have unique names, just as they
+    // would have if they had ben imported successfully.
+    // The test is successful if the bindings compile.
+    let hdr = indoc! {"
+        struct Blocked {};
+        class A {
+        public:
+            void take_blocked(Blocked);
+            void take_blocked(Blocked, int);
+        };
+    "};
+    let rs = quote! {};
+    run_test_ex(
+        "",
+        hdr,
+        rs,
+        &["A"],
+        &[],
+        Some(quote! { block!("Blocked") }),
+        &[],
+        None,
+    );
+}
+
 // Yet to test:
 // 6. Ifdef
 // 7. Out param pointers


### PR DESCRIPTION
See also https://github.com/google/autocxx/issues/428