### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ use autocxx::include_cpp;
 
 include_cpp!{
     #include "base/bob.h"
-    generate!("Bob")
+    safety!(unsafe_ffi)
+    generate!("base::Bob")
 }
 
 let a = ffi::base::Bob::make_unique("hello");


### PR DESCRIPTION
It looks like autocxx needs `safety!(unsafe_ffi)` to generate "safe" functions (the example doesn't use an `unsafe` block), and the name needs to be namespaced in the call to `generate!()`.

(PR template removed, as this isn't fixing an issue, just a drive-by while I learn enough autocxx to actually try to fix a real issue :sunglasses:.)