### PR TITLE
'byvalue' mode using moveit.

### DIFF
--- a/.github/workflows/rust-byvalue.yml
+++ b/.github/workflows/rust-byvalue.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --all --verbose --features byvalue
+    - name: Install creduce
+      run: sudo apt-get install creduce
+    - name: Run tests
+      run: cargo test --all --verbose --features byvalue

--- a/.github/workflows/rust-byvalue.yml
+++ b/.github/workflows/rust-byvalue.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust (byvalue)
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,16 @@ categories = ["development-tools::ffi", "api-bindings"]
 # where we are depending on such features.
 resolver = "2"
 
+[features]
+byvalue = [ "moveit" ]
+
 [dependencies]
 autocxx-macro = { path="macro", version="0.14.0" }
 autocxx-engine = { path="engine", version="0.14.0" } # so that
   # we can refer to autocxx_engine::cxx. But even that isn't sufficient...
 cxx = "1.0.54" # ... also needed because expansion of type_id refers to ::cxx
 aquamarine = "0.1" # docs
+moveit = { optional = true, git = "https://github.com/google/moveit", rev="refs/pull/25/head" }
 
 [workspace]
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce", "integration-tests"]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -28,6 +28,7 @@ default = [ "reproduction_case" ]
 build = ["cc"]
 nightly = [] # for doc generation purposes only; used by docs.rs
 reproduction_case = [ "serde_json", "autocxx-parser/reproduction_case" ]
+byvalue = [ "moveit" ]
 
 [dependencies]
 log = "0.4"
@@ -50,6 +51,7 @@ tempfile = "3.1"
 once_cell = "1.7"
 strum_macros = "0.20.1"
 serde_json = { version = "1.0", optional = true }
+moveit = { optional = true, git = "https://github.com/google/moveit", rev="refs/pull/25/head" }
 
 [dependencies.syn]
 version = "1.0.39"

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -158,6 +158,10 @@ fn get_struct_field_types(
     extra_apis: &mut Vec<UnanalyzedApi>,
 ) -> Result<(), ConvertError> {
     for f in &s.fields {
+        log::info!("Field name is {}", f.ident.as_ref().unwrap());
+        if f.ident.as_ref().unwrap() == "_bindgen_opaque_blob" {
+            continue;
+        }
         let annotated =
             type_converter.convert_type(f.ty.clone(), ns, &TypeConversionContext::CxxInnerType)?;
         extra_apis.extend(annotated.extra_apis);

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -824,11 +824,11 @@ impl<'a> RsCodeGenerator<'a> {
         );
         let orig_item = item_creator();
         match type_kind {
-            TypeKind::Pod | TypeKind::NonPodNested => {
+            TypeKind::Pod | TypeKind::NonPodNested | TypeKind::NonPod => {
                 let mut item = orig_item
                     .expect("Instantiable types must provide instance")
                     .0;
-                if matches!(type_kind, TypeKind::NonPodNested) {
+                if !matches!(type_kind, TypeKind::Pod) {
                     // We have to use 'type A = super::bindgen::A::B'
                     // because if we use simply 'type A', there is no combination
                     // of cxx-acceptable attributes which will inform cxx that
@@ -852,7 +852,7 @@ impl<'a> RsCodeGenerator<'a> {
                     extern_rust_mod_items: Vec::new(),
                 }
             }
-            TypeKind::NonPod | TypeKind::Abstract => {
+             | TypeKind::Abstract => {
                 bindgen_mod_items.push(Item::Use(parse_quote! { pub use cxxbridge::#id; }));
                 let doc_attr = orig_item.map(|maybe_item| maybe_item.1).flatten();
                 RsCodegenResult {

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -852,7 +852,7 @@ impl<'a> RsCodeGenerator<'a> {
                     extern_rust_mod_items: Vec::new(),
                 }
             }
-             | TypeKind::Abstract => {
+            TypeKind::Abstract => {
                 bindgen_mod_items.push(Item::Use(parse_quote! { pub use cxxbridge::#id; }));
                 let doc_attr = orig_item.map(|maybe_item| maybe_item.1).flatten();
                 RsCodegenResult {

--- a/engine/src/conversion/codegen_rs/non_pod_struct.rs
+++ b/engine/src/conversion/codegen_rs/non_pod_struct.rs
@@ -40,9 +40,15 @@ pub(crate) fn make_non_pod(s: &mut ItemStruct) {
     // Rustc can use least-significant bits of the reference for other storage.
     log::info!("Before: {}", s.to_token_stream());
 
-    let attrs = s.attrs
+    let attrs = s
+        .attrs
         .iter()
-        .filter(|a| a.path.get_ident().iter().any(|p| *p == "repr" || *p == "doc"))
+        .filter(|a| {
+            a.path
+                .get_ident()
+                .iter()
+                .any(|p| *p == "repr" || *p == "doc")
+        })
         .cloned();
     s.attrs = attrs.collect();
     // Now fill in fields. Usually, we just want a single field
@@ -67,7 +73,11 @@ pub(crate) fn make_non_pod(s: &mut ItemStruct) {
     // See cxx's opaque::Opaque for rationale for this type... in
     // short, it's to avoid being Send/Sync.
     let bindgen_opaque_blob = if let syn::Fields::Named(fieldlist) = &s.fields {
-        fieldlist.named.iter().filter(|f| f.ident.as_ref().unwrap().to_string() == "_bindgen_opaque_blob").next()
+        fieldlist
+            .named
+            .iter()
+            .filter(|f| f.ident.as_ref().unwrap().to_string() == "_bindgen_opaque_blob")
+            .next()
     } else {
         None
     };

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -312,6 +312,9 @@ impl IncludeCppEngine {
                     .allowlist_var(&a);
             }
         }
+        
+        // TODO un-opaque things based on generate_pod
+        builder = builder.opaque_type(".*");
 
         log::info!(
             "Bindgen flags would be: {}",

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -312,7 +312,7 @@ impl IncludeCppEngine {
                     .allowlist_var(&a);
             }
         }
-        
+
         // TODO un-opaque things based on generate_pod
         builder = builder.opaque_type(".*");
 

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -23,6 +23,9 @@ repository = "https://github.com/google/autocxx"
 keywords = ["ffi"]
 categories = ["development-tools::ffi", "api-bindings"]
 
+[features]
+byvalue = [ "autocxx-engine/byvalue" ]
+
 [dependencies]
 autocxx-engine = { version="=0.14.0", path="../../engine", features = ["build"] }
 env_logger = "0.9.0"

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -23,6 +23,9 @@ repository = "https://github.com/google/autocxx"
 keywords = ["ffi"]
 categories = ["development-tools::ffi", "api-bindings"]
 
+[features]
+byvalue = [ "autocxx-engine/byvalue" ]
+
 [dependencies]
 autocxx-engine = { version="=0.14.0", path="../../engine" }
 clap = "~2.33"

--- a/integration-tests/src/byvalue_tests.rs
+++ b/integration-tests/src/byvalue_tests.rs
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::test_utils::run_test_ex;
+use indoc::indoc;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+fn run_byvalue_test(
+    cxx_code: &str,
+    header_code: &str,
+    rust_code: TokenStream,
+    generate_byvalue: &[&str],
+) {
+    let directives = generate_byvalue.iter().map(|s| {
+        quote! {
+            generate_byvalue!(#s)
+        }
+    });
+    let directives = quote! {
+        #(#directives)*
+    };
+    run_test_ex(
+        cxx_code,
+        header_code,
+        rust_code,
+        directives,
+        None,
+        None,
+        None,
+    )
+}
+
+#[test]
+fn test_return_nontrvial() {
+    let hdr = indoc! {"
+    class NonTrivial {
+    public:
+        NonTrivial() {}
+        ~NonTrivial() {}
+        NonTrivial(NonTrivial&&) {}
+    };
+    NonTrivial get() {
+        NonTrivial a;
+        return a;
+    }
+    "};
+    let rs = quote! {
+        ffi::get();
+    };
+    run_byvalue_test("", hdr, rs, &["get"]);
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -17,3 +17,7 @@ mod tests;
 
 #[cfg(test)]
 mod test_utils;
+
+//#[cfg(all(feature="byvalue",test))]
+#[cfg(test)]
+mod byvalue_tests;


### PR DESCRIPTION
This is just a feature and doesn't yet do anything.

'byvalue' chosen because features cannot have the same name as crates.

First tiny step on #379 