### PR TITLE
Reduce unnecessary attr stripping

### DIFF
--- a/engine/src/conversion/analysis/abstract_types.rs
+++ b/engine/src/conversion/analysis/abstract_types.rs
@@ -40,7 +40,7 @@ pub(crate) fn mark_types_abstract(apis: &mut Vec<Api<FnAnalysis>>) {
     for api in apis.iter_mut() {
         let tyname = api.name();
         match &mut api.detail {
-            ApiDetail::Type { analysis, .. } if abstract_types.contains(&tyname) => {
+            ApiDetail::Struct { analysis, .. } if abstract_types.contains(&tyname) => {
                 *analysis = TypeKind::Abstract;
             }
             _ => {}

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -164,8 +164,12 @@ impl<'a> FnAnalyzer<'a> {
     fn build_pod_safe_type_set(apis: &[Api<PodAnalysis>]) -> HashSet<QualifiedName> {
         apis.iter()
             .filter_map(|api| match api.detail {
-                ApiDetail::Type {
-                    bindgen_mod_item: _,
+                ApiDetail::Struct {
+                    item: _,
+                    analysis: TypeKind::Pod,
+                } => Some(api.name()),
+                ApiDetail::Enum {
+                    item: _,
                     analysis: TypeKind::Pod,
                 } => Some(api.name()),
                 _ => None,
@@ -220,14 +224,8 @@ impl<'a> FnAnalyzer<'a> {
             ApiDetail::Const { const_item } => ApiDetail::Const { const_item },
             ApiDetail::Typedef { item, analysis } => ApiDetail::Typedef { item, analysis },
             ApiDetail::CType { typename } => ApiDetail::CType { typename },
-            // Just changes to this one...
-            ApiDetail::Type {
-                bindgen_mod_item,
-                analysis,
-            } => ApiDetail::Type {
-                bindgen_mod_item,
-                analysis,
-            },
+            ApiDetail::Enum { item, analysis } => ApiDetail::Enum { item, analysis },
+            ApiDetail::Struct { item, analysis } => ApiDetail::Struct { item, analysis },
             ApiDetail::ForwardDeclaration => ApiDetail::ForwardDeclaration,
             ApiDetail::IgnoredItem { err, ctx } => ApiDetail::IgnoredItem { err, ctx },
         };

--- a/engine/src/conversion/analysis/mod.rs
+++ b/engine/src/conversion/analysis/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use syn::Attribute;
+
 pub(crate) mod abstract_types;
 pub(crate) mod ctypes;
 pub(crate) mod fun;
@@ -20,3 +22,20 @@ pub(crate) mod pod; // hey, that rhymes
 pub(crate) mod remove_ignored;
 pub(crate) mod tdef;
 mod type_converter;
+
+// Remove `bindgen_` attributes. They don't have a corresponding macro defined anywhere,
+// so they will cause compilation errors if we leave them in.
+fn remove_bindgen_attrs(attrs: &mut Vec<Attribute>) {
+    fn is_bindgen_attr(attr: &Attribute) -> bool {
+        let segments = &attr.path.segments;
+        segments.len() == 1
+            && segments
+                .first()
+                .unwrap()
+                .ident
+                .to_string()
+                .starts_with("bindgen_")
+    }
+
+    attrs.retain(|a| !is_bindgen_attr(a))
+}

--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use autocxx_parser::TypeConfig;
 use std::collections::HashMap;
-use syn::{Item, ItemStruct, Type};
+use syn::{ItemStruct, Type};
 
 #[derive(Clone)]
 enum PodState {
@@ -115,21 +115,17 @@ impl ByValueChecker {
                         None => byvalue_checker.ingest_nonpod_type(name),
                     }
                 }
-                ApiDetail::Type {
-                    bindgen_mod_item,
+                ApiDetail::Struct { item, analysis: _ } => {
+                    byvalue_checker.ingest_struct(&item, &api.name.get_namespace())
+                }
+                ApiDetail::Enum {
+                    item: _,
                     analysis: _,
-                } => match bindgen_mod_item {
-                    None => {}
-                    Some(Item::Struct(s)) => {
-                        byvalue_checker.ingest_struct(&s, &api.name.get_namespace())
-                    }
-                    Some(Item::Enum(_)) => {
-                        byvalue_checker
-                            .results
-                            .insert(api.name(), StructDetails::new(PodState::IsPod));
-                    }
-                    _ => {}
-                },
+                } => {
+                    byvalue_checker
+                        .results
+                        .insert(api.name(), StructDetails::new(PodState::IsPod));
+                }
                 _ => {}
             }
         }

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -28,6 +28,8 @@ use crate::{
     types::QualifiedName,
 };
 
+use super::remove_bindgen_attrs;
+
 /// Analysis phase where typedef analysis has been performed but no other
 /// analyses just yet.
 pub(crate) struct TypedefAnalysis;
@@ -83,13 +85,8 @@ pub(crate) fn convert_typedef_targets(
                     item: item.clone(),
                     analysis: item,
                 }),
-                ApiDetail::Type {
-                    bindgen_mod_item,
-                    analysis,
-                } => Some(ApiDetail::Type {
-                    bindgen_mod_item,
-                    analysis,
-                }),
+                ApiDetail::Struct { item, analysis } => Some(ApiDetail::Struct { item, analysis }),
+                ApiDetail::Enum { item, analysis } => Some(ApiDetail::Enum { item, analysis }),
                 ApiDetail::CType { typename } => Some(ApiDetail::CType { typename }),
                 ApiDetail::IgnoredItem { err, ctx } => Some(ApiDetail::IgnoredItem { err, ctx }),
             };
@@ -115,6 +112,7 @@ fn get_replacement_typedef(
     deps: &mut HashSet<QualifiedName>,
 ) -> Result<ApiDetail<TypedefAnalysis>, ConvertErrorWithContext> {
     let mut converted_type = ity.clone();
+    remove_bindgen_attrs(&mut converted_type.attrs);
     let type_conversion_results = type_converter.convert_type(
         (*ity.ty).clone(),
         name.get_namespace(),

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -456,7 +456,8 @@ impl<'a> TypeConverter<'a> {
                 ApiDetail::ForwardDeclaration
                 | ApiDetail::ConcreteType { .. }
                 | ApiDetail::Typedef { .. }
-                | ApiDetail::Type { .. } => Some(api.name()),
+                | ApiDetail::Enum { .. }
+                | ApiDetail::Struct { .. } => Some(api.name()),
                 ApiDetail::StringConstructor
                 | ApiDetail::Function { .. }
                 | ApiDetail::Const { .. }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -15,7 +15,9 @@
 use crate::types::QualifiedName;
 use itertools::Itertools;
 use std::collections::HashSet;
-use syn::{ForeignItemFn, Ident, ImplItem, Item, ItemConst, ItemType, ItemUse, Type};
+use syn::{
+    ForeignItemFn, Ident, ImplItem, ItemConst, ItemEnum, ItemStruct, ItemType, ItemUse, Type,
+};
 
 use super::{convert_error::ErrorContext, ConvertError};
 
@@ -104,10 +106,16 @@ pub(crate) enum ApiDetail<T: AnalysisPhase> {
         item: TypedefKind,
         analysis: T::TypedefAnalysis,
     },
-    /// A type (struct or enum) encountered in the
+    /// An enum encountered in the
     /// `bindgen` output.
-    Type {
-        bindgen_mod_item: Option<Item>,
+    Enum {
+        item: ItemEnum,
+        analysis: T::TypeAnalysis,
+    },
+    /// A struct encountered in the
+    /// `bindgen` output.
+    Struct {
+        item: ItemStruct,
         analysis: T::TypeAnalysis,
     },
     /// A variable-length C integer type (e.g. int, unsigned long).

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -326,10 +326,7 @@ impl<'a> RsCodeGenerator<'a> {
         }
 
         fn remove_bindgen_attrs(attrs: &mut Vec<Attribute>) {
-            *attrs = attrs
-                .drain(..)
-                .filter(|attr| !is_bindgen_attr(&attr))
-                .collect();
+            attrs.retain(|a| !is_bindgen_attr(a))
         }
 
         match &mut item {


### PR DESCRIPTION
Strip bindgen attributes during the analysis phases, when we know exactly what item types we're dealing with.

This also distinguishes `ApiDetail::Enum` from `ApiDetail::Struct`.