### PR TITLE
Simplify subclass defaults

### DIFF
--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -50,7 +50,7 @@ pub(super) fn subclasses_by_superclass(
 pub(super) fn create_subclass_fn_wrapper(
     sub: SubclassName,
     super_fn_name: QualifiedName,
-    fun: &Box<FuncToConvert>,
+    fun: &FuncToConvert,
 ) -> (Box<FuncToConvert>, ApiName) {
     let self_ty = Some(sub.cpp());
     let maybe_wrap = Box::new(FuncToConvert {
@@ -129,7 +129,7 @@ pub(super) fn create_subclass_function(
 
 pub(super) fn create_subclass_constructor_wrapper(
     sub: SubclassName,
-    fun: &Box<FuncToConvert>,
+    fun: &FuncToConvert,
 ) -> (Box<FuncToConvert>, ApiName) {
     let subclass_constructor_name = make_ident(format!(
         "{}_{}",

--- a/engine/src/integration_tests.rs
+++ b/engine/src/integration_tests.rs
@@ -6272,7 +6272,7 @@ fn test_pv_subclass_derive_defaults() {
         None,
         Some(quote! {
             #[autocxx::subclass::is_subclass]
-            #[derive(Default,autocxx::subclass::CppSubclassDefault)]
+            #[derive(Default)]
             pub struct MyObserver {
                 a: u32
             }

--- a/examples/subclass/src/main.rs
+++ b/examples/subclass/src/main.rs
@@ -41,7 +41,7 @@ include_cpp! {
 // is instantiated.
 
 #[is_subclass(superclass("MessageDisplayer"))]
-#[derive(CppSubclassDefault, Default)]
+#[derive(Default)]
 pub struct UwuDisplayer {}
 
 impl ffi::MessageDisplayer_methods for UwuDisplayer {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -18,7 +18,7 @@ use proc_macro2::{Ident, Span};
 use proc_macro_error::{abort, proc_macro_error};
 use quote::quote;
 use syn::parse::Parser;
-use syn::{parse_macro_input, parse_quote, Fields, ItemStruct};
+use syn::{parse_macro_input, Fields, ItemStruct};
 
 /// Implementation of the `include_cpp` macro. See documentation for `autocxx` crate.
 #[proc_macro_error]
@@ -71,33 +71,6 @@ pub fn is_subclass(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #self_owned_bit
-    };
-    toks.into()
-}
-
-/// Derive macro which will add constructors which initialize all members
-/// as default.
-#[proc_macro_error]
-#[proc_macro_derive(CppSubclassDefault)]
-pub fn cpp_subclass_default_derive(input: TokenStream) -> TokenStream {
-    derive_default(input, parse_quote! { CppSubclassDefault })
-}
-
-/// Derive macro which will add constructors which initialize all members
-/// as default, for a self-owned subclass.
-#[proc_macro_error]
-#[proc_macro_derive(CppSubclassSelfOwnedDefault)]
-pub fn cpp_subclass_default_derive_self_owned(input: TokenStream) -> TokenStream {
-    derive_default(input, parse_quote! { CppSubclassSelfOwnedDefault })
-}
-
-fn derive_default(input: TokenStream, trt: Ident) -> TokenStream {
-    let s: ItemStruct =
-        syn::parse(input).unwrap_or_else(|_| abort!(Span::call_site(), "Expected a struct"));
-    let id = s.ident;
-    let cpp_ident = Ident::new(&format!("{}Cpp", id.to_string()), Span::call_site());
-    let toks = quote! {
-        impl autocxx::subclass::#trt<ffi::#cpp_ident> for #id {}
     };
     toks.into()
 }

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -24,8 +24,6 @@ use std::{
 use cxx::{memory::UniquePtrTarget, UniquePtr};
 
 pub use autocxx_macro::is_subclass;
-pub use autocxx_macro::CppSubclassDefault;
-pub use autocxx_macro::CppSubclassSelfOwnedDefault;
 
 /// A prelude containing all the traits and macros required to create
 /// Rust subclasses of C++ classes. It's recommended that you:
@@ -313,12 +311,22 @@ pub trait CppSubclassSelfOwned<CppPeer: CppSubclassCppPeer>: CppSubclass<CppPeer
 pub trait CppSubclassDefault<CppPeer: CppSubclassCppPeer>: CppSubclass<CppPeer> + Default {
     /// Create a Rust-owned instance of this subclass, initializing with default values. See
     /// [`CppSubclass`] for more details of the ownership models available.
+    fn default_rust_owned() -> Rc<RefCell<Self>>;
+
+    /// Create a C++-owned instance of this subclass, initializing with default values. See
+    /// [`CppSubclass`] for more details of the ownership models available.
+    fn default_cpp_owned() -> UniquePtr<CppPeer>;
+}
+
+impl<T, CppPeer> CppSubclassDefault<CppPeer> for T
+where
+    T: CppSubclass<CppPeer> + Default,
+    CppPeer: CppSubclassCppPeer,
+{
     fn default_rust_owned() -> Rc<RefCell<Self>> {
         Self::new_rust_owned(Self::default())
     }
 
-    /// Create a C++-owned instance of this subclass, initializing with default values. See
-    /// [`CppSubclass`] for more details of the ownership models available.
     fn default_cpp_owned() -> UniquePtr<CppPeer> {
         Self::new_cpp_owned(Self::default())
     }
@@ -331,6 +339,14 @@ pub trait CppSubclassSelfOwnedDefault<CppPeer: CppSubclassCppPeer>:
 {
     /// Create a self-owned instance of this subclass, initializing with default values. See
     /// [`CppSubclass`] for more details of the ownership models available.
+    fn default_self_owned() -> Rc<RefCell<Self>>;
+}
+
+impl<T, CppPeer> CppSubclassSelfOwnedDefault<CppPeer> for T
+where
+    T: CppSubclassSelfOwned<CppPeer> + Default,
+    CppPeer: CppSubclassCppPeer,
+{
     fn default_self_owned() -> Rc<RefCell<Self>> {
         Self::new_self_owned(Self::default())
     }


### PR DESCRIPTION
Simplify default traits for subclasses. No need for a procedural macro any longer.