### PR TITLE
Rename original_name -> cpp_name.

### DIFF
--- a/engine/src/conversion/analysis/ctypes.rs
+++ b/engine/src/conversion/analysis/ctypes.rs
@@ -34,7 +34,7 @@ pub(crate) fn append_ctype_information(apis: &mut Vec<Api<FnAnalysis>>) {
     for (id, tn) in ctypes {
         apis.push(Api {
             name: QualifiedName::new(&Namespace::new(), id),
-            original_name: None,
+            cpp_name: None,
             deps: HashSet::new(),
             detail: ApiDetail::CType { typename: tn },
         });

--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -33,7 +33,7 @@ pub(crate) fn check_names(apis: Vec<Api<FnAnalysis>>) -> Vec<Api<FnAnalysis>> {
         | ApiDetail::Enum { .. }
         | ApiDetail::Struct { .. } => {
             let cxx_name = api
-                .original_name
+                .cpp_name
                 .as_ref()
                 .map(|s|
                     QualifiedName::new_from_cpp_name(&s)

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -145,7 +145,7 @@ fn analyze_pod_api(
     };
     Ok(Api {
         name: api.name,
-        original_name: api.original_name,
+        cpp_name: api.cpp_name,
         deps: new_deps,
         detail: api_detail,
     })

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -70,7 +70,7 @@ fn create_ignore_item(api: Api<FnAnalysis>, err: ConvertError) -> Api<FnAnalysis
     let id = api.name().get_final_ident();
     Api {
         name: api.name(),
-        original_name: api.original_name,
+        cpp_name: api.cpp_name,
         deps: HashSet::new(),
         detail: ApiDetail::IgnoredItem {
             err,

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -52,7 +52,7 @@ pub(crate) fn convert_typedef_targets(
         .into_iter()
         .filter_map(|api| {
             let name = api.name();
-            let original_name = api.original_name;
+            let cpp_name = api.cpp_name;
             let ns = name.get_namespace();
             let mut newdeps = api.deps;
             let detail = match api.detail {
@@ -93,7 +93,7 @@ pub(crate) fn convert_typedef_targets(
             detail.map(|detail| Api {
                 detail,
                 name,
-                original_name,
+                cpp_name,
                 deps: newdeps,
             })
         })

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -393,7 +393,7 @@ impl<'a> TypeConverter<'a> {
                     name: name.clone(),
                     // This is a synthesized type that isn't nested within anything else,
                     // so it doesn't have an orignal_name.
-                    original_name: None,
+                    cpp_name: None,
                     deps: HashSet::new(),
                     detail: crate::conversion::api::ApiDetail::ConcreteType {
                         rs_definition: Box::new(rs_definition.clone()),
@@ -523,7 +523,7 @@ pub(crate) fn add_analysis<A: AnalysisPhase>(api: UnanalyzedApi) -> Api<A> {
     };
     Api {
         name: api.name,
-        original_name: api.original_name,
+        cpp_name: api.cpp_name,
         deps: api.deps,
         detail: new_detail,
     }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -144,8 +144,10 @@ pub(crate) enum ApiDetail<T: AnalysisPhase> {
 /// because sometimes we pass on the `bindgen` output directly in the
 /// Rust codegen output.
 pub(crate) struct Api<T: AnalysisPhase> {
+    /// The name by which we refer to this within Rust.
     pub(crate) name: QualifiedName,
-    pub(crate) original_name: Option<String>,
+    /// The C++ name, if it's different.
+    pub(crate) cpp_name: Option<String>,
     /// Any dependencies of this API, such that during garbage collection
     /// we can ensure to keep them.
     pub(crate) deps: HashSet<QualifiedName>,

--- a/engine/src/conversion/codegen_cpp/function_wrapper_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/function_wrapper_cpp.rs
@@ -18,37 +18,31 @@ use crate::conversion::{
 };
 use crate::known_types::type_lacks_copy_constructor;
 
-use super::type_to_cpp::{type_to_cpp, OriginalNameMap};
+use super::type_to_cpp::{type_to_cpp, CppNameMap};
 
 impl TypeConversionPolicy {
     pub(super) fn unconverted_type(
         &self,
-        original_name_map: &OriginalNameMap,
+        cpp_name_map: &CppNameMap,
     ) -> Result<String, ConvertError> {
         match self.cpp_conversion {
-            CppConversionType::FromUniquePtrToValue => self.wrapped_type(original_name_map),
-            _ => self.unwrapped_type_as_string(original_name_map),
+            CppConversionType::FromUniquePtrToValue => self.wrapped_type(cpp_name_map),
+            _ => self.unwrapped_type_as_string(cpp_name_map),
         }
     }
 
-    pub(super) fn converted_type(
-        &self,
-        original_name_map: &OriginalNameMap,
-    ) -> Result<String, ConvertError> {
+    pub(super) fn converted_type(&self, cpp_name_map: &CppNameMap) -> Result<String, ConvertError> {
         match self.cpp_conversion {
-            CppConversionType::FromValueToUniquePtr => self.wrapped_type(original_name_map),
-            _ => self.unwrapped_type_as_string(original_name_map),
+            CppConversionType::FromValueToUniquePtr => self.wrapped_type(cpp_name_map),
+            _ => self.unwrapped_type_as_string(cpp_name_map),
         }
     }
 
-    fn unwrapped_type_as_string(
-        &self,
-        original_name_map: &OriginalNameMap,
-    ) -> Result<String, ConvertError> {
-        type_to_cpp(&self.unwrapped_type, original_name_map)
+    fn unwrapped_type_as_string(&self, cpp_name_map: &CppNameMap) -> Result<String, ConvertError> {
+        type_to_cpp(&self.unwrapped_type, cpp_name_map)
     }
 
-    fn wrapped_type(&self, original_name_map: &OriginalNameMap) -> Result<String, ConvertError> {
+    fn wrapped_type(&self, original_name_map: &CppNameMap) -> Result<String, ConvertError> {
         Ok(format!(
             "std::unique_ptr<{}>",
             self.unwrapped_type_as_string(original_name_map)?
@@ -58,7 +52,7 @@ impl TypeConversionPolicy {
     pub(super) fn cpp_conversion(
         &self,
         var_name: &str,
-        original_name_map: &OriginalNameMap,
+        cpp_name_map: &CppNameMap,
     ) -> Result<String, ConvertError> {
         Ok(match self.cpp_conversion {
             CppConversionType::None => {
@@ -71,7 +65,7 @@ impl TypeConversionPolicy {
             CppConversionType::FromUniquePtrToValue => format!("std::move(*{})", var_name),
             CppConversionType::FromValueToUniquePtr => format!(
                 "std::make_unique<{}>({})",
-                self.unconverted_type(original_name_map)?,
+                self.unconverted_type(cpp_name_map)?,
                 var_name
             ),
         })

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -20,7 +20,7 @@ use autocxx_parser::IncludeCppConfig;
 use itertools::Itertools;
 use std::collections::HashSet;
 use syn::Type;
-use type_to_cpp::{original_name_map_from_apis, type_to_cpp, OriginalNameMap};
+use type_to_cpp::{original_name_map_from_apis, type_to_cpp, CppNameMap};
 
 use super::{
     analysis::fun::{
@@ -82,7 +82,7 @@ struct AdditionalFunction {
 pub(crate) struct CppCodeGenerator<'a> {
     additional_functions: Vec<AdditionalFunction>,
     inclusions: String,
-    original_name_map: OriginalNameMap,
+    original_name_map: CppNameMap,
     config: &'a IncludeCppConfig,
 }
 
@@ -99,7 +99,7 @@ impl<'a> CppCodeGenerator<'a> {
 
     fn new(
         inclusions: String,
-        original_name_map: OriginalNameMap,
+        original_name_map: CppNameMap,
         config: &'a IncludeCppConfig,
     ) -> Self {
         CppCodeGenerator {

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -40,7 +40,7 @@ use self::{
 };
 
 use super::codegen_cpp::type_to_cpp::{
-    namespaced_name_using_original_name_map, original_name_map_from_apis, OriginalNameMap,
+    namespaced_name_using_original_name_map, original_name_map_from_apis, CppNameMap,
 };
 use super::{
     analysis::fun::FnAnalysis,
@@ -120,7 +120,7 @@ fn remove_nones<T>(input: Vec<Option<T>>) -> Vec<T> {
 pub(crate) struct RsCodeGenerator<'a> {
     include_list: &'a [String],
     bindgen_mod: ItemMod,
-    original_name_map: OriginalNameMap,
+    original_name_map: CppNameMap,
     config: &'a IncludeCppConfig,
 }
 
@@ -567,10 +567,10 @@ impl<'a> RsCodeGenerator<'a> {
         let id = name.get_final_ident();
         let mut ns_components: Vec<_> = ns.iter().cloned().collect();
         let mut cxx_name = None;
-        if let Some(original_name) = self.original_name_map.get(name) {
-            let original_name = QualifiedName::new_from_cpp_name(original_name);
-            cxx_name = Some(original_name.get_final_item().to_string());
-            ns_components.extend(original_name.ns_segment_iter().cloned());
+        if let Some(cpp_name) = self.original_name_map.get(name) {
+            let cpp_name = QualifiedName::new_from_cpp_name(cpp_name);
+            cxx_name = Some(cpp_name.get_final_item().to_string());
+            ns_components.extend(cpp_name.ns_segment_iter().cloned());
         };
 
         let mut for_extern_c_ts = if !ns_components.is_empty() {

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -92,7 +92,7 @@ pub(crate) fn convert_item_apis<F, A, B>(
 fn ignored_item<A: AnalysisPhase>(ns: &Namespace, ctx: ErrorContext, err: ConvertError) -> Api<A> {
     Api {
         name: QualifiedName::new(ns, ctx.get_id().clone()),
-        original_name: None,
+        cpp_name: None,
         deps: HashSet::new(),
         detail: ApiDetail::IgnoredItem { err, ctx },
     }

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -141,28 +141,22 @@ impl<'a> ParseBindgen<'a> {
                 }
                 let tyname = Self::qualify_name(ns, s.ident.clone())?;
                 let is_forward_declaration = Self::spot_forward_declaration(&s.fields);
-                let original_name = get_bindgen_original_name_annotation(&s.attrs);
+                let cpp_name = get_bindgen_original_name_annotation(&s.attrs);
                 // cxx::bridge can't cope with type aliases to generic
                 // types at the moment.
-                self.parse_type(
-                    tyname.clone(),
-                    is_forward_declaration,
-                    s,
-                    original_name,
-                    |s| ApiDetail::Struct {
+                self.parse_type(tyname.clone(), is_forward_declaration, s, cpp_name, |s| {
+                    ApiDetail::Struct {
                         item: s,
                         analysis: (),
-                    },
-                );
+                    }
+                });
                 self.latest_virtual_this_type = Some(tyname);
                 Ok(())
             }
             Item::Enum(e) => {
                 let tyname = Self::qualify_name(ns, e.ident.clone())?;
-                let original_name = get_bindgen_original_name_annotation(&e.attrs);
-                self.parse_type(tyname, false, e, original_name, |e| ApiDetail::Enum {
-                    item: e,
-                });
+                let cpp_name = get_bindgen_original_name_annotation(&e.attrs);
+                self.parse_type(tyname, false, e, cpp_name, |e| ApiDetail::Enum { item: e });
                 Ok(())
             }
             Item::Impl(imp) => {
@@ -222,9 +216,7 @@ impl<'a> ParseBindgen<'a> {
                             deps.insert(old_tyname);
                             self.apis.push(UnanalyzedApi {
                                 name: QualifiedName::new(ns, new_id.clone()),
-                                original_name: get_bindgen_original_name_annotation(
-                                    &use_item.attrs,
-                                ),
+                                cpp_name: get_bindgen_original_name_annotation(&use_item.attrs),
                                 deps,
                                 detail: ApiDetail::Typedef {
                                     item: TypedefKind::Use(parse_quote! {
@@ -248,7 +240,7 @@ impl<'a> ParseBindgen<'a> {
             Item::Const(const_item) => {
                 self.apis.push(UnanalyzedApi {
                     name: QualifiedName::new(ns, const_item.ident.clone()),
-                    original_name: get_bindgen_original_name_annotation(&const_item.attrs),
+                    cpp_name: get_bindgen_original_name_annotation(&const_item.attrs),
                     deps: HashSet::new(),
                     detail: ApiDetail::Const { const_item },
                 });
@@ -257,7 +249,7 @@ impl<'a> ParseBindgen<'a> {
             Item::Type(ity) => {
                 self.apis.push(UnanalyzedApi {
                     name: QualifiedName::new(ns, ity.ident.clone()),
-                    original_name: get_bindgen_original_name_annotation(&ity.attrs),
+                    cpp_name: get_bindgen_original_name_annotation(&ity.attrs),
                     deps: HashSet::new(),
                     detail: ApiDetail::Typedef {
                         item: TypedefKind::Type(ity),
@@ -300,7 +292,7 @@ impl<'a> ParseBindgen<'a> {
         name: QualifiedName,
         is_forward_declaration: bool,
         bindgen_mod_item: T,
-        original_name: Option<String>,
+        cpp_name: Option<String>,
         api_make: F,
     ) where
         F: FnOnce(T) -> ApiDetail<NullAnalysis>,
@@ -310,7 +302,7 @@ impl<'a> ParseBindgen<'a> {
         }
         let api = UnanalyzedApi {
             name,
-            original_name,
+            cpp_name,
             deps: HashSet::new(),
             detail: if is_forward_declaration {
                 ApiDetail::ForwardDeclaration

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -131,7 +131,7 @@ impl ParseForeignMod {
             fun.self_ty = self.method_receivers.get(&fun.item.sig.ident).cloned();
             apis.push(UnanalyzedApi {
                 name: QualifiedName::new(&self.ns, fun.item.sig.ident.clone()),
-                original_name: get_bindgen_original_name_annotation(&fun.item.attrs),
+                cpp_name: get_bindgen_original_name_annotation(&fun.item.attrs),
                 deps: HashSet::new(), // filled in later - TODO make compile-time safe
                 detail: ApiDetail::Function {
                     fun: Box::new(fun),

--- a/engine/src/conversion/utilities.rs
+++ b/engine/src/conversion/utilities.rs
@@ -30,7 +30,7 @@ pub(crate) fn generate_utilities(apis: &mut Vec<UnanalyzedApi>, config: &Include
     // unless the include_cpp macro has specified ExcludeUtilities.
     apis.push(UnanalyzedApi {
         name: QualifiedName::new(&Namespace::new(), make_ident(config.get_makestring_name())),
-        original_name: None,
+        cpp_name: None,
         deps: HashSet::new(),
         detail: super::api::ApiDetail::StringConstructor,
     });


### PR DESCRIPTION
It's more concise, and more accurately reflects what we may do with
this field in future changes.

Step towards #520.