### PR TITLE
Temporarily fix autocxx-bindgen 0.58.3.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "0.58.3"
+autocxx-bindgen = "=0.58.3"
 itertools = "0.9"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"


### PR DESCRIPTION
A bugfix will be needed in order to be able to absorb
0.58.4.