### PR TITLE
Add exclude_impls directive.

### DIFF
--- a/engine/src/conversion/codegen_rs/impl_item_creator.rs
+++ b/engine/src/conversion/codegen_rs/impl_item_creator.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use autocxx_parser::IncludeCppConfig;
 use syn::{parse_quote, Ident, Item};
 
-pub(crate) fn create_impl_items(id: &Ident) -> Vec<Item> {
+pub(crate) fn create_impl_items(id: &Ident, config: &IncludeCppConfig) -> Vec<Item> {
+    if config.exclude_impls {
+        return vec![];
+    }
     vec![
         Item::Impl(parse_quote! {
             impl UniquePtr<#id> {}

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -406,7 +406,7 @@ impl<'a> RsCodeGenerator<'a> {
             },
             ApiDetail::ConcreteType { .. } => RsCodegenResult {
                 global_items: self.generate_extern_type_impl(TypeKind::NonPod, &name),
-                bridge_items: create_impl_items(&id),
+                bridge_items: create_impl_items(&id, self.config),
                 extern_c_mod_item: Some(ForeignItem::Verbatim(self.generate_cxxbridge_type(name))),
                 bindgen_mod_item: Some(Item::Struct(new_non_pod_struct(id.clone()))),
                 impl_entry: None,
@@ -477,7 +477,7 @@ impl<'a> RsCodeGenerator<'a> {
             global_items: self.generate_extern_type_impl(analysis, &name),
             impl_entry: None,
             bridge_items: if analysis.can_be_instantiated() {
-                create_impl_items(&id)
+                create_impl_items(&id, self.config)
             } else {
                 Vec::new()
             },

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5357,6 +5357,29 @@ fn test_issue_470_492() {
 }
 
 #[test]
+fn test_no_impl() {
+    let hdr = indoc! {"
+        struct A {
+            int a;
+        };
+    "};
+    let rs = quote! {};
+    run_test_ex(
+        "",
+        hdr,
+        rs,
+        &["A"],
+        &[],
+        Some(quote! {
+            exclude_impls!()
+            exclude_utilities!()
+        }),
+        &[],
+        None,
+    );
+}
+
+#[test]
 fn test_generate_all() {
     let hdr = indoc! {"
         #include <cstdint>

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -98,6 +98,7 @@ pub struct IncludeCppConfig {
     pub inclusions: Vec<String>,
     pub unsafe_policy: UnsafePolicy,
     pub parse_only: bool,
+    pub exclude_impls: bool,
     pod_requests: Vec<String>,
     allowlist: Allowlist,
     blocklist: Vec<String>,
@@ -114,6 +115,7 @@ impl Parse for IncludeCppConfig {
 
         let mut inclusions = Vec::new();
         let mut parse_only = false;
+        let mut exclude_impls = false;
         let mut unsafe_policy = UnsafePolicy::AllFunctionsUnsafe;
         let mut allowlist = Allowlist::Unspecified;
         let mut blocklist = Vec::new();
@@ -156,6 +158,9 @@ impl Parse for IncludeCppConfig {
                 } else if ident == "parse_only" {
                     parse_only = true;
                     swallow_parentheses(&input, &ident)?;
+                } else if ident == "exclude_impls" {
+                    exclude_impls = true;
+                    swallow_parentheses(&input, &ident)?;
                 } else if ident == "generate_all" {
                     allowlist.set_all(&ident)?;
                     swallow_parentheses(&input, &ident)?;
@@ -192,6 +197,7 @@ impl Parse for IncludeCppConfig {
             blocklist,
             exclude_utilities,
             mod_name,
+            exclude_impls,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,17 @@ macro_rules! safety {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
+/// Whether to avoid generating [`cxx::UniquePtr`] and [`cxx::Vector`]
+/// implementations. This is primarily useful for reducing test cases and
+/// shouldn't be used in normal operation.
+///
+/// A directive to be included inside
+/// [include_cpp] - see [include_cpp] for general information.
+#[macro_export]
+macro_rules! exclude_impls {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! usage {


### PR DESCRIPTION
Useful to avoid extraneous definitions of std::unique_ptr
and std::vector (and their dependents) in minimized test cases.

Works towards #493.