### PR TITLE
Activate previously failing test for deleted functions.

### DIFF
--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5074,7 +5074,6 @@ fn test_int_vector() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/426
 fn test_deleted_function() {
     // We shouldn't generate bindings for deleted functions.
     // The test is successful if the bindings compile, i.e. if autocxx doesn't


### PR DESCRIPTION
The test passes now that we use bindgen 0.58.4.

Fixes #426.