### PR TITLE
Bump autocxx-bindgen version.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "0.59.2"
+autocxx-bindgen = "0.59.3"
 itertools = "0.10"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"


### PR DESCRIPTION
This is to absorb a fix which prevents some infinite loops.
