### PR TITLE
Name consistency.

### DIFF
--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -118,7 +118,7 @@ fn parse_file_contents(source: syn::File, auto_allowlist: bool) -> Result<Parsed
                     attr.path
                         .segments
                         .last()
-                        .map(|seg| seg.ident == "is_subclass")
+                        .map(|seg| seg.ident == "is_subclass" || seg.ident == "subclass")
                         .unwrap_or(false)
                 });
                 if let Some(is_superclass_attr) = is_superclass_attr {

--- a/examples/subclass/src/main.rs
+++ b/examples/subclass/src/main.rs
@@ -117,9 +117,6 @@ impl BoxDisplayer {
     }
 }
 
-#[autocxx::extern_rust]
-fn create_box_displayer() {}
-
 impl ffi::MessageDisplayer_methods for BoxDisplayer {
     fn display_message(&self, msg: &CxxString) {
         let msg = textwrap::fill(msg.to_str().unwrap(), 70);

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -33,7 +33,7 @@ pub fn include_cpp_impl(input: TokenStream) -> TokenStream {
 /// track a C++ instantiation of this Rust subclass.
 #[proc_macro_error]
 #[proc_macro_attribute]
-pub fn is_subclass(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn subclass(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut s: ItemStruct =
         syn::parse(item).unwrap_or_else(|_| abort!(Span::call_site(), "Expected a struct"));
     let id = &s.ident;
@@ -75,11 +75,11 @@ pub fn is_subclass(attr: TokenStream, item: TokenStream) -> TokenStream {
     toks.into()
 }
 
-/// Attribute to state that a Rust function or type is to be exported to C++
+/// Attribute to state that a Rust type is to be exported to C++
 /// in the `extern "Rust"` section of the generated `cxx` bindings.
 #[proc_macro_error]
 #[proc_macro_attribute]
-pub fn extern_rust(attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn extern_rust_type(attr: TokenStream, input: TokenStream) -> TokenStream {
     if !attr.is_empty() {
         abort!(Span::call_site(), "Expected no attributes");
     }
@@ -87,7 +87,24 @@ pub fn extern_rust(attr: TokenStream, input: TokenStream) -> TokenStream {
         syn::parse(input.clone()).unwrap_or_else(|_| abort!(Span::call_site(), "Expected an item"));
     match i {
         Item::Struct(..) | Item::Enum(..) | Item::Fn(..) => {}
-        _ => abort!(Span::call_site(), "Expected a function, struct or enum"),
+        _ => abort!(Span::call_site(), "Expected a struct or enum"),
+    }
+    input
+}
+
+/// Attribute to state that a Rust function is to be exported to C++
+/// in the `extern "Rust"` section of the generated `cxx` bindings.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn extern_rust_function(attr: TokenStream, input: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        abort!(Span::call_site(), "Expected no attributes");
+    }
+    let i: Item =
+        syn::parse(input.clone()).unwrap_or_else(|_| abort!(Span::call_site(), "Expected an item"));
+    match i {
+        Item::Fn(..) => {}
+        _ => abort!(Span::call_site(), "Expected a function"),
     }
     input
 }

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -180,7 +180,7 @@ impl Parse for IncludeCppConfig {
                     syn::parenthesized!(args in input);
                     let generate: syn::LitStr = args.parse()?;
                     blocklist.push(generate.value());
-                } else if ident == "rust_type" {
+                } else if ident == "rust_type" || ident == "extern_rust_type" {
                     let args;
                     syn::parenthesized!(args in input);
                     let id: Ident = args.parse()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,24 +638,10 @@ macro_rules! exclude_impls {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
-/// Declare that a given type is a Rust type. These may be used within
-/// references in the signatures of C++ functions, for instance.
-/// This will contribute to an `extern "Rust"` section of the generated
-/// `cxx` bindings.
+/// Deprecated - use [`extern_rust_type`] instead.
 #[macro_export]
+#[deprecated]
 macro_rules! rust_type {
-    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
-}
-
-/// Declare a Rust subclass of a C++ class.
-/// A directive to be included inside
-/// [include_cpp] - see [include_cpp] for general information.
-/// Use this in conjunction with [`subclass::is_subclass`].
-/// See [`subclass::CppSubclass`] for information about the
-/// multiple steps you need to take to be able to make Rust
-/// subclasses of a C++ class.
-#[macro_export]
-macro_rules! subclass {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
@@ -728,4 +714,71 @@ pub struct BindingGenerationFailure {
     _pinned: core::marker::PhantomData<core::marker::PhantomPinned>,
 }
 
-pub use autocxx_macro::extern_rust;
+/// Declare that this is a Rust type which is to be exported to C++.
+/// You can use this in two ways:
+/// * as an attribute macro on a Rust type, for instance:
+///   ```
+///   # use autocxx_macro::extern_rust_type as extern_rust_type;
+///   #[extern_rust_type]
+///   struct Bar;
+///   ```
+/// * as a directive within the [include_cpp] macro, in which case
+///   provide the type path in brackets:
+///   ```
+///   # use autocxx_macro::include_cpp_impl as include_cpp;
+///   include_cpp!(
+///   #   parse_only!()
+///       #include "input.h"
+///       extern_rust_type!(Bar)
+///       safety!(unsafe)
+///   );
+///   struct Bar;
+///   ```
+/// These may be used within references in the signatures of C++ functions,
+/// for instance. This will contribute to an `extern "Rust"` section of the
+/// generated `cxx` bindings, and this type will appear in the C++ header
+/// generated for use in C++.
+pub use autocxx_macro::extern_rust_type;
+
+/// Declare that a given function is a Rust function which is to be exported
+/// to C++. This is used as an attribute macro on a Rust function, for instance:
+/// ```
+/// # use autocxx_macro::extern_rust_function as extern_rust_function;
+/// #[extern_rust_function]
+/// pub fn call_me_from_cpp() { }
+/// ```
+pub use autocxx_macro::extern_rust_function;
+
+/// Declare a Rust subclass of a C++ class.
+/// You can use this in two ways:
+/// * As an attribute macro on a struct which is to be a subclass.
+///   In this case, you must specify the superclass as described below.
+///   For instance,
+///   ```nocompile
+///   # use autocxx_macro::subclass as subclass;
+///   #[subclass(superclass("MyCppSuperclass"))]
+///   struct Bar {};
+///   ```
+/// * as a directive within the [include_cpp] macro, in which case you
+///   must provide two arguments of the superclass and then the
+///   subclass:
+///   ```
+///   # use autocxx_macro::include_cpp_impl as include_cpp;
+///   include_cpp!(
+///   #   parse_only!()
+///       #include "input.h"
+///       subclass!("MyCppSuperclass",Bar)
+///       safety!(unsafe)
+///   );
+///   struct Bar {
+///     // ...
+///   }
+///   ```
+///   In this latter case, you'll need to implement the trait
+///   [`subclass::CppSubclass`] for the struct, so it's
+///   generally easier to use the former option.
+///   
+/// See [`subclass::CppSubclass`] for information about the
+/// multiple steps you need to take to be able to make Rust
+/// subclasses of a C++ class.
+pub use autocxx_macro::subclass;

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -23,7 +23,9 @@ use std::{
 
 use cxx::{memory::UniquePtrTarget, UniquePtr};
 
-pub use autocxx_macro::is_subclass;
+/// Deprecated - use [`macro@self::super::subclass`] instead.
+#[deprecated]
+pub use autocxx_macro::subclass as is_subclass;
 
 /// A prelude containing all the traits and macros required to create
 /// Rust subclasses of C++ classes. It's recommended that you:
@@ -36,6 +38,7 @@ pub mod prelude {
         is_subclass, CppPeerConstructor, CppSubclass, CppSubclassDefault,
         CppSubclassRustPeerHolder, CppSubclassSelfOwned, CppSubclassSelfOwnedDefault,
     };
+    pub use crate::subclass;
 }
 
 #[doc(hidden)]
@@ -150,11 +153,14 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 /// A subclass of a C++ type.
 ///
 /// To create a Rust subclass of a C++ class, you must do these things:
-/// * Use the `subclass` directive in your [`crate::include_cpp`] macro (or use
-///   the auto-allow mode in your `build.rs`)
-/// * Create a `struct` to act as your subclass, and add the #[`is_subclass`] attribute.
+/// * Create a `struct` to act as your subclass, and add the #[`macro@crate::subclass`] attribute.
 ///   This adds a field to your struct for autocxx record-keeping. You can
-///   instead choose to implement [`CppSubclass`] a different way.
+///   instead choose to implement [`CppSubclass`] a different way, in which case
+///   you must provide the [`macro@crate::subclass`] inside your [`crate::include_cpp`]
+///   macro. (`autocxx` will do the required codegen for your subclass
+///   whether it discovers a [`macro@crate::subclass`] directive inside your
+///   [`crate::include_cpp`], or elsewhere used as an attribute macro,
+///   or both.)
 /// * Use the [`CppSubclass`] trait, and instantiate the subclass using
 ///   [`CppSubclass::new_rust_owned`] or [`CppSubclass::new_cpp_owned`]
 ///   constructors. (You can use [`CppSubclassSelfOwned`] if you need that


### PR DESCRIPTION
This attempts to reduce fiddly naming differences between the directives
that go into the include_cpp! macro versus those that can be used elsewhere
in the code and auto-detected.

Fixes #634.
