### PR TITLE
Allow --cxx-impl-annotationx XYZ.

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -91,6 +91,7 @@ pub struct Builder<BuilderContext> {
     custom_gendir: Option<PathBuf>,
     auto_allowlist: bool,
     suppress_system_headers: bool,
+    cxx_impl_annotations: Option<String>,
     // This member is to ensure that this type is parameterized
     // by a BuilderContext. The goal is to balance three needs:
     // (1) have most of the functionality over in autocxx_engine,
@@ -119,6 +120,7 @@ impl<CTX: BuilderContext> Builder<CTX> {
             custom_gendir: None,
             auto_allowlist: false,
             suppress_system_headers: false,
+            cxx_impl_annotations: None,
             ctx: PhantomData,
         }
     }
@@ -160,6 +162,11 @@ impl<CTX: BuilderContext> Builder<CTX> {
     /// that the bindings could ever need.
     pub fn suppress_system_headers(mut self, do_it: bool) -> Self {
         self.suppress_system_headers = do_it;
+        self
+    }
+
+    pub fn cxx_impl_annotations(mut self, cxx_impl_annotations: Option<String>) -> Self {
+        self.cxx_impl_annotations = cxx_impl_annotations;
         self
     }
 
@@ -220,7 +227,10 @@ impl<CTX: BuilderContext> Builder<CTX> {
         builder.includes(parsed_file.include_dirs());
         for include_cpp in parsed_file.get_cpp_buildables() {
             let generated_code = include_cpp
-                .generate_h_and_cxx(self.suppress_system_headers)
+                .generate_h_and_cxx(
+                    self.suppress_system_headers,
+                    self.cxx_impl_annotations.clone(),
+                )
                 .map_err(BuilderError::InvalidCxx)?;
             for filepair in generated_code.0 {
                 let fname = format!("gen{}.cxx", counter);

--- a/engine/src/cxxbridge.rs
+++ b/engine/src/cxxbridge.rs
@@ -43,8 +43,13 @@ impl CppBuildable for CxxBridge {
     fn generate_h_and_cxx(
         &self,
         suppress_system_headers: bool,
+        cxx_impl_annotations: Option<String>,
     ) -> Result<GeneratedCpp, cxx_gen::Error> {
-        let fp = do_cxx_cpp_generation(self.tokens.clone(), suppress_system_headers)?;
+        let fp = do_cxx_cpp_generation(
+            self.tokens.clone(),
+            suppress_system_headers,
+            cxx_impl_annotations,
+        )?;
         Ok(GeneratedCpp(vec![fp]))
     }
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -522,8 +522,10 @@ static ALL_KNOWN_SYSTEM_HEADERS: &[&str] = &[
 pub fn do_cxx_cpp_generation(
     rs: TokenStream2,
     suppress_system_headers: bool,
+    cxx_impl_annotations: Option<String>,
 ) -> Result<CppFilePair, cxx_gen::Error> {
-    let opt = cxx_gen::Opt::default();
+    let mut opt = cxx_gen::Opt::default();
+    opt.cxx_impl_annotations = cxx_impl_annotations;
     let cxx_generated = cxx_gen::generate_header_and_cc(rs, &opt)?;
     Ok(CppFilePair {
         header: strip_system_headers(cxx_generated.header, suppress_system_headers),
@@ -554,6 +556,7 @@ impl CppBuildable for IncludeCppEngine {
     fn generate_h_and_cxx(
         &self,
         suppress_system_headers: bool,
+        cxx_impl_annotations: Option<String>,
     ) -> Result<GeneratedCpp, cxx_gen::Error> {
         let mut files = Vec::new();
         match &self.state {
@@ -561,7 +564,11 @@ impl CppBuildable for IncludeCppEngine {
             State::NotGenerated => panic!("Call generate() first"),
             State::Generated(gen_results) => {
                 let rs = gen_results.item_mod.to_token_stream();
-                files.push(do_cxx_cpp_generation(rs, suppress_system_headers)?);
+                files.push(do_cxx_cpp_generation(
+                    rs,
+                    suppress_system_headers,
+                    cxx_impl_annotations,
+                )?);
                 if let Some(cpp_file_pair) = &gen_results.cpp {
                     files.push(cpp_file_pair.clone());
                 }

--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -215,6 +215,7 @@ pub trait CppBuildable {
     fn generate_h_and_cxx(
         &self,
         suppress_system_headers: bool,
+        cxx_impl_annotations: Option<String>,
     ) -> Result<GeneratedCpp, cxx_gen::Error>;
 }
 

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -162,6 +162,13 @@ fn main() {
                 .help("Do not refer to any system headers from generated code. May be useful for minimization.")
         )
         .arg(
+            Arg::with_name("cxx-impl-annotations")
+                .long("cxx-impl-annotations")
+                .value_name("ANNOTATION")
+                .help("prefix for symbols to be exported from C++ bindings, e.g. __attribute__ ((visibility (\"default\")))")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("clang-args")
                 .last(true)
                 .multiple(true)
@@ -185,6 +192,9 @@ fn main() {
         .unwrap_or_default()
         .collect();
     let suppress_system_headers = matches.is_present("suppress-system-headers");
+    let cxx_impl_annotations = matches
+        .value_of("cxx-impl-annotations")
+        .map(|s| s.to_string());
     // In future, we should provide an option to write a .d file here
     // by passing a callback into the dep_recorder parameter here.
     // https://github.com/google/autocxx/issues/56
@@ -200,7 +210,7 @@ fn main() {
         let mut counter = 0usize;
         for include_cxx in parsed_file.get_cpp_buildables() {
             let generations = include_cxx
-                .generate_h_and_cxx(suppress_system_headers)
+                .generate_h_and_cxx(suppress_system_headers, cxx_impl_annotations.clone())
                 .expect("Unable to generate header and C++ code");
             for pair in generations.0 {
                 let cppname = format!("gen{}.{}", counter, cpp);


### PR DESCRIPTION
This is required for some types of build where external Rust executables
need to call C++ bindings esported from shared objects.

Fixes #704.
