### PR TITLE
Make nested types work

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.58.3"
+autocxx-bindgen = "0.58.4"
 itertools = "0.9"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"

--- a/engine/src/conversion/analysis/ctypes.rs
+++ b/engine/src/conversion/analysis/ctypes.rs
@@ -34,6 +34,7 @@ pub(crate) fn append_ctype_information(apis: &mut Vec<Api<FnAnalysis>>) {
     for (id, tn) in ctypes {
         apis.push(Api {
             name: QualifiedName::new(&Namespace::new(), id),
+            original_name: None,
             deps: HashSet::new(),
             detail: ApiDetail::CType { typename: tn },
         });

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -30,8 +30,8 @@ use autocxx_parser::{TypeConfig, UnsafePolicy};
 use function_wrapper::{FunctionWrapper, FunctionWrapperPayload, TypeConversionPolicy};
 use proc_macro2::Span;
 use syn::{
-    parse_quote, punctuated::Punctuated, FnArg, ForeignItemFn, Ident, LitStr, Pat, ReturnType, Type,
-    TypePtr, Visibility,
+    parse_quote, punctuated::Punctuated, FnArg, ForeignItemFn, Ident, LitStr, Pat, ReturnType,
+    Type, TypePtr, Visibility,
 };
 
 use crate::{

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -121,6 +121,7 @@ fn analyze_pod_api(
     };
     Ok(Api {
         name: api.name,
+        original_name: api.original_name,
         deps: new_deps,
         detail: api_detail,
     })

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -70,6 +70,7 @@ fn create_ignore_item(api: Api<FnAnalysis>, err: ConvertError) -> Api<FnAnalysis
     let id = api.typename().get_final_ident();
     Api {
         name: api.typename(),
+        original_name: api.original_name,
         deps: HashSet::new(),
         detail: ApiDetail::IgnoredItem {
             err,

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -127,6 +127,7 @@ pub(crate) enum ApiDetail<T: ApiAnalysis> {
 /// Rust codegen output.
 pub(crate) struct Api<T: ApiAnalysis> {
     pub(crate) name: QualifiedName,
+    pub(crate) original_name: Option<String>,
     /// Any dependencies of this API, such that during garbage collection
     /// we can ensure to keep them.
     pub(crate) deps: HashSet<QualifiedName>,

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -70,6 +70,7 @@ fn push_ignored_item(
 ) {
     apis.push(Api {
         name: QualifiedName::new(ns, ctx.get_id().clone()),
+        original_name: None,
         deps: HashSet::new(),
         detail: ApiDetail::IgnoredItem { err, ctx },
     });

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -17,6 +17,7 @@ use crate::conversion::{
     api::{FuncToConvert, UnanalyzedApi},
     convert_error::ConvertErrorWithContext,
     convert_error::ErrorContext,
+    parse::parse_bindgen::get_bindgen_original_name_annotation,
 };
 use crate::{
     conversion::api::ApiDetail,
@@ -130,6 +131,7 @@ impl ParseForeignMod {
             fun.self_ty = self.method_receivers.get(&fun.item.sig.ident).cloned();
             apis.push(UnanalyzedApi {
                 name: QualifiedName::new(&self.ns, fun.item.sig.ident.clone()),
+                original_name: get_bindgen_original_name_annotation(&fun.item.attrs),
                 deps: HashSet::new(), // filled in later - TODO make compile-time safe
                 detail: ApiDetail::Function {
                     fun: Box::new(fun),

--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -401,6 +401,9 @@ impl<'a> TypeConverter<'a> {
                     .insert(cpp_definition.clone(), name.clone());
                 let api = UnanalyzedApi {
                     name: name.clone(),
+                    // This is a synthesized type that isn't nested within anything else,
+                    // so it doesn't have an orignal_name.
+                    original_name: None,
                     deps: HashSet::new(),
                     detail: crate::conversion::api::ApiDetail::ConcreteType {
                         rs_definition: Box::new(rs_definition.clone()),

--- a/engine/src/conversion/parse/type_converter.rs
+++ b/engine/src/conversion/parse/type_converter.rs
@@ -388,7 +388,9 @@ impl<'a> TypeConverter<'a> {
     ) -> Result<(QualifiedName, Option<UnanalyzedApi>), ConvertError> {
         let count = self.concrete_templates.len();
         // We just use this as a hash key, essentially.
-        let cpp_definition = type_to_cpp(rs_definition)?;
+        // TODO: Once we've completed the TypeConverter refactoring (see #220),
+        // pass in an actual original_name_map here.
+        let cpp_definition = type_to_cpp(rs_definition, &HashMap::new())?;
         let e = self.concrete_templates.get(&cpp_definition);
         match e {
             Some(tn) => Ok((tn.clone(), None)),

--- a/engine/src/conversion/utilities.rs
+++ b/engine/src/conversion/utilities.rs
@@ -28,6 +28,7 @@ pub(crate) fn generate_utilities(apis: &mut Vec<UnanalyzedApi>) {
     // unless the include_cpp macro has specified ExcludeUtilities.
     apis.push(UnanalyzedApi {
         name: QualifiedName::new(&Namespace::new(), make_ident("make_string")),
+        original_name: None,
         deps: HashSet::new(),
         detail: super::api::ApiDetail::StringConstructor,
     });


### PR DESCRIPTION
We use the `bindgen_original_type` attribute emitted by autocxx-bindgen to refer to the correct C++ type in generated C++ and Rust code.

For details, see #115.

Fixes #115.