### PR TITLE
Do not generate Rust keywords as identifiers.

### DIFF
--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -47,6 +47,7 @@ pub enum ConvertError {
     UnknownDependentType,
     IgnoredDependent,
     MoveConstructorUnsupported,
+    ReservedName,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -86,6 +87,7 @@ impl Display for ConvertError {
             ConvertError::UnknownDependentType => write!(f, "This item relies on a type not known to autocxx.")?,
             ConvertError::IgnoredDependent => write!(f, "This item depends on some other type which autocxx could not generate.")?,
             ConvertError::MoveConstructorUnsupported => write!(f, "This is a move constructor, for which we currently cannot generate bindings.")?,
+            ConvertError::ReservedName => write!(f, "The item name is a reserved word in Rust.")?,
         }
         Ok(())
     }

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5050,6 +5050,28 @@ fn test_error_generated_for_array_dependent_method() {
     );
 }
 
+#[test]
+fn test_keyword_function() {
+    let hdr = indoc! {"
+        inline void move(int a) {};
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["move_"], &[]);
+}
+
+#[test]
+#[ignore] // https://github.com/google/autocxx/issues/494
+fn test_keyword_method() {
+    let hdr = indoc! {"
+        struct A {
+            int a;
+            inline void move() {};
+        };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["A"], &[]);
+}
+
 /// Returns a closure which simply hunts for a given string in the results
 fn make_string_finder(
     error_texts: Vec<&str>,

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -14,6 +14,7 @@
 
 use itertools::Itertools;
 use proc_macro2::Span;
+use quote::ToTokens;
 use std::iter::Peekable;
 use std::{fmt::Display, sync::Arc};
 use syn::{parse_quote, Ident, PathSegment, TypePath};
@@ -226,11 +227,19 @@ impl Display for QualifiedName {
 /// wrapper for a CxxCompatibleIdent which is used in any context
 /// where code will be output as part of the `#[cxx::bridge]` mod.
 pub fn validate_ident_ok_for_cxx(id: &str) -> Result<(), ConvertError> {
+    validate_ident_ok_for_rust(id)?;
     if id.contains("__") {
         Err(ConvertError::TooManyUnderscores)
     } else {
         Ok(())
     }
+}
+
+pub fn validate_ident_ok_for_rust(id: &str) -> Result<(), ConvertError> {
+    let id = make_ident(id);
+    syn::parse2::<syn::Ident>(id.into_token_stream())
+        .map_err(|_| ConvertError::ReservedName)
+        .map(|_| ())
 }
 
 #[cfg(test)]

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use itertools::Itertools;
 use proc_macro2::Span;
 use std::iter::Peekable;
 use std::{fmt::Display, sync::Arc};
@@ -180,15 +181,7 @@ impl QualifiedName {
         let special_cpp_name = known_types().special_cpp_name(&self);
         match special_cpp_name {
             Some(name) => name,
-            None => {
-                let mut s = String::new();
-                for seg in &self.0 {
-                    s.push_str(&seg);
-                    s.push_str("::");
-                }
-                s.push_str(&self.1);
-                s
-            }
+            None => self.0.iter().chain(std::iter::once(&self.1)).join("::"),
         }
     }
 


### PR DESCRIPTION
Partial fix for #494.