### PR TITLE
Spot base classes not on the allowlist.

### DIFF
--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -23,9 +23,13 @@ use super::{convert_error::ErrorContext, ConvertError};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum TypeKind {
-    Pod,      // trivial. Can be moved and copied in Rust.
-    NonPod,   // has destructor or non-trivial move constructors. Can only hold by UniquePtr
-    Abstract, // has pure virtual members - can't even generate UniquePtr
+    Pod,    // trivial. Can be moved and copied in Rust.
+    NonPod, // has destructor or non-trivial move constructors. Can only hold by UniquePtr
+    Abstract, // has pure virtual members - can't even generate UniquePtr.
+            // It's possible that the type itself isn't pure virtual, but it inherits from
+            // some other type which is pure virtual. Alternatively, maybe we just don't
+            // know if the base class is pure virtual because it wasn't on the allowlist,
+            // in which case we'll err on the side of caution.
 }
 
 impl TypeKind {

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -129,7 +129,7 @@ impl<'a> BridgeConverter<'a> {
                 // If any of those functions turned out to be pure virtual, don't attempt
                 // to generate UniquePtr implementations for the type, since it can't
                 // be instantiated.
-                mark_types_abstract(&mut analyzed_apis);
+                mark_types_abstract(&self.config, &mut analyzed_apis);
                 Self::dump_apis("main analyses", &analyzed_apis);
                 // During parsing or subsequent processing we might have encountered
                 // items which we couldn't process due to as-yet-unsupported features.

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -4630,7 +4630,6 @@ fn test_recursive_derived_abstract_class_no_make_unique() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/491
 fn test_derived_abstract_class_with_no_allowlisting_no_make_unique() {
     let hdr = indoc! {"
         class A {


### PR DESCRIPTION
And assume the derived classes are abstract.

Fixes #491.