### PR TITLE
Preprocess mode: Check env vars `CLANG_PATH` and `CXX` for path to Clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ order of preference here's how we would like to hear about your problem:
 * Use the C++ preprocessor to give a single complete C++ file which demonstrates
   the problem, along with the `include_cpp!` directive you use.
   Alternatively, run your build using `AUTOCXX_PREPROCESS=output.h` which should
-  put everything we need into `output.h`.
+  put everything we need into `output.h`. If necessary, you can use the `CLANG_PATH`
+  or `CXX` environment variables to specify the path to the Clang compiler to use.
 * Failing all else, build using
   `cargo clean -p <your package name> && RUST_LOG=autocxx_engine=info cargo build -vvv`
   and send the _entire_ log to us. This will include two key bits of logging:


### PR DESCRIPTION
This is to support environments that need to use a different `clang++` than the one on the path. `CLANG_PATH` is the variable used by the clang-sys crate; in most cases where a custom Clang is needed, people will already be specifying this, and things should just work.

Also improve the error reporting when preprocessing goes wrong:

- Check not just the `Error` returned by `output()` (which merely tells us whether we spawned the Clang process successfully) but also the `status` field of `std::process::Output` (i.e. the process's exit code).

- Forward Clang's stderr to autocxx's stderr.

I ran into an error where the version of Clang on the path did not understand a certain flag that I was trying to pass (and which is understood by the Clang I'm setting with `CLANG_PATH`), but I wasn't getting an error message, which made it harder to diagnose what was going on.