### PR TITLE
Generate consts inside the correct namespace

### DIFF
--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -413,8 +413,8 @@ impl<'a> RsCodeGenerator<'a> {
                 impl_entry: None,
                 bridge_items: Vec::new(),
                 extern_c_mod_item: None,
-                bindgen_mod_item: None,
-                materialization: Use::Custom(Box::new(Item::Const(const_item))),
+                bindgen_mod_item: Some(Item::Const(const_item)),
+                materialization: Use::UsedFromBindgen,
             },
             ApiDetail::Typedef { payload } => RsCodegenResult {
                 extern_c_mod_item: None,

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -47,7 +47,7 @@ use quote::quote;
 
 unzip_n::unzip_n!(pub 3);
 
-/// Whether and how this type should be exposed in the mods constructed
+/// Whether and how this item should be exposed in the mods constructed
 /// for actual end-user use.
 #[derive(Clone)]
 enum Use {
@@ -409,12 +409,12 @@ impl<'a> RsCodeGenerator<'a> {
                 gen_function(name.get_namespace(), *fun, analysis)
             }
             ApiDetail::Const { const_item } => RsCodegenResult {
-                global_items: vec![Item::Const(const_item)],
+                global_items: Vec::new(),
                 impl_entry: None,
                 bridge_items: Vec::new(),
                 extern_c_mod_item: None,
                 bindgen_mod_item: None,
-                materialization: Use::Unused,
+                materialization: Use::Custom(Box::new(Item::Const(const_item))),
             },
             ApiDetail::Typedef { payload } => RsCodegenResult {
                 extern_c_mod_item: None,

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -222,9 +222,6 @@ impl<'a> ParseBindgen<'a> {
                 Ok(())
             }
             Item::Const(const_item) => {
-                // The following puts this constant into
-                // the global namespace which is bug
-                // https://github.com/google/autocxx/issues/133
                 self.results.apis.push(UnanalyzedApi {
                     name: QualifiedName::new(ns, const_item.ident.clone()),
                     deps: HashSet::new(),

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5047,6 +5047,27 @@ fn test_overloaded_ignored_function() {
     );
 }
 
+
+#[test]
+#[ignore]  // #133
+fn test_namespaced_constant() {
+    let hdr = indoc! {"
+        namespace A {
+            const int kConstant = 3;
+        }
+    "};
+    let rs = quote! {
+        assert_eq!(ffi::A::kConstant, 3);
+    };
+    run_test(
+        "",
+        hdr,
+        rs,
+        &["A::kConstant"],
+        &[],
+    );
+}
+
 // Yet to test:
 // 6. Ifdef
 // 7. Out param pointers

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5049,7 +5049,6 @@ fn test_overloaded_ignored_function() {
 
 
 #[test]
-#[ignore]  // #133
 fn test_namespaced_constant() {
     let hdr = indoc! {"
         namespace A {


### PR DESCRIPTION
Fixes #133

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

---

```
test result: ok. 183 passed; 0 failed; 20 ignored; 0 measured; 0 filtered out; finished in 286.38s
```

This change retains the constant inside the bindgen module, and then generates an alias:

```
        mod bindgen {                                                                                  
            pub(super) mod root {                                                                      
                pub mod A {                                                                            
                    pub const kConstant: ::std::os::raw::c_int = 3;                                    
                    #[allow(unused_imports)]                                                           
                    use self::super::super::super::cxxbridge;                                          
                    #[allow(unused_imports)]                                                           
                    use self::super::super::super::ToCppString;                                        
                    #[allow(unused_imports)]       
                    use self::super::super::root;
                }                                                                                      
                #[allow(unused_imports)]                                                               
                use self::super::super::cxxbridge;                                                     
                #[allow(unused_imports)]                                                               
                use self::super::super::ToCppString;                                                   
                #[allow(unused_imports)]
                use self::super::root;                                                                 
            }                                      
        }                                                                                              
        #[cxx::bridge]
        mod cxxbridge {                                                                                
            unsafe extern "C++" {                                                                      
                fn make_string(str_: &str) -> UniquePtr<CxxString>;                                    
                include!("input.h");                                                                   
                include!("autocxxgen.h");          
            }                                      
        }                                                                                              
        #[allow(unused_imports)]            
        use bindgen::root;                         
        pub mod A {                                
            pub use super::bindgen::root::A::kConstant;      
        }
```