### PR TITLE
Support Rust types as references

### DIFF
--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -60,6 +60,7 @@ pub(crate) fn check_names(apis: Vec<Api<FnAnalysis>>) -> Vec<Api<FnAnalysis>> {
         Api::ConcreteType { .. }
         | Api::CType { .. }
         | Api::StringConstructor { .. }
+        | Api::RustType { .. }
         | Api::IgnoredItem { .. } => Ok(Some(api)),
     });
 

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -452,7 +452,8 @@ impl<'a> TypeConverter<'a> {
                 | Api::ConcreteType { .. }
                 | Api::Typedef { .. }
                 | Api::Enum { .. }
-                | Api::Struct { .. } => Some(api.name()),
+                | Api::Struct { .. }
+                | Api::RustType { .. } => Some(api.name()),
                 Api::StringConstructor { .. }
                 | Api::Function { .. }
                 | Api::Const { .. }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -171,6 +171,8 @@ pub(crate) enum Api<T: AnalysisPhase> {
         err: ConvertError,
         ctx: ErrorContext,
     },
+    /// A Rust type which is not a C++ type.
+    RustType { name: ApiName },
 }
 
 impl<T: AnalysisPhase> Api<T> {
@@ -186,6 +188,7 @@ impl<T: AnalysisPhase> Api<T> {
             Api::Struct { name, .. } => name,
             Api::CType { name, .. } => name,
             Api::IgnoredItem { name, .. } => name,
+            Api::RustType { name, .. } => name,
         }
     }
 

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -144,6 +144,7 @@ pub(super) fn gen_function(
         bindgen_mod_item: None,
         impl_entry,
         materialization,
+        extern_rust_mod_item: None,
     }
 }
 

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -94,6 +94,7 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B>(
             Api::StringConstructor { name } => Ok(Some(Api::StringConstructor { name })),
             Api::Const { name, const_item } => Ok(Some(Api::Const { name, const_item })),
             Api::CType { name, typename } => Ok(Some(Api::CType { name, typename })),
+            Api::RustType { name } => Ok(Some(Api::RustType { name })),
             Api::IgnoredItem { name, err, ctx } => Ok(Some(Api::IgnoredItem { name, err, ctx })),
             // Apply a mapping to the following
             Api::Enum { name, item } => enum_conversion(name, item),

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -164,7 +164,9 @@ impl<'a> ParseBindgen<'a> {
                 // cxx::bridge can't cope with type aliases to generic
                 // types at the moment.
                 let name = api_name_qualified(ns, s.ident.clone(), &s.attrs)?;
-                let api = if is_forward_declaration {
+                let api = if ns.is_empty() && self.config.is_rust_type(&s.ident) {
+                    UnanalyzedApi::RustType { name }
+                } else if is_forward_declaration {
                     UnanalyzedApi::ForwardDeclaration { name }
                 } else {
                     UnanalyzedApi::Struct {

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -5922,6 +5922,37 @@ fn test_rust_reference() {
 }
 
 #[test]
+fn test_pass_thru_rust_reference() {
+    let hdr = indoc! {"
+    #include <cstdint>
+
+    struct RustType;
+    inline const RustType& pass_rust_reference(const RustType& a) {
+        return a;
+    }
+    "};
+    let rs = quote! {
+        let foo = RustType(3);
+        assert_eq!(ffi::pass_rust_reference(&foo).0, 3);
+    };
+    run_test_ex2(
+        "",
+        hdr,
+        rs,
+        &["pass_rust_reference"],
+        &[],
+        Some(quote! {
+            rust_type!(RustType)
+        }),
+        &[],
+        None,
+        Some(quote! {
+            pub struct RustType(i32);
+        }),
+    );
+}
+
+#[test]
 #[ignore]
 fn test_rust_reference_method() {
     let hdr = indoc! {"

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -104,6 +104,7 @@ pub struct IncludeCppConfig {
     blocklist: Vec<String>,
     exclude_utilities: bool,
     mod_name: Option<Ident>,
+    pub rust_types: Vec<Ident>,
 }
 
 impl Parse for IncludeCppConfig {
@@ -120,6 +121,7 @@ impl Parse for IncludeCppConfig {
         let mut allowlist = Allowlist::Unspecified;
         let mut blocklist = Vec::new();
         let mut pod_requests = Vec::new();
+        let mut rust_types = Vec::new();
         let mut exclude_utilities = false;
         let mut mod_name = None;
 
@@ -155,6 +157,11 @@ impl Parse for IncludeCppConfig {
                     syn::parenthesized!(args in input);
                     let generate: syn::LitStr = args.parse()?;
                     blocklist.push(generate.value());
+                } else if ident == "rust_type" {
+                    let args;
+                    syn::parenthesized!(args in input);
+                    let ident: syn::Ident = args.parse()?;
+                    rust_types.push(ident);
                 } else if ident == "parse_only" {
                     parse_only = true;
                     swallow_parentheses(&input, &ident)?;
@@ -194,6 +201,7 @@ impl Parse for IncludeCppConfig {
             parse_only,
             exclude_impls,
             pod_requests,
+            rust_types,
             allowlist,
             blocklist,
             exclude_utilities,
@@ -300,6 +308,10 @@ impl IncludeCppConfig {
                 .map(|i| i.to_string())
                 .unwrap_or_else(|| "default".into())
         )
+    }
+
+    pub fn is_rust_type(&self, id: &Ident) -> bool {
+        self.rust_types.contains(id)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,6 +606,15 @@ macro_rules! exclude_impls {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
+/// Declare that a given type is a Rust type. These may be used within
+/// references in the signatures of C++ functions, for instance.
+/// This will contribute to an `extern "Rust"` section of the generated
+/// `cxx` bindings.
+#[macro_export]
+macro_rules! rust_type {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! usage {


### PR DESCRIPTION
Step towards #199.

This PR in itself doesn't really achieve anything useful. With it, you _can_ now pass references to Rust types from Rust to C++ and vice-versa... but you can't actually interact with them or use them in any way once you've got them in C++.

Future PRs should add support for `rust::Box`.