### PR TITLE
No ast macros

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -129,9 +129,14 @@ impl<CTX: BuilderContext> Builder<CTX> {
     /// Automatically discover uses of the C++ `ffi` mod and generate the allowlist
     /// from that.
     /// This is a highly experimental option, not currently recommended.
-    /// It doesn't work in cases where you're using a different name for your
-    /// `ffi` mod, or if you've got uses scattered across multiple files, or
-    /// if you're using `use` statements to rename mods or items. If this
+    /// It doesn't work in the following cases:
+    /// * Static function calls on types within the FFI mod.
+    /// * Anything inside a macro invocation.
+    /// * You're using a different name for your `ffi` mod
+    /// * You're using multiple FFI mods
+    /// * You've got usages scattered across files beyond that with the
+    ///   `include_cpp` invocation
+    /// * You're using `use` statements to rename mods or items. If this
     /// proves to be a promising or helpful direction, autocxx would be happy
     /// to accept pull requests to remove some of these limitations.
     pub fn auto_allowlist(mut self, do_it: bool) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ use autocxx_engine::IncludeCppEngine;
 ///
 /// * *Recommended*: provide various [`generate`] directives in the
 ///   [`include_cpp`] macro. This can specify functions or types.
-/// * *Not recommended*: in your `build.rs`, call `Builder::auto_allowlist`.
+/// * *Not recommended*: in your `build.rs`, call [`Builder::auto_allowlist`].
 ///   This will attempt to spot _uses_ of FFI bindings anywhere in your Rust code
 ///   and build the allowlist that way. This is experimental and has known limitations.
 /// * *Strongly not recommended*: use [`generate_all`]. This will attempt to

--- a/tools/reduce/src/main.rs
+++ b/tools/reduce/src/main.rs
@@ -1,6 +1,3 @@
-//! Crate to `#include` C++ headers in your Rust code, and generate
-//! idiomatic bindings using `cxx`. See [include_cpp] for details.
-
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes #650 (by documenting the problem; it can't readily be solved because the contents of a function-position macro is just a `TokenStream`).