### PR TITLE
Fix typedefs to non-path types.

### DIFF
--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -231,7 +231,7 @@ impl<'a> TypeConverter<'a> {
             Some(other) => {
                 return Ok(Annotated::new(
                     other.clone(),
-                    HashSet::new(),
+                    deps,
                     Vec::new(),
                     false,
                 ))


### PR DESCRIPTION
These weren't being marked properly as dependencies of functions,
so were disappearing during garbage collection.

This is a partial solution to the test added for issue #443
and will be tested as part of that.