### PR TITLE
Inline all additional cpp

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -162,10 +162,12 @@ pub(crate) fn build_with_existing_parsed_file(
             .generate_h_and_cxx()
             .map_err(BuilderError::InvalidCxx)?;
         for filepair in generated_code.0 {
-            let fname = format!("gen{}.cxx", counter);
-            counter += 1;
-            let gen_cxx_path = write_to_file(&cxxdir, &fname, &filepair.implementation)?;
-            builder.file(gen_cxx_path);
+            if let Some(implementation) = &filepair.implementation {
+                let fname = format!("gen{}.cxx", counter);
+                counter += 1;
+                let gen_cxx_path = write_to_file(&cxxdir, &fname, implementation)?;
+                builder.file(gen_cxx_path);
+            }
 
             write_to_file(&incdir, &filepair.header_name, &filepair.header)?;
             let fname = include_cpp.get_rs_filename();

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -140,7 +140,7 @@ impl CppCodeGenerator {
             log::info!("Additional C++ decls:\n{}", declarations);
             Some(CppFilePair {
                 header: declarations.into_bytes(),
-                implementation: vec![],
+                implementation: None,
                 header_name: "autocxxgen.h".into(),
             })
         }

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -16,6 +16,7 @@ mod function_wrapper_cpp;
 pub(crate) mod type_to_cpp;
 
 use crate::{types::QualifiedName, CppFilePair};
+use indoc::indoc;
 use itertools::Itertools;
 use std::collections::HashSet;
 use syn::Type;
@@ -69,7 +70,6 @@ impl Header {
 struct AdditionalFunction {
     type_definition: String, // are output before main declarations
     declaration: String,
-    definition: String,
     headers: Vec<Header>,
 }
 
@@ -137,13 +137,10 @@ impl CppCodeGenerator {
                 "#ifndef __AUTOCXXGEN_H__\n#define __AUTOCXXGEN_H__\n\n{}\n{}\n{}\n{}#endif // __AUTOCXXGEN_H__\n",
                 headers, self.inclusions, type_definitions, declarations
             );
-            let definitions = self.concat_additional_items(|x| &x.definition);
-            let definitions = format!("#include \"autocxxgen.h\"\n{}", definitions);
             log::info!("Additional C++ decls:\n{}", declarations);
-            log::info!("Additional C++ defs:\n{}", definitions);
             Some(CppFilePair {
                 header: declarations.into_bytes(),
-                implementation: definitions.into_bytes(),
+                implementation: vec![],
                 header_name: "autocxxgen.h".into(),
             })
         }
@@ -164,16 +161,14 @@ impl CppCodeGenerator {
     }
 
     fn generate_string_constructor(&mut self) {
-        let declaration = "std::unique_ptr<std::string> make_string(::rust::Str str)";
-        let definition = format!(
-            "{} {{ return std::make_unique<std::string>(std::string(str)); }}",
-            declaration
-        );
+        let declaration = indoc! {"
+        inline std::unique_ptr<std::string> make_string(::rust::Str str)
+        { return std::make_unique<std::string>(std::string(str)); }
+        "};
         let declaration = format!("{};", declaration);
         self.additional_functions.push(AdditionalFunction {
             type_definition: "".into(),
             declaration,
-            definition,
             headers: vec![
                 Header::system("memory"),
                 Header::system("string"),
@@ -259,12 +254,10 @@ impl CppCodeGenerator {
             underlying_function_call =
                 format!("return {}", ret.cpp_conversion(&underlying_function_call)?);
         };
-        let definition = format!("{} {{ {}; }}", declaration, underlying_function_call,);
-        let declaration = format!("{};", declaration);
+        let declaration = format!("{} {{ {}; }}", declaration, underlying_function_call,);
         self.additional_functions.push(AdditionalFunction {
             type_definition: "".into(),
             declaration,
-            definition,
             headers: vec![Header::system("memory")],
         });
         Ok(())
@@ -280,7 +273,6 @@ impl CppCodeGenerator {
         self.additional_functions.push(AdditionalFunction {
             type_definition: format!("typedef {} {};", definition, our_name),
             declaration: "".into(),
-            definition: "".into(),
             headers: Vec::new(),
         })
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -75,8 +75,8 @@ pub use cxx;
 pub struct CppFilePair {
     /// Declarations to go into a header file.
     pub header: Vec<u8>,
-    /// Implementations to go into a .cpp file.
-    pub implementation: Vec<u8>,
+    /// Implementations to go into a .cpp file, if any.
+    pub implementation: Option<Vec<u8>>,
     /// The name which should be used for the header file
     /// (important as it may be `#include`d elsewhere)
     pub header_name: String,
@@ -418,7 +418,7 @@ impl IncludeCppEngine {
                 files.push(CppFilePair {
                     header: cxx_generated.header,
                     header_name: "cxxgen.h".to_string(),
-                    implementation: cxx_generated.implementation,
+                    implementation: Some(cxx_generated.implementation),
                 });
                 if let Some(cpp_file_pair) = &gen_results.cpp {
                     files.push(cpp_file_pair.clone());

--- a/gen/cmd/src/cmd_test.rs
+++ b/gen/cmd/src/cmd_test.rs
@@ -71,7 +71,7 @@ fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .success();
     assert_contentful(&tmp_dir, "gen0.cc");
-    assert_contentful(&tmp_dir, "gen1.cc");
+    assert_exists(&tmp_dir, "gen1.cc");
     assert_exists(&tmp_dir, "gen2.cc");
     assert_contentful(&tmp_dir, "gen0.include.rs");
     assert_exists(&tmp_dir, "gen1.include.rs");

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -188,10 +188,12 @@ fn main() {
                 .generate_h_and_cxx()
                 .expect("Unable to generate header and C++ code");
             for pair in generations.0 {
-                let cppname = format!("gen{}.{}", counter, cpp);
-                write_to_file(&outdir, cppname, &pair.implementation);
                 write_to_file(&outdir, pair.header_name, &pair.header);
-                counter += 1;
+                if let Some(implementation) = &pair.implementation {
+                    let cppname = format!("gen{}.{}", counter, cpp);
+                    write_to_file(&outdir, cppname, implementation);
+                    counter += 1;
+                }
             }
         }
         write_placeholders(&outdir, counter, desired_number, cpp);


### PR DESCRIPTION
autocxx generates two lumps of C++ code:
* code generated by cxx (both .h and .cpp)
* code generated by autocxx (previously, both .h and .cpp)

In fact all functions within the second area of code are only ever called from the cxx-generated .cpp file. This change ensures all our functions (in the second generated section of code) are inlined, to avoid the waste of an extra C++ compiler invocation, and to encourage inlining even in build systems where link-time optimization may not be enabled.
