### PR TITLE
Remove `bindgen_` attributes from output

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.58.3"
+autocxx-bindgen = "0.58.4"
 itertools = "0.9"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"


### PR DESCRIPTION
These attributes don't have a corresponding macro defined anywhere, so they will cause compilation errors if we leave them in.

This bug was exposed by a recent change in autocxx-bindgen that added `bindgen_original_name` attributes for nested types; this is why autocxx-bindgen was temporarily pinned to version 0.58.3, which does not contain those changes.

Because the bug is now fixed, this change also updates autocxx-bindgen to 0.58.4.