### PR TITLE
Reduce rust-analyzer confusion

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -37,8 +37,8 @@ use autocxx_parser::{IncludeCppConfig, UnsafePolicy};
 use function_wrapper::{FunctionWrapper, FunctionWrapperPayload, TypeConversionPolicy};
 use proc_macro2::Span;
 use syn::{
-    parse_quote, punctuated::Punctuated, FnArg, ForeignItemFn, Ident, LitStr, Pat, ReturnType,
-    Type, TypePtr, Visibility,
+    parse_quote, punctuated::Punctuated, token::Comma, FnArg, ForeignItemFn, Ident, LitStr, Pat,
+    ReturnType, Type, TypePtr, Visibility,
 };
 
 use crate::{
@@ -88,7 +88,7 @@ pub(crate) struct FnAnalysisBody {
     pub(crate) cxxbridge_name: Ident,
     pub(crate) rust_name: String,
     pub(crate) rust_rename_strategy: RustRenameStrategy,
-    pub(crate) params: Punctuated<FnArg, syn::Token![,]>,
+    pub(crate) params: Punctuated<FnArg, Comma>,
     pub(crate) kind: FnKind,
     pub(crate) ret_type: ReturnType,
     pub(crate) param_details: Vec<ArgumentAnalysis>,
@@ -288,7 +288,7 @@ impl<'a> FnAnalyzer<'a> {
                 )
             })
             .partition(Result::is_ok);
-        let (mut params, mut param_details): (Punctuated<_, syn::Token![,]>, Vec<_>) =
+        let (mut params, mut param_details): (Punctuated<_, Comma>, Vec<_>) =
             param_details.into_iter().map(Result::unwrap).unzip();
 
         let params_deps: HashSet<_> = param_details

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -15,8 +15,11 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse::Parser, parse_quote, punctuated::Punctuated, token::Unsafe, Attribute, FnArg,
-    ForeignItem, Ident, ImplItem, Item, ReturnType,
+    parse::Parser,
+    parse_quote,
+    punctuated::Punctuated,
+    token::{Comma, Unsafe},
+    Attribute, FnArg, ForeignItem, Ident, ImplItem, Item, ReturnType,
 };
 
 use super::{
@@ -151,8 +154,8 @@ pub(super) fn gen_function(
 fn generate_arg_lists(
     param_details: &[ArgumentAnalysis],
     is_constructor: bool,
-) -> (Punctuated<FnArg, syn::Token![,]>, Vec<TokenStream>) {
-    let mut wrapper_params: Punctuated<FnArg, syn::Token![,]> = Punctuated::new();
+) -> (Punctuated<FnArg, Comma>, Vec<TokenStream>) {
+    let mut wrapper_params: Punctuated<FnArg, Comma> = Punctuated::new();
     let mut arg_list = Vec::new();
 
     for pd in param_details {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -126,7 +126,7 @@ impl Parse for IncludeCppConfig {
         let mut mod_name = None;
 
         while !input.is_empty() {
-            let has_hexathorpe = input.parse::<Option<syn::Token![#]>>()?.is_some();
+            let has_hexathorpe = input.parse::<Option<syn::token::Pound>>()?.is_some();
             let ident: syn::Ident = input.parse()?;
             if has_hexathorpe {
                 if ident != "include" {
@@ -135,7 +135,7 @@ impl Parse for IncludeCppConfig {
                 let hdr: syn::LitStr = input.parse()?;
                 inclusions.push(hdr.value());
             } else {
-                input.parse::<Option<syn::Token![!]>>()?;
+                input.parse::<Option<syn::token::Bang>>()?;
                 if ident == "generate" {
                     let args;
                     syn::parenthesized!(args in input);


### PR DESCRIPTION
rust-analyzer doesn't currently seem to like
`syn::Token!` macro invocations. This replaces some where
we can, which increases the usability of the autocxx codegen
in IDEs that use rust-analyzer.
