### PR TITLE
Squash all double underscores

### DIFF
--- a/engine/src/conversion/analysis/mod.rs
+++ b/engine/src/conversion/analysis/mod.rs
@@ -17,3 +17,4 @@ pub(crate) mod ctypes;
 pub(crate) mod fun;
 pub(crate) mod gc;
 pub(crate) mod pod; // hey, that rhymes
+pub(crate) mod remove_ignored;

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -136,7 +136,7 @@ fn get_struct_field_types(
 ) -> Result<(), ConvertError> {
     for f in &s.fields {
         let annotated =
-            type_converter.convert_type(f.ty.clone(), ns, &TypeConversionContext::Cxx)?;
+            type_converter.convert_type(f.ty.clone(), ns, &TypeConversionContext::CxxInnerType)?;
         extra_apis.extend(annotated.extra_apis);
         deps.extend(annotated.types_encountered);
     }

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use super::fun::FnAnalysis;
+use crate::conversion::api::{Api, ApiDetail};
+use crate::conversion::convert_error::ErrorContext;
+
+/// Remove any APIs which depend on other items which have been ignored.
+pub(crate) fn filter_apis_by_ignored_dependents(
+    mut apis: Vec<Api<FnAnalysis>>,
+) -> Vec<Api<FnAnalysis>> {
+    let mut ignored_items: HashSet<_> = apis
+        .iter()
+        .filter_map(|api| {
+            if matches!(
+                api.detail,
+                ApiDetail::IgnoredItem {
+                    ctx: ErrorContext::Item(..),
+                    ..
+                }
+            ) {
+                Some(api.typename())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let mut iterate_again = true;
+    while iterate_again {
+        iterate_again = false;
+        apis = apis
+            .into_iter()
+            .filter(|api| {
+                if api.deps.iter().any(|dep| ignored_items.contains(dep)) {
+                    iterate_again = true;
+                    ignored_items.insert(api.typename());
+                    eprintln!(
+                        "Skipping item {} because it depends on another item we skipped.",
+                        api.typename().to_string()
+                    );
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
+    }
+    apis
+}

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -238,7 +238,7 @@ impl<'a> ParseBindgen<'a> {
                 let type_conversion_results = self.results.type_converter.convert_type(
                     *ity.ty,
                     ns,
-                    &TypeConversionContext::NonCxx,
+                    &TypeConversionContext::CxxInnerType,
                 );
                 match type_conversion_results {
                     Err(ConvertError::OpaqueTypeFound) => {


### PR DESCRIPTION
Solves #452, but I want to add a test case too.

This PR reverts #383, and in so doing, re-adds a phase where APIs are removed when their dependent types are unavailable.

This was previously thought unnecessary because _functions_ discarded themselves if any of their parameters/return types were unavailable. But it turns out that other types of depdendency relationship may have the same problem - typedefs in particular may be generated even if we discarded the refererent.