### PR TITLE
Don't generate bindings for move constructors

### DIFF
--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -47,6 +47,7 @@ pub enum ConvertError {
     TooManyUnderscores,
     UnknownDependentType,
     IgnoredDependent,
+    MoveConstructorUnsupported,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -86,6 +87,7 @@ impl Display for ConvertError {
             ConvertError::TooManyUnderscores => write!(f, "Names containing __ are reserved by C++ so not acceptable to cxx")?,
             ConvertError::UnknownDependentType => write!(f, "This item relies on a type not known to autocxx.")?,
             ConvertError::IgnoredDependent => write!(f, "This item depends on some other type which autocxx could not generate.")?,
+            ConvertError::MoveConstructorUnsupported => write!(f, "This is a move constructor, for which we currently cannot generate bindings.")?,
         }
         Ok(())
     }

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5065,11 +5065,18 @@ fn test_deleted_function() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/426
-fn test_implicitly_deleted_copy_constructor() {
-    // We shouldn't generate bindings for implicitly deleted functions.
-    // The test is successful if the bindings compile, i.e. if autocxx doesn't
-    // attempt to call the implicitly deleted copy constructor.
+fn test_ignore_move_constructor() {
+    // Test that we don't generate bindings for move constructors and,
+    // specifically, don't erroneously import them as copy constructors.
+    // We used to do this because bindgen creates the same Rust signature for
+    // move constructors and for copy constructors.
+    // The way this tests works is a bit subtle.  Declaring a move constructor
+    // causes the copy constructor to be implicitly deleted (unless it is]
+    // explicitly declared). If we erroneously tried to create a binding for the
+    // move constructor (because the signature led us to believe it is a copy
+    // constructor), the generated C++ code would therefore try to call the
+    // deleted copy constructor, which would result in a compile error.
+    // The test is therefore successful if the bindings compile.
     let hdr = indoc! {"
         class A {
         public:


### PR DESCRIPTION
For details, see https://github.com/google/autocxx/issues/456.

I'm duplicating some code from `get_bindgen_original_name_annotation` in `get_bindgen_special_member_annotation` because I plan to move the former function to a different module when I implement support for nested types.

Fixes #456 