### PR TITLE
Reinstate cpp file

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -160,12 +160,10 @@ pub(crate) fn build_with_existing_parsed_file(
             .generate_h_and_cxx()
             .map_err(BuilderError::InvalidCxx)?;
         for filepair in generated_code.0 {
-            if let Some(implementation) = &filepair.implementation {
-                let fname = format!("gen{}.cxx", counter);
-                counter += 1;
-                let gen_cxx_path = write_to_file(&cxxdir, &fname, implementation)?;
-                builder.file(gen_cxx_path);
-            }
+            let fname = format!("gen{}.cxx", counter);
+            counter += 1;
+            let gen_cxx_path = write_to_file(&cxxdir, &fname, &filepair.implementation)?;
+            builder.file(gen_cxx_path);
 
             write_to_file(&incdir, &filepair.header_name, &filepair.header)?;
         }

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -272,15 +272,14 @@ impl<'a> CppCodeGenerator<'a> {
                 ret.cpp_conversion(&underlying_function_call, &self.original_name_map)?
             );
         };
-        let definition = Some(format!(
+        let declaration = Some(format!(
             "{} {{ {}; }}",
             declaration, underlying_function_call,
         ));
-        let declaration = Some(format!("{};", declaration));
         self.additional_functions.push(AdditionalFunction {
             type_definition: None,
             declaration,
-            definition,
+            definition: None,
             headers: vec![Header::system("memory")],
         });
         Ok(())

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -176,19 +176,11 @@ impl<'a> CppCodeGenerator<'a> {
 
     fn generate_string_constructor(&mut self) {
         let makestring_name = self.config.get_makestring_name();
-        let declaration = format!(
-            "std::unique_ptr<std::string> {}(::rust::Str str)",
-            makestring_name
-        );
-        let definition = Some(format!(
-            "{} {{ return std::make_unique<std::string>(std::string(str)); }}",
-            declaration
-        ));
-        let declaration = Some(format!("{};", declaration));
+        let declaration = Some(format!("inline std::unique_ptr<std::string> {}(::rust::Str str) {{ return std::make_unique<std::string>(std::string(str)); }}", makestring_name));
         self.additional_functions.push(AdditionalFunction {
             type_definition: None,
             declaration,
-            definition,
+            definition: None,
             headers: vec![
                 Header::system("memory"),
                 Header::system("string"),

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -82,8 +82,8 @@ pub use cxx;
 pub struct CppFilePair {
     /// Declarations to go into a header file.
     pub header: Vec<u8>,
-    /// Implementations to go into a .cpp file, if any.
-    pub implementation: Option<Vec<u8>>,
+    /// Implementations to go into a .cpp file.
+    pub implementation: Vec<u8>,
     /// The name which should be used for the header file
     /// (important as it may be `#include`d elsewhere)
     pub header_name: String,
@@ -481,7 +481,7 @@ pub fn do_cxx_cpp_generation(rs: TokenStream2) -> Result<CppFilePair, cxx_gen::E
     Ok(CppFilePair {
         header: cxx_generated.header,
         header_name: "cxxgen.h".into(),
-        implementation: Some(cxx_generated.implementation),
+        implementation: cxx_generated.implementation,
     })
 }
 

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -190,12 +190,10 @@ fn main() {
                 .generate_h_and_cxx()
                 .expect("Unable to generate header and C++ code");
             for pair in generations.0 {
+                let cppname = format!("gen{}.{}", counter, cpp);
+                write_to_file(&outdir, cppname, &pair.implementation);
                 write_to_file(&outdir, pair.header_name, &pair.header);
-                if let Some(implementation) = &pair.implementation {
-                    let cppname = format!("gen{}.{}", counter, cpp);
-                    write_to_file(&outdir, cppname, implementation);
-                    counter += 1;
-                }
+                counter += 1;
             }
         }
         write_placeholders(&outdir, counter, desired_number, cpp);


### PR DESCRIPTION
This undoes #434. Whilst working on #200, I realized we needed to generate a `.cpp` file such that we can use types within cxx's generated .h file.

This PR is WIP because we still want to inline as much as possible.