### PR TITLE
Exclude constructors for abstract types.

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4483,7 +4483,6 @@ fn test_get_pure_virtual() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/424
 fn test_abstract_class_no_make_unique() {
     // We shouldn't generate a make_unique() for abstract classes.
     // The test is successful if the bindings compile, i.e. if autocxx doesn't


### PR DESCRIPTION
We previously did the right thing in eliding
  impl UniquePtr<T>
for abstract types, but we might still have attempted
to generate constructors.

Fixes #424.