### PR TITLE
Improve documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fn main() {
 }
 ```
 
-See [demo/src/main.rs](demo/src/main.rs) for a basic example, and the [examples](examples/) directory for more.
+How to start: read the documentation for `include_cpp`. See [demo/src/main.rs](demo/src/main.rs) for a basic example, and the [examples](examples/) directory for more.
 
 The existing cxx facilities are used to allow safe ownership of C++ types from Rust; specifically things like `std::unique_ptr` and `std::string` - so the Rust code should not typically require use of unsafe code, unlike with normal `bindgen` bindings.
 
@@ -78,11 +78,11 @@ The project also contains test code which does this end-to-end, for all sorts of
 | std::vector | Works |
 | Field access to opaque objects via UniquePtr | - |
 | Plain-old-data structs containing opaque fields | Impossible by design, but may not be ergonomic so may need more thought |
-| Reference counting, std::shared_ptr | - |
+| Reference counting, std::shared_ptr | Works, but mutable references not allowed |
 | std::optional | - |
 | Function pointers | - |
 | Unique ptrs to primitives | - |
-| Inheritance from pure virtual classes | - |
+| Inheritance from pure virtual classes | Works, subject to various limitations |
 | Generic (templated) types | Works but no field access or methods |
 | Arrays | - |
 
@@ -128,8 +128,8 @@ any included header file changes. This is now handled automatically by our
 See [here](https://docs.rs/autocxx/latest/autocxx/macro.include_cpp.html#configuring-the-build) for a diagram.
 
 Finally, this interop inevitably involves lots of fiddly small functions. It's likely to perform
-far better if you can achieve cross-language LTO. https://github.com/dtolnay/cxx/issues/371
-may give some useful hints - see also all the build-related help in https://cxx.rs/ which all
+far better if you can achieve cross-language LTO. [This issue](https://github.com/dtolnay/cxx/issues/371)
+may give some useful hints - see also all the build-related help in [the cxx manual](https://cxx.rs/) which all
 applies here too.
 
 # Directory structure

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The intention is that it has all the fluent safety from [cxx](https://github.com
 
 # Overview
 
-```rust
+```rust,ignore
 autocxx::include_cpp! {
     #include "url/origin.h"
     generate!("url::Origin")
@@ -168,7 +168,7 @@ in the way of useful diagnostics, because `stdout` is swallowed by cargo build s
 So, practically speaking, you would almost always move onto running one of the tests
 in the test suite. With suitable options, you can get plenty of output. For instance:
 
-```
+```ignore
 RUST_BACKTRACE=1 RUST_LOG=autocxx_engine=info cargo test  integration_tests::test_cycle_string_full_pipeline -- --nocapture
 ```
 

--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -124,6 +124,12 @@ impl<CTX: BuilderContext> Builder<CTX> {
 
     /// Automatically discover uses of the C++ `ffi` mod and generate the allowlist
     /// from that.
+    /// This is a highly experimental option, not currently recommended.
+    /// It doesn't work in cases where you're using a different name for your
+    /// `ffi` mod, or if you've got uses scattered across multiple files, or
+    /// if you're using `use` statements to rename mods or items. If this
+    /// proves to be a promising or helpful direction, autocxx would be happy
+    /// to accept pull requests to remove some of these limitations.
     pub fn auto_allowlist(mut self, do_it: bool) -> Self {
         self.auto_allowlist = do_it;
         self
@@ -250,7 +256,7 @@ fn write_rs_to_file(
 }
 
 fn rust_version_check() {
-    if !version_check::is_min_version("1.48.0").unwrap_or(false) {
-        panic!("Rust 1.48 or later is required.")
+    if !version_check::is_min_version("1.54.0").unwrap_or(false) {
+        panic!("Rust 1.54 or later is required.")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-//! Crate to `#include` C++ headers in your Rust code, and generate
-//! idiomatic bindings using `cxx`. See [include_cpp] for details.
+#![doc = include_str!("../README.md")]
 
 // Copyright 2020 Google LLC
 //
@@ -73,7 +72,7 @@ use autocxx_engine::IncludeCppEngine;
 /// * This manual will describe how to include `autocxx` in your build process.
 /// * `autocxx` chooses to generate Rust bindings for C++ APIs in particular ways,
 ///   over which you have _some_ control. The manual discusses what and how.
-/// * The combination of `autocxx` and [cxx] are not perfect. There are some STL
+/// * The combination of `autocxx` and [`cxx`] are not perfect. There are some STL
 ///   types and some fundamental C++ features which are not yet supported. Where that occurs,
 ///   you may need to create some manual bindings or otherwise workaround deficiencies.
 ///   This manual tells you how to spot such circumstances and work around them.
@@ -159,7 +158,7 @@ use autocxx_engine::IncludeCppEngine;
 ///
 /// * `#include "cpp_header.h"`: a header filename to parse and include
 /// * `generate!("type_or_function_name")`: a type or function name whose declaration
-///   should be made available to C++.
+///   should be made available to C++. (See the section on Allowlisting, below).
 /// * Optionally, `safety!(unsafe)` - see discussion of [`safety`].
 ///
 /// Other directives are possible as documented in this crate.
@@ -194,6 +193,24 @@ use autocxx_engine::IncludeCppEngine;
 /// * Write manual bindings. This is most useful if a type is supported by [cxx]
 ///   but not `autocxx` (for example, at the time of writing `std::array`). See
 ///   the later section on 'combinining automatic and manual bindings'.
+///
+/// # Allowlisting
+///
+/// How do you inform autocxx which bindings to generate? There are three
+/// strategies:
+///
+/// * *Recommended*: provide various [`generate`] directives in the
+///   [`include_cpp`] macro. This can specify functions or types.
+/// * *Not recommended*: in your `build.rs`, call `Builder::auto_allowlist`.
+///   This will attempt to spot _uses_ of FFI bindings anywhere in your Rust code
+///   and build the allowlist that way. This is experimental and has known limitations.
+/// * *Strongly not recommended*: use [`generate_all`]. This will attempt to
+///   generate Rust bindings for _any_ C++ type or function discovered in the
+///   header files. This is generally a disaster if you're including any
+///   remotely complex header file: we'll try to generate bindings for all sorts
+///   of STL types. This will be slow, and some may well cause problems.
+///   Effectively this is just a debug option to discover such problems. Don't
+///   use it!
 ///
 /// # The generated bindings
 ///

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -160,7 +160,7 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 /// * Use the [`CppSubclass`] trait, and instantiate the subclass using
 ///   [`CppSubclass::new_rust_owned`] or [`CppSubclass::new_cpp_owned`]
 ///   constructors. (You can use [`CppSubclassSelfOwned`] if you need that
-///   instead; also, see [`CppSubclassDefaultSelfOwned`] and [`CppSubclassDefault`]
+///   instead; also, see [`CppSubclassSelfOwnedDefault`] and [`CppSubclassDefault`]
 ///   to arrange for easier constructors to exist.
 /// * You _may_ need to implement [`CppPeerConstructor`] for your subclass,
 ///   but only if autocxx determines that there are multiple possible superclass
@@ -233,7 +233,7 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 /// * *Complex or multiple constructors*. At present, this code doesn't work
 ///   if the superclass has anything other than a single, zero-argument,
 ///   constructor. This is
-///   https://github.com/google/autocxx/issues/596 and is just a matter of doing
+///   [this issue](https://github.com/google/autocxx/issues/596) and is just a matter of doing
 ///   a bit of work to plumb this together. (See [`CppPeerConstructor`] for
 ///   how this will work when it's done.)
 ///
@@ -241,10 +241,10 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 ///
 /// * *Non-trivial class hierarchies*. We don't yet consider virtual methods
 ///   on base classes of base classes. This is a temporary limitation,
-///   https://github.com/google/autocxx/issues/610.
+///   [see this issue](https://github.com/google/autocxx/issues/610).
 ///
 /// * *Namespaces.* Superclasses in namespaces are not yet supported:
-///   https://github.com/google/autocxx/issues/599.
+///   [see this issue](https://github.com/google/autocxx/issues/599).
 pub trait CppSubclass<CppPeer: CppSubclassCppPeer>: CppPeerConstructor<CppPeer> {
     /// Return the field which holds the C++ peer object. This is normally
     /// implemented by the #[`is_subclass`] macro, but you're welcome to


### PR DESCRIPTION
This uses Rust 1.54 facilities to include the README.md in the
main documentation, so this also increases the minimum supported
Rust version to 1.54.

Fixes part of #578.