### PR TITLE
Allow Rust to inherit from C++ subclasses

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -160,12 +160,10 @@ pub(crate) fn build_with_existing_parsed_file(
             .generate_h_and_cxx()
             .map_err(BuilderError::InvalidCxx)?;
         for filepair in generated_code.0 {
-            if let Some(implementation) = &filepair.implementation {
-                let fname = format!("gen{}.cxx", counter);
-                counter += 1;
-                let gen_cxx_path = write_to_file(&cxxdir, &fname, implementation)?;
-                builder.file(gen_cxx_path);
-            }
+            let fname = format!("gen{}.cxx", counter);
+            counter += 1;
+            let gen_cxx_path = write_to_file(&cxxdir, &fname, &filepair.implementation)?;
+            builder.file(gen_cxx_path);
 
             write_to_file(&incdir, &filepair.header_name, &filepair.header)?;
         }

--- a/engine/src/conversion/analysis/abstract_types.rs
+++ b/engine/src/conversion/analysis/abstract_types.rs
@@ -30,7 +30,7 @@ pub(crate) fn mark_types_abstract(config: &IncludeCppConfig, apis: &mut Vec<Api<
             Api::Function {
                 analysis:
                     FnAnalysisBody {
-                        kind: FnKind::Method(self_ty_name, MethodKind::PureVirtual),
+                        kind: FnKind::Method(self_ty_name, MethodKind::PureVirtual(_)),
                         ..
                     },
                 ..

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -15,17 +15,28 @@
 use crate::types::Namespace;
 use syn::{parse_quote, Ident, Type};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum CppConversionType {
     None,
     FromUniquePtrToValue,
     FromValueToUniquePtr,
 }
 
-#[derive(Clone)]
+impl CppConversionType {
+    fn inverse(&self) -> Self {
+        match self {
+            CppConversionType::None => CppConversionType::None,
+            CppConversionType::FromUniquePtrToValue => CppConversionType::FromValueToUniquePtr,
+            CppConversionType::FromValueToUniquePtr => CppConversionType::FromUniquePtrToValue,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(crate) enum RustConversionType {
     None,
     FromStr,
+    ToBoxedUpHolder(Ident),
 }
 
 /// A policy for converting types. Conversion may occur on both the Rust and
@@ -39,7 +50,7 @@ pub(crate) enum RustConversionType {
 /// * Finally, the actual C++ API receives a `std::string` by value.
 /// The implementation here is distributed across this file, and
 /// `function_wrapper_rs` and `function_wrapper_cpp`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct TypeConversionPolicy {
     pub(crate) unwrapped_type: Type,
     pub(crate) cpp_conversion: CppConversionType,
@@ -79,6 +90,14 @@ impl TypeConversionPolicy {
         }
     }
 
+    pub(crate) fn box_up_subclass_holder(ty: Type, holder_name: Ident) -> Self {
+        TypeConversionPolicy {
+            unwrapped_type: ty,
+            cpp_conversion: CppConversionType::None,
+            rust_conversion: RustConversionType::ToBoxedUpHolder(holder_name),
+        }
+    }
+
     pub(crate) fn cpp_work_needed(&self) -> bool {
         !matches!(self.cpp_conversion, CppConversionType::None)
     }
@@ -107,18 +126,41 @@ impl TypeConversionPolicy {
     pub(crate) fn rust_work_needed(&self) -> bool {
         !matches!(self.rust_conversion, RustConversionType::None)
     }
+
+    pub(crate) fn inverse(&self) -> Self {
+        Self {
+            unwrapped_type: self.unwrapped_type.clone(),
+            cpp_conversion: self.cpp_conversion.inverse(),
+            rust_conversion: self.rust_conversion.clone(),
+        }
+    }
 }
+
+#[derive(Clone)]
 
 pub(crate) enum CppFunctionBody {
     FunctionCall(Namespace, Ident),
     StaticMethodCall(Namespace, Ident, Ident),
     Constructor,
+    AssignSubclassHolderField,
 }
 
+#[derive(Clone)]
+
+pub(crate) enum CppFunctionKind {
+    Function,
+    Method,
+    ConstMethod,
+    Constructor,
+}
+
+#[derive(Clone)]
 pub(crate) struct CppFunction {
     pub(crate) payload: CppFunctionBody,
     pub(crate) wrapper_function_name: Ident,
     pub(crate) return_conversion: Option<TypeConversionPolicy>,
     pub(crate) argument_conversion: Vec<TypeConversionPolicy>,
-    pub(crate) is_a_method: bool,
+    pub(crate) kind: CppFunctionKind,
+    pub(crate) pass_obs_field: bool,
+    pub(crate) qualification: Option<Ident>,
 }

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -109,14 +109,12 @@ impl TypeConversionPolicy {
     }
 }
 
-#[derive(Clone)] // TODO wish this didn't need to be cloneable
 pub(crate) enum FunctionWrapperPayload {
     FunctionCall(Namespace, Ident),
     StaticMethodCall(Namespace, Ident, Ident),
     Constructor,
 }
 
-#[derive(Clone)] // TODO wish this didn't need to be cloneable
 pub(crate) struct FunctionWrapper {
     pub(crate) payload: FunctionWrapperPayload,
     pub(crate) wrapper_function_name: Ident,

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -109,14 +109,14 @@ impl TypeConversionPolicy {
     }
 }
 
-pub(crate) enum FunctionWrapperPayload {
+pub(crate) enum CppFunctionBody {
     FunctionCall(Namespace, Ident),
     StaticMethodCall(Namespace, Ident, Ident),
     Constructor,
 }
 
-pub(crate) struct FunctionWrapper {
-    pub(crate) payload: FunctionWrapperPayload,
+pub(crate) struct CppFunction {
+    pub(crate) payload: CppFunctionBody,
     pub(crate) wrapper_function_name: Ident,
     pub(crate) return_conversion: Option<TypeConversionPolicy>,
     pub(crate) argument_conversion: Vec<TypeConversionPolicy>,

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -1,0 +1,182 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+
+use syn::parse_quote;
+
+use crate::conversion::analysis::fun::ReceiverMutability;
+use crate::conversion::analysis::pod::PodAnalysis;
+use crate::conversion::api::{RustSubclassFnDetails, SubclassName};
+use crate::{
+    conversion::{
+        analysis::fun::{
+            function_wrapper::{
+                CppFunction, CppFunctionBody, CppFunctionKind, TypeConversionPolicy,
+            },
+            ArgumentAnalysis,
+        },
+        api::{Api, ApiName},
+    },
+    types::{make_ident, Namespace, QualifiedName},
+};
+
+use super::{FnAnalysis, FnKind, MethodKind};
+
+pub(super) fn subclasses_by_superclass(
+    apis: &[Api<PodAnalysis>],
+) -> HashMap<QualifiedName, Vec<SubclassName>> {
+    let mut subclasses_per_superclass: HashMap<QualifiedName, Vec<SubclassName>> = HashMap::new();
+
+    for api in apis.iter() {
+        if let Api::Subclass { name, superclass } = api {
+            subclasses_per_superclass
+                .entry(superclass.clone())
+                .or_default()
+                .push(name.clone());
+        }
+    }
+    subclasses_per_superclass
+}
+
+pub(super) fn create_subclass_function(
+    sub: &SubclassName,
+    analysis: &super::FnAnalysisBody,
+    name: &ApiName,
+    receiver_mutability: &ReceiverMutability,
+    superclass: &QualifiedName,
+) -> Api<FnAnalysis> {
+    let cpp = sub.cpp();
+    let holder_name = sub.holder();
+    let rust_call_name = make_ident(format!(
+        "{}_{}",
+        sub.0.name.get_final_item(),
+        name.name.get_final_item()
+    ));
+    let params = std::iter::once(parse_quote! {
+        me: & #holder_name
+    })
+    .chain(analysis.params.iter().skip(1).cloned())
+    .collect();
+    let kind = if matches!(receiver_mutability, ReceiverMutability::Mutable) {
+        CppFunctionKind::Method
+    } else {
+        CppFunctionKind::ConstMethod
+    };
+    let super_fn_api_name = QualifiedName::new(
+        &Namespace::new(),
+        SubclassName::get_super_fn_name(&analysis.rust_name.to_string()),
+    );
+    let subclass_function: Api<FnAnalysis> = Api::RustSubclassFn {
+        name: ApiName::new_in_root_namespace(rust_call_name.clone()),
+        subclass: sub.clone(),
+        details: Box::new(RustSubclassFnDetails {
+            params,
+            ret: analysis.ret_type.clone(),
+            method_name: make_ident(&analysis.rust_name),
+            cpp_impl: CppFunction {
+                payload: CppFunctionBody::FunctionCall(Namespace::new(), rust_call_name),
+                wrapper_function_name: name.name.get_final_ident(),
+                return_conversion: analysis.ret_conversion.clone(),
+                argument_conversion: analysis
+                    .param_details
+                    .iter()
+                    .skip(1)
+                    .map(|p| p.conversion.clone())
+                    .collect(),
+                kind,
+                pass_obs_field: true,
+                qualification: Some(cpp),
+            },
+            superclass: superclass.clone(),
+            receiver_mutability: receiver_mutability.clone(),
+            super_fn_api_name,
+        }),
+    };
+    subclass_function
+}
+
+pub(super) fn add_subclass_constructor(
+    sub: &SubclassName,
+    new_apis: &mut Vec<Api<FnAnalysis>>,
+    analysis: &super::FnAnalysisBody,
+    fun: &crate::conversion::api::FuncToConvert,
+) {
+    let holder_name = sub.holder();
+    let cpp = sub.cpp();
+    let cpp_impl = CppFunction {
+        payload: CppFunctionBody::AssignSubclassHolderField,
+        wrapper_function_name: cpp.clone(),
+        return_conversion: None,
+        argument_conversion: vec![TypeConversionPolicy::new_unconverted(parse_quote! {
+            rust::Box< #holder_name >
+        })],
+        kind: CppFunctionKind::Constructor,
+        pass_obs_field: false,
+        qualification: Some(cpp.clone()),
+    };
+    new_apis.push(Api::RustSubclassConstructor {
+        name: ApiName::new_in_root_namespace(cpp.clone()),
+        subclass: sub.clone(),
+        cpp_impl: Box::new(cpp_impl),
+    });
+    let wrapper_name = make_ident(format!("{}_make_unique", cpp));
+    let mut constructor_wrapper = analysis.clone();
+    let id = sub.0.name.get_final_ident();
+    constructor_wrapper.param_details.insert(
+        0,
+        ArgumentAnalysis {
+            conversion: TypeConversionPolicy::box_up_subclass_holder(
+                parse_quote! {
+                    autocxx::subclass::CppSubclassRustPeerHolder<super::super::super:: #id>
+                },
+                holder_name.clone(),
+            ),
+            name: parse_quote! {rs_peer},
+            self_type: None,
+            was_reference: false,
+            deps: HashSet::new(),
+            is_virtual: false,
+            requires_unsafe: false,
+        },
+    );
+    constructor_wrapper
+        .params
+        .insert(0, parse_quote! { rs_peer: Box<#holder_name> });
+    constructor_wrapper.cxxbridge_name = wrapper_name.clone();
+    constructor_wrapper.ret_type = parse_quote! { -> cxx::UniquePtr < #cpp > };
+    constructor_wrapper.kind = FnKind::Method(
+        QualifiedName::new(&Namespace::new(), cpp.clone()),
+        MethodKind::Static,
+    );
+    constructor_wrapper.cpp_wrapper = Some(CppFunction {
+        payload: CppFunctionBody::Constructor,
+        wrapper_function_name: wrapper_name.clone(),
+        return_conversion: Some(TypeConversionPolicy::new_to_unique_ptr(
+            parse_quote! { #cpp },
+        )),
+        argument_conversion: vec![TypeConversionPolicy::new_unconverted(parse_quote! {
+            rust::Box< #holder_name >
+        })],
+        kind: CppFunctionKind::Function,
+        pass_obs_field: false,
+        qualification: None,
+    });
+    new_apis.push(Api::Function {
+        name: ApiName::new_in_root_namespace(wrapper_name),
+        name_for_gc: Some(sub.0.name.clone()),
+        analysis: constructor_wrapper,
+        fun: Box::new(fun.clone()),
+    })
+}

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -108,9 +108,9 @@ pub(crate) fn analyze_pod_apis(
 fn analyze_enum(
     name: ApiName,
     mut item: ItemEnum,
-) -> Result<Option<Api<PodAnalysis>>, ConvertErrorWithContext> {
+) -> Result<Box<dyn Iterator<Item = Api<PodAnalysis>>>, ConvertErrorWithContext> {
     super::remove_bindgen_attrs(&mut item.attrs, name.name.get_final_ident())?;
-    Ok(Some(Api::Enum { name, item }))
+    Ok(Box::new(std::iter::once(Api::Enum { name, item })))
 }
 
 fn analyze_struct(
@@ -119,7 +119,7 @@ fn analyze_struct(
     extra_apis: &mut Vec<UnanalyzedApi>,
     name: ApiName,
     mut item: ItemStruct,
-) -> Result<Option<Api<PodAnalysis>>, ConvertErrorWithContext> {
+) -> Result<Box<dyn Iterator<Item = Api<PodAnalysis>>>, ConvertErrorWithContext> {
     let id = name.name.get_final_ident();
     super::remove_bindgen_attrs(&mut item.attrs, id.clone())?;
     let bases = get_bases(&item);
@@ -141,7 +141,7 @@ fn analyze_struct(
         // ... and say we don't depend on other types.
         TypeKind::NonPod
     };
-    Ok(Some(Api::Struct {
+    Ok(Box::new(std::iter::once(Api::Struct {
         name,
         item,
         analysis: PodStructAnalysisBody {
@@ -149,7 +149,7 @@ fn analyze_struct(
             bases,
             field_deps,
         },
-    }))
+    })))
 }
 
 fn get_struct_field_types(

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -60,7 +60,7 @@ pub(crate) fn convert_typedef_targets(
         Api::struct_unchanged,
         Api::enum_unchanged,
         |name, item, old_tyname, _| {
-            Ok(Some(match item {
+            Ok(Box::new(std::iter::once(match item {
                 TypedefKind::Type(ity) => get_replacement_typedef(
                     name,
                     ity,
@@ -77,7 +77,7 @@ pub(crate) fn convert_typedef_targets(
                         deps: HashSet::new(),
                     },
                 },
-            }))
+            })))
         },
     );
     results.extend(extra_apis.into_iter().map(add_analysis));

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -467,11 +467,14 @@ impl<'a> TypeConverter<'a> {
                 | Api::Typedef { .. }
                 | Api::Enum { .. }
                 | Api::Struct { .. }
+                | Api::Subclass { .. }
                 | Api::RustType { .. } => Some(api.name()),
                 Api::StringConstructor { .. }
                 | Api::Function { .. }
                 | Api::Const { .. }
                 | Api::CType { .. }
+                | Api::RustSubclassFn { .. }
+                | Api::RustSubclassConstructor { .. }
                 | Api::IgnoredItem { .. } => None,
             })
             .cloned()

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -272,15 +272,14 @@ impl<'a> CppCodeGenerator<'a> {
                 ret.cpp_conversion(&underlying_function_call, &self.original_name_map)?
             );
         };
-        let definition = Some(format!(
+        let declaration = Some(format!(
             "{} {{ {}; }}",
             declaration, underlying_function_call,
         ));
-        let declaration = Some(format!("{};", declaration));
         self.additional_functions.push(AdditionalFunction {
             type_definition: None,
             declaration,
-            definition,
+            definition: None,
             headers: vec![Header::system("memory")],
         });
         Ok(())

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -23,7 +23,7 @@ use type_to_cpp::{original_name_map_from_apis, type_to_cpp, CppNameMap};
 
 use super::{
     analysis::fun::{
-        function_wrapper::{FunctionWrapper, FunctionWrapperPayload},
+        function_wrapper::{CppFunction, CppFunctionBody},
         FnAnalysis,
     },
     api::Api,
@@ -189,7 +189,7 @@ impl<'a> CppCodeGenerator<'a> {
         })
     }
 
-    fn generate_by_value_wrapper(&mut self, details: &FunctionWrapper) -> Result<(), ConvertError> {
+    fn generate_by_value_wrapper(&mut self, details: &CppFunction) -> Result<(), ConvertError> {
         // Even if the original function call is in a namespace,
         // we generate this wrapper in the global namespace.
         // We could easily do this the other way round, and when
@@ -245,8 +245,8 @@ impl<'a> CppCodeGenerator<'a> {
         let receiver = if is_a_method { arg_list.next() } else { None };
         let arg_list = arg_list.join(", ");
         let mut underlying_function_call = match &details.payload {
-            FunctionWrapperPayload::Constructor => arg_list,
-            FunctionWrapperPayload::FunctionCall(ns, id) => match receiver {
+            CppFunctionBody::Constructor => arg_list,
+            CppFunctionBody::FunctionCall(ns, id) => match receiver {
                 Some(receiver) => format!("{}.{}({})", receiver, id.to_string(), arg_list),
                 None => {
                     let underlying_function_call = ns
@@ -257,7 +257,7 @@ impl<'a> CppCodeGenerator<'a> {
                     format!("{}({})", underlying_function_call, arg_list)
                 }
             },
-            FunctionWrapperPayload::StaticMethodCall(ns, ty_id, fn_id) => {
+            CppFunctionBody::StaticMethodCall(ns, ty_id, fn_id) => {
                 let underlying_function_call = ns
                     .into_iter()
                     .cloned()

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -118,7 +118,7 @@ impl<'a> CppCodeGenerator<'a> {
                             ..
                         },
                     ..
-                } => self.generate_by_value_wrapper(cpp_wrapper)?,
+                } => self.generate_cpp_function(cpp_wrapper)?,
                 Api::ConcreteType { rs_definition, .. } => self.generate_typedef(
                     api.name(),
                     type_to_cpp(rs_definition, &self.original_name_map)?,
@@ -189,7 +189,7 @@ impl<'a> CppCodeGenerator<'a> {
         })
     }
 
-    fn generate_by_value_wrapper(&mut self, details: &CppFunction) -> Result<(), ConvertError> {
+    fn generate_cpp_function(&mut self, details: &CppFunction) -> Result<(), ConvertError> {
         // Even if the original function call is in a namespace,
         // we generate this wrapper in the global namespace.
         // We could easily do this the other way round, and when

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -176,19 +176,11 @@ impl<'a> CppCodeGenerator<'a> {
 
     fn generate_string_constructor(&mut self) {
         let makestring_name = self.config.get_makestring_name();
-        let declaration = format!(
-            "std::unique_ptr<std::string> {}(::rust::Str str)",
-            makestring_name
-        );
-        let definition = Some(format!(
-            "{} {{ return std::make_unique<std::string>(std::string(str)); }}",
-            declaration
-        ));
-        let declaration = Some(format!("{};", declaration));
+        let declaration = Some(format!("inline std::unique_ptr<std::string> {}(::rust::Str str) {{ return std::make_unique<std::string>(std::string(str)); }}", makestring_name));
         self.additional_functions.push(AdditionalFunction {
             type_definition: None,
             declaration,
-            definition,
+            definition: None,
             headers: vec![
                 Header::system("memory"),
                 Header::system("string"),

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -141,13 +141,13 @@ pub(super) fn gen_function(
         #vis #unsafety fn #cxxbridge_name ( #params ) #ret_type;
     ));
     RsCodegenResult {
-        extern_c_mod_item: Some(extern_c_mod_item),
+        extern_c_mod_items: vec![extern_c_mod_item],
         bridge_items: Vec::new(),
         global_items: Vec::new(),
-        bindgen_mod_item: None,
+        bindgen_mod_items: Vec::new(),
         impl_entry,
         materialization,
-        extern_rust_mod_item: None,
+        extern_rust_mod_items: Vec::new(),
     }
 }
 

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -24,7 +24,9 @@ use syn::parse_quote;
 impl TypeConversionPolicy {
     pub(super) fn rust_wrapper_unconverted_type(&self) -> Type {
         match self.rust_conversion {
-            RustConversionType::None => self.converted_rust_type(),
+            RustConversionType::None | RustConversionType::ToBoxedUpHolder(..) => {
+                self.converted_rust_type()
+            }
             RustConversionType::FromStr => parse_quote! { impl ToCppString },
         }
     }
@@ -33,6 +35,9 @@ impl TypeConversionPolicy {
         match self.rust_conversion {
             RustConversionType::None => quote! { #var },
             RustConversionType::FromStr => quote! ( #var .into_cpp() ),
+            RustConversionType::ToBoxedUpHolder(ref holder_type) => quote! {
+                Box::new(#holder_type(#var))
+            },
         }
     }
 }

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -49,7 +49,7 @@ where
 /// Run some code which generates an API. Add that API, or if
 /// anything goes wrong, instead add a note of the problem in our
 /// output API such that users will see documentation for the problem.
-pub(crate) fn convert_apis<FF, SF, EF, TF, A, B>(
+pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
     in_apis: Vec<Api<A>>,
     out_apis: &mut Vec<Api<B>>,
     mut func_conversion: FF,
@@ -63,75 +63,130 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B>(
         ApiName,
         Box<FuncToConvert>,
         A::FunAnalysis,
-    ) -> Result<Option<Api<B>>, ConvertErrorWithContext>,
+        Option<QualifiedName>,
+    ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
     SF: FnMut(
         ApiName,
         ItemStruct,
         A::StructAnalysis,
-    ) -> Result<Option<Api<B>>, ConvertErrorWithContext>,
-    EF: FnMut(ApiName, ItemEnum) -> Result<Option<Api<B>>, ConvertErrorWithContext>,
+    ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
+    EF: FnMut(
+        ApiName,
+        ItemEnum,
+    ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
     TF: FnMut(
         ApiName,
         TypedefKind,
         Option<QualifiedName>,
         A::TypedefAnalysis,
-    ) -> Result<Option<Api<B>>, ConvertErrorWithContext>,
+    ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
 {
-    out_apis.extend(in_apis.into_iter().filter_map(|api| {
-        let tn = api.name().clone();
-        let result = match api {
-            // No changes to any of these...
-            Api::ConcreteType {
-                name,
-                rs_definition,
-                cpp_definition,
-            } => Ok(Some(Api::ConcreteType {
-                name,
-                rs_definition,
-                cpp_definition,
-            })),
-            Api::ForwardDeclaration { name } => Ok(Some(Api::ForwardDeclaration { name })),
-            Api::StringConstructor { name } => Ok(Some(Api::StringConstructor { name })),
-            Api::Const { name, const_item } => Ok(Some(Api::Const { name, const_item })),
-            Api::CType { name, typename } => Ok(Some(Api::CType { name, typename })),
-            Api::RustType { name } => Ok(Some(Api::RustType { name })),
-            Api::IgnoredItem { name, err, ctx } => Ok(Some(Api::IgnoredItem { name, err, ctx })),
-            // Apply a mapping to the following
-            Api::Enum { name, item } => enum_conversion(name, item),
-            Api::Typedef {
-                name,
-                item,
-                old_tyname,
-                analysis,
-            } => typedef_conversion(name, item, old_tyname, analysis),
-            Api::Function {
-                name,
-                fun,
-                analysis,
-            } => func_conversion(name, fun, analysis),
-            Api::Struct {
-                name,
-                item,
-                analysis,
-            } => struct_conversion(name, item, analysis),
-        };
-        api_or_error(tn, result)
-    }))
+    out_apis.extend(
+        &mut in_apis
+            .into_iter()
+            .map(|api| {
+                let tn = api.name().clone();
+                let result: Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext> =
+                    match api {
+                        // No changes to any of these...
+                        Api::ConcreteType {
+                            name,
+                            rs_definition,
+                            cpp_definition,
+                        } => Ok(Box::new(std::iter::once(Api::ConcreteType {
+                            name,
+                            rs_definition,
+                            cpp_definition,
+                        }))),
+                        Api::ForwardDeclaration { name } => {
+                            Ok(Box::new(std::iter::once(Api::ForwardDeclaration { name })))
+                        }
+                        Api::StringConstructor { name } => {
+                            Ok(Box::new(std::iter::once(Api::StringConstructor { name })))
+                        }
+                        Api::Const { name, const_item } => {
+                            Ok(Box::new(std::iter::once(Api::Const { name, const_item })))
+                        }
+                        Api::CType { name, typename } => {
+                            Ok(Box::new(std::iter::once(Api::CType { name, typename })))
+                        }
+                        Api::RustType { name } => {
+                            Ok(Box::new(std::iter::once(Api::RustType { name })))
+                        }
+                        Api::RustSubclassFn {
+                            name,
+                            subclass,
+                            details,
+                        } => Ok(Box::new(std::iter::once(Api::RustSubclassFn {
+                            name,
+                            subclass,
+                            details,
+                        }))),
+                        Api::RustSubclassConstructor {
+                            name,
+                            subclass,
+                            cpp_impl,
+                        } => Ok(Box::new(std::iter::once(Api::RustSubclassConstructor {
+                            name,
+                            subclass,
+                            cpp_impl,
+                        }))),
+                        Api::Subclass { name, superclass } => {
+                            Ok(Box::new(std::iter::once(Api::Subclass {
+                                name,
+                                superclass,
+                            })))
+                        }
+                        Api::IgnoredItem { name, err, ctx } => {
+                            Ok(Box::new(std::iter::once(Api::IgnoredItem {
+                                name,
+                                err,
+                                ctx,
+                            })))
+                        }
+                        // Apply a mapping to the following
+                        Api::Enum { name, item } => enum_conversion(name, item),
+                        Api::Typedef {
+                            name,
+                            item,
+                            old_tyname,
+                            analysis,
+                        } => typedef_conversion(name, item, old_tyname, analysis),
+                        Api::Function {
+                            name,
+                            fun,
+                            analysis,
+                            name_for_gc,
+                        } => func_conversion(name, fun, analysis, name_for_gc),
+                        Api::Struct {
+                            name,
+                            item,
+                            analysis,
+                        } => struct_conversion(name, item, analysis),
+                    };
+                api_or_error(tn, result)
+            })
+            .flatten(),
+    )
 }
 
-fn api_or_error<T: AnalysisPhase>(
+fn api_or_error<T: AnalysisPhase + 'static>(
     name: QualifiedName,
-    api_or_error: Result<Option<Api<T>>, ConvertErrorWithContext>,
-) -> Option<Api<T>> {
+    api_or_error: Result<Box<dyn Iterator<Item = Api<T>>>, ConvertErrorWithContext>,
+) -> Box<dyn Iterator<Item = Api<T>>> {
     match api_or_error {
         Ok(opt) => opt,
         Err(ConvertErrorWithContext(err, None)) => {
             eprintln!("Ignored {}: {}", name.to_string(), err);
-            None
+            Box::new(std::iter::empty())
         }
         Err(ConvertErrorWithContext(err, Some(ctx))) => {
             eprintln!("Ignored {}: {}", name.to_string(), err);
-            Some(ignored_item(name.get_namespace(), ctx, err))
+            Box::new(std::iter::once(ignored_item(
+                name.get_namespace(),
+                ctx,
+                err,
+            )))
         }
     }
 }
@@ -140,22 +195,27 @@ fn api_or_error<T: AnalysisPhase>(
 /// a method). Add that API, or if
 /// anything goes wrong, instead add a note of the problem in our
 /// output API such that users will see documentation for the problem.
-pub(crate) fn convert_item_apis<F, A, B>(
+pub(crate) fn convert_item_apis<F, A, B: 'static>(
     in_apis: Vec<Api<A>>,
     out_apis: &mut Vec<Api<B>>,
     mut fun: F,
 ) where
-    F: FnMut(Api<A>) -> Result<Option<Api<B>>, ConvertError>,
+    F: FnMut(Api<A>) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertError>,
     A: AnalysisPhase,
     B: AnalysisPhase,
 {
-    out_apis.extend(in_apis.into_iter().filter_map(|api| {
-        let tn = api.name().clone();
-        let result = fun(api).map_err(|e| {
-            ConvertErrorWithContext(e, Some(ErrorContext::Item(tn.get_final_ident())))
-        });
-        api_or_error(tn, result)
-    }))
+    out_apis.extend(
+        in_apis
+            .into_iter()
+            .map(|api| {
+                let tn = api.name().clone();
+                let result = fun(api).map_err(|e| {
+                    ConvertErrorWithContext(e, Some(ErrorContext::Item(tn.get_final_ident())))
+                });
+                api_or_error(tn, result)
+            })
+            .flatten(),
+    )
 }
 
 fn ignored_item<A: AnalysisPhase>(ns: &Namespace, ctx: ErrorContext, err: ConvertError) -> Api<A> {

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -107,7 +107,8 @@ impl<'a> BridgeConverter<'a> {
                 let apis = parser.parse_items(items_to_process)?;
                 Self::dump_apis("parsing", &apis);
                 // Inside parse_results, we now have a list of APIs.
-                // We now enter various analysis phases. First, convert any typedefs.
+                // We now enter various analysis phases.
+                // Next, convert any typedefs.
                 // "Convert" means replacing bindgen-style type targets
                 // (e.g. root::std::unique_ptr) with cxx-style targets (e.g. UniquePtr).
                 let apis = convert_typedef_targets(self.config, apis);

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use crate::{
     conversion::{
-        api::{ApiName, TypedefKind, UnanalyzedApi},
+        api::{Api, ApiName, SubclassName, TypedefKind, UnanalyzedApi},
         ConvertError,
     },
     types::Namespace,
@@ -104,10 +104,20 @@ impl<'a> ParseBindgen<'a> {
         if !self.config.exclude_utilities() {
             generate_utilities(&mut self.apis, self.config);
         }
+        self.add_subclasses();
         let root_ns = Namespace::new();
         self.parse_mod_items(items, root_ns);
         self.confirm_all_generate_directives_obeyed()?;
         Ok(self.apis)
+    }
+
+    fn add_subclasses(&mut self) {
+        self.apis
+            .extend(self.config.subclasses.iter().map(|sc| Api::Subclass {
+                // TODO support namespaces
+                name: SubclassName::new(sc.subclass.clone()),
+                superclass: QualifiedName::new_from_cpp_name(&sc.superclass),
+            }));
     }
 
     fn find_items_in_root(items: Vec<Item>) -> Result<Vec<Item>, ConvertError> {

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -133,6 +133,7 @@ impl ParseForeignMod {
                 name: api_name(&self.ns, fun.item.sig.ident.clone(), &fun.item.attrs),
                 fun: Box::new(fun),
                 analysis: (),
+                name_for_gc: None,
             })
         }
     }

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -428,6 +428,7 @@ pub(crate) fn type_lacks_copy_constructor(ty: &Type) -> bool {
         Type::Path(typ) => {
             let tn = QualifiedName::from_type_path(typ);
             tn.to_cpp_name().starts_with("std::unique_ptr")
+                || tn.to_cpp_name().starts_with("rust::Box")
         }
         _ => false,
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -82,8 +82,8 @@ pub use cxx;
 pub struct CppFilePair {
     /// Declarations to go into a header file.
     pub header: Vec<u8>,
-    /// Implementations to go into a .cpp file, if any.
-    pub implementation: Option<Vec<u8>>,
+    /// Implementations to go into a .cpp file.
+    pub implementation: Vec<u8>,
     /// The name which should be used for the header file
     /// (important as it may be `#include`d elsewhere)
     pub header_name: String,
@@ -481,7 +481,7 @@ pub fn do_cxx_cpp_generation(rs: TokenStream2) -> Result<CppFilePair, cxx_gen::E
     Ok(CppFilePair {
         header: cxx_generated.header,
         header_name: "cxxgen.h".into(),
-        implementation: Some(cxx_generated.implementation),
+        implementation: cxx_generated.implementation,
     })
 }
 

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -190,12 +190,10 @@ fn main() {
                 .generate_h_and_cxx()
                 .expect("Unable to generate header and C++ code");
             for pair in generations.0 {
+                let cppname = format!("gen{}.{}", counter, cpp);
+                write_to_file(&outdir, cppname, &pair.implementation);
                 write_to_file(&outdir, pair.header_name, &pair.header);
-                if let Some(implementation) = &pair.implementation {
-                    let cppname = format!("gen{}.{}", counter, cpp);
-                    write_to_file(&outdir, cppname, implementation);
-                    counter += 1;
-                }
+                counter += 1;
             }
         }
         write_placeholders(&outdir, counter, desired_number, cpp);

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -29,6 +29,8 @@ proc-macro = true
 [dependencies]
 autocxx-parser = { path="../parser", version="0.11.1" }
 proc-macro-error = "1.0"
+proc-macro2 = "1.0.11"
+quote = "1.0"
 
 [dependencies.syn]
 version = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 // do anything - all the magic is handled entirely by
 // autocxx_macro::include_cpp_impl.
 
+pub mod subclass;
+
 #[allow(unused_imports)] // doc cross-reference only
 use autocxx_engine::IncludeCppEngine;
 
@@ -612,6 +614,15 @@ macro_rules! exclude_impls {
 /// `cxx` bindings.
 #[macro_export]
 macro_rules! rust_type {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
+/// Declare a Rust subclass of a C++ class.
+/// A directive to be included inside
+/// [include_cpp] - see [include_cpp] for general information.
+/// Use this in conjunction with [`subclass::is_subclass`].
+#[macro_export]
+macro_rules! subclass {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -1,0 +1,258 @@
+//! Module to make Rust subclasses of C++ classes. See [`CppSubclass`]
+//! for details.
+
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    cell::RefCell,
+    pin::Pin,
+    rc::{Rc, Weak},
+};
+
+use cxx::{memory::UniquePtrTarget, UniquePtr};
+
+pub use autocxx_macro::is_subclass;
+
+#[doc(hidden)]
+pub trait CppSubclassCppPeer: UniquePtrTarget {
+    fn relinquish_ownership(&self);
+}
+
+#[doc(hidden)]
+pub enum CppSubclassRustPeerHolder<T> {
+    Owned(Rc<RefCell<T>>),
+    Unowned(Weak<RefCell<T>>),
+}
+
+impl<T> CppSubclassRustPeerHolder<T> {
+    pub fn get(&self) -> Option<Rc<RefCell<T>>> {
+        match self {
+            CppSubclassRustPeerHolder::Owned(strong) => Some(strong.clone()),
+            CppSubclassRustPeerHolder::Unowned(weak) => weak.upgrade(),
+        }
+    }
+    pub fn relinquish_ownership(self) -> Self {
+        match self {
+            CppSubclassRustPeerHolder::Owned(strong) => {
+                CppSubclassRustPeerHolder::Unowned(Rc::downgrade(&strong))
+            }
+            _ => self,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub enum CppSubclassCppPeerHolder<CppPeer: CppSubclassCppPeer> {
+    Empty,
+    Owned(Box<UniquePtr<CppPeer>>),
+    Unowned(*mut CppPeer),
+}
+
+impl<CppPeer: CppSubclassCppPeer> Default for CppSubclassCppPeerHolder<CppPeer> {
+    fn default() -> Self {
+        CppSubclassCppPeerHolder::Empty
+    }
+}
+
+impl<CppPeer: CppSubclassCppPeer> CppSubclassCppPeerHolder<CppPeer> {
+    fn pin_mut(&mut self) -> Pin<&mut CppPeer> {
+        match self {
+            CppSubclassCppPeerHolder::Empty => panic!("Peer not set up"),
+            CppSubclassCppPeerHolder::Owned(peer) => peer.pin_mut(),
+            CppSubclassCppPeerHolder::Unowned(peer) => unsafe {
+                Pin::new_unchecked(peer.as_mut().unwrap())
+            },
+        }
+    }
+    fn get(&self) -> &CppPeer {
+        match self {
+            CppSubclassCppPeerHolder::Empty => panic!("Peer not set up"),
+            CppSubclassCppPeerHolder::Owned(peer) => peer.as_ref(),
+            CppSubclassCppPeerHolder::Unowned(peer) => unsafe { peer.as_ref().unwrap() },
+        }
+    }
+    fn set_owned(&mut self, peer: UniquePtr<CppPeer>) {
+        *self = Self::Owned(Box::new(peer));
+    }
+    fn set_unowned(&mut self, peer: &mut UniquePtr<CppPeer>) {
+        *self = Self::Unowned(unsafe {
+            std::pin::Pin::<&mut CppPeer>::into_inner_unchecked(peer.pin_mut())
+        });
+    }
+}
+
+fn make_owning_peer<CppPeer, PeerConstructor, Subclass, PeerBoxer>(
+    me: Subclass,
+    peer_constructor: PeerConstructor,
+    peer_boxer: PeerBoxer,
+) -> Rc<RefCell<Subclass>>
+where
+    CppPeer: CppSubclassCppPeer,
+    Subclass: CppSubclass<CppPeer>,
+    PeerConstructor: FnOnce(CppSubclassRustPeerHolder<Subclass>) -> UniquePtr<CppPeer>,
+    PeerBoxer: FnOnce(Rc<RefCell<Subclass>>) -> CppSubclassRustPeerHolder<Subclass>,
+{
+    let me = Rc::new(RefCell::new(me));
+    let holder = peer_boxer(me.clone());
+    let cpp_side = peer_constructor(holder);
+    me.as_ref()
+        .borrow_mut()
+        .peer_holder_mut()
+        .set_owned(cpp_side);
+    me
+}
+
+/// A subclass of a C++ type.
+///
+/// To create a Rust subclass of a C++ class, you must do three things:
+/// * Use the `subclass` directive in your [`crate::include_cpp`] macro
+/// * Create a `struct` to act as your subclass, and add the #[`is_subclass`] attribute.
+/// * Use the [`CppSubclass`] trait, and instantiate the subclass using
+///   [`CppSubclass::new_rust_owned`] or [`CppSubclass::new_cpp_owned`]
+///   constructors. (You can use [`CppSubclassSelfOwned`] if you need that
+///   instead.)
+///
+/// # How to access your Rust structure from outside
+///
+/// Use [`CppSubclass::new_rust_owned`] then use [`std::cell::RefCell::borrow`]
+/// or [`std::cell::RefCell::borrow_mut`] to obtain the underlying Rust struct.
+///
+/// # How to call C++ methods on the subclass
+///
+/// Do the same. You should find that your subclass struct `impl`s all the
+/// C++ methods belonging to the superclass.
+///
+/// # How to implement virtual methods
+///
+/// Simply add an `impl` for the `struct`, implementing the relevant method.
+/// The C++ virtual function call will be redirected to your Rust implementation.
+///
+/// # How _not_ to implement virtual methods
+///
+/// If you don't want to implement a virtual method, don't: the superclass
+/// method will be called instead. Naturally, you must implement any virtual
+/// methods.
+///
+/// # How it works
+///
+/// This actually consists of two objects: this object itself and a C++-side
+/// peer. The ownership relationship between those two things can work in three
+/// different ways:
+/// 1. Neither object is owned by Rust. The C++ peer is owned by a C++
+///    [`UniquePtr`] held elsewhere in C++. That C++ peer then owns
+///    this Rust-side object via a strong [`Rc`] reference. This is the
+///    ownership relationship set up by [`CppSubclass::new_cpp_owned`].
+/// 2. The object pair is owned by Rust. Specifically, by a strong
+///    [`Rc`] reference to this Rust-side object. In turn, the Rust-side object
+///    owns the C++-side peer via a [`UniquePtr`]. This is what's set up by
+///    [`CppSubclass::new_rust_owned`]. The C++-side peer _does not_ own the Rust
+///    object; it just has a weak pointer. (Otherwise we'd get a reference)
+///    loop and nothing would ever be freed.
+/// 3. The object pair is self-owned and will stay around forever until
+///    [`CppSubclassSelfOwned::delete_self`] is called. In this case there's a strong reference
+///    from the C++ to the Rust and from the Rust to the C++. This is useful
+///    for cases where the subclass is listening for events, and needs to
+///    stick around until a particular event occurs then delete itself.
+pub trait CppSubclass<CppPeer: CppSubclassCppPeer> {
+    /// Return the field which holds the C++ peer object. This is normally
+    /// implemented by the #[`is_subclass`] macro, but you're welcome to
+    /// implement it yourself if you prefer.
+    fn peer_holder(&self) -> &CppSubclassCppPeerHolder<CppPeer>;
+
+    /// Return the field which holds the C++ peer object. This is normally
+    /// implemented by the #[`is_subclass`] macro, but you're welcome to
+    /// implement it yourself if you prefer.
+    fn peer_holder_mut(&mut self) -> &mut CppSubclassCppPeerHolder<CppPeer>;
+
+    /// Return a reference to the C++ part of this object pair.
+    /// This can be used to register listeners, etc.
+    fn peer(&self) -> &CppPeer {
+        self.peer_holder().get()
+    }
+
+    /// Return a mutable reference to the C++ part of this object pair.
+    /// This can be used to register listeners, etc.
+    fn peer_mut(&mut self) -> Pin<&mut CppPeer> {
+        self.peer_holder_mut().pin_mut()
+    }
+
+    /// Creates a new instance of this subclass. This instance is owned by the
+    /// returned [`cxx::UniquePtr`] and is thus suitable to be passed around
+    /// in C++.
+    fn new_cpp_owned<PeerConstructor, Subclass>(
+        me: Subclass,
+        peer_constructor: PeerConstructor,
+    ) -> UniquePtr<CppPeer>
+    where
+        Subclass: CppSubclass<CppPeer>,
+        PeerConstructor: FnOnce(CppSubclassRustPeerHolder<Subclass>) -> UniquePtr<CppPeer>,
+    {
+        let me = Rc::new(RefCell::new(me));
+        let holder = CppSubclassRustPeerHolder::Owned(me.clone());
+        let mut cpp_side = peer_constructor(holder);
+        me.as_ref()
+            .borrow_mut()
+            .peer_holder_mut()
+            .set_unowned(&mut cpp_side);
+        cpp_side
+    }
+
+    /// Creates a new instance of this subclass. This instance is not owned
+    /// by C++, and therefore will be deleted when it goes out of scope in
+    /// Rust.
+    fn new_rust_owned<PeerConstructor, Subclass>(
+        me: Subclass,
+        peer_constructor: PeerConstructor,
+    ) -> Rc<RefCell<Subclass>>
+    where
+        Subclass: CppSubclass<CppPeer>,
+        PeerConstructor: FnOnce(CppSubclassRustPeerHolder<Subclass>) -> UniquePtr<CppPeer>,
+    {
+        make_owning_peer(me, peer_constructor, |me| {
+            CppSubclassRustPeerHolder::Unowned(Rc::downgrade(&me))
+        })
+    }
+}
+
+/// Trait to be implemented by subclasses which are self-owned, i.e. not owned
+/// externally by either Rust or C++ code, and thus need the ability to delete
+/// themselves when some virtual function is called.
+pub trait CppSubclassSelfOwned<CppPeer: CppSubclassCppPeer>: CppSubclass<CppPeer> {
+    /// Creates a new instance of this subclass which owns itself.
+    /// This is useful
+    /// for observers (etc.) which self-register to listen to events.
+    /// If an event occurs which would cause this to want to unregister,
+    /// use [`CppSubclassSelfOwned::delete_self`].
+    /// The return value may be useful to register this, etc. but can ultimately
+    /// be discarded without destroying this object.
+    fn new_self_owned<PeerConstructor, Subclass>(
+        me: Subclass,
+        peer_constructor: PeerConstructor,
+    ) -> Rc<RefCell<Subclass>>
+    where
+        CppPeer: CppSubclassCppPeer,
+        Subclass: CppSubclass<CppPeer>,
+        PeerConstructor: FnOnce(CppSubclassRustPeerHolder<Subclass>) -> UniquePtr<CppPeer>,
+    {
+        make_owning_peer(me, peer_constructor, CppSubclassRustPeerHolder::Owned)
+    }
+
+    /// Relinquishes ownership from the C++ side. If there are no outstanding
+    /// references from the Rust side, this will result in the destruction
+    /// of this subclass instance.
+    fn delete_self(&self) {
+        self.peer().relinquish_ownership()
+    }
+}


### PR DESCRIPTION
This is WIP towards #200, a major feature.

At the moment this is a bundle of hacks. It won't work for anything remotely complicated (e.g. functions with unreasonable requirements, like returning a value!)