### PR TITLE
Ignore protected and private types

### DIFF
--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -112,8 +112,8 @@ impl ByValueChecker {
                         None => byvalue_checker.ingest_nonpod_type(name.clone()),
                     }
                 }
-                Api::Struct { item, .. } => {
-                    byvalue_checker.ingest_struct(item, api.name().get_namespace())
+                Api::Struct { details, .. } => {
+                    byvalue_checker.ingest_struct(&details.item, api.name().get_namespace())
                 }
                 Api::Enum { .. } => {
                     byvalue_checker

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -49,11 +49,17 @@ pub(crate) struct ImplBlockDetails {
 }
 
 /// C++ visibility.
-#[derive(Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub(crate) enum CppVisibility {
     Public,
     Protected,
     Private,
+}
+
+/// Details about a C++ struct.
+pub(crate) struct StructDetails {
+    pub(crate) vis: CppVisibility,
+    pub(crate) item: ItemStruct,
 }
 
 /// A C++ function for which we need to generate bindings, but haven't
@@ -265,7 +271,7 @@ pub(crate) enum Api<T: AnalysisPhase> {
     /// `bindgen` output.
     Struct {
         name: ApiName,
-        item: ItemStruct,
+        details: Box<StructDetails>,
         analysis: T::StructAnalysis,
     },
     /// A variable-length C integer type (e.g. int, unsigned long).
@@ -409,7 +415,7 @@ impl<T: AnalysisPhase> Api<T> {
 
     pub(crate) fn struct_unchanged(
         name: ApiName,
-        item: ItemStruct,
+        details: Box<StructDetails>,
         analysis: T::StructAnalysis,
     ) -> Result<Box<dyn Iterator<Item = Api<T>>>, ConvertErrorWithContext>
     where
@@ -417,7 +423,7 @@ impl<T: AnalysisPhase> Api<T> {
     {
         Ok(Box::new(std::iter::once(Api::Struct {
             name,
-            item,
+            details,
             analysis,
         })))
     }

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -515,13 +515,15 @@ impl<'a> RsCodeGenerator<'a> {
                 materializations: vec![Use::UsedFromBindgen],
                 extern_rust_mod_items: Vec::new(),
             },
-            Api::Struct { item, analysis, .. } => {
-                let doc_attr = get_doc_attr(&item.attrs);
+            Api::Struct {
+                details, analysis, ..
+            } => {
+                let doc_attr = get_doc_attr(&details.item.attrs);
                 self.generate_type(
                     &name,
                     id,
                     analysis.kind,
-                    || Some((Item::Struct(item), doc_attr)),
+                    || Some((Item::Struct(details.item), doc_attr)),
                     associated_methods,
                 )
             }

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -53,6 +53,7 @@ pub enum ConvertError {
     BoxContainingNonRustType(QualifiedName),
     RustTypeWithAPath(QualifiedName),
     AbstractNestedType,
+    NonPublicNestedType,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -98,6 +99,7 @@ impl Display for ConvertError {
             ConvertError::BoxContainingNonRustType(ty) => write!(f, "A rust::Box<T> was encountered where T was not known to be a Rust type. Use rust_type!(T): {}", ty.to_cpp_name())?,
             ConvertError::RustTypeWithAPath(ty) => write!(f, "A qualified Rust type was found (i.e. one containing ::): {}. Rust types must always be a simple identifier.", ty.to_cpp_name())?,
             ConvertError::AbstractNestedType => write!(f, "This type is nested within another struct/class, yet is abstract (or is not on the allowlist so we can't be sure). This is not yet supported by autocxx. If you don't believe this type is abstract, add it to the allowlist.")?,
+            ConvertError::NonPublicNestedType => write!(f, "This type is nested within another struct/class with protected or private visibility.")?,
         }
         Ok(())
     }

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use syn::{ItemEnum, ItemStruct};
+use syn::ItemEnum;
 
 use super::{
-    api::{AnalysisPhase, Api, ApiName, FuncToConvert, TypedefKind},
+    api::{AnalysisPhase, Api, ApiName, FuncToConvert, StructDetails, TypedefKind},
     convert_error::{ConvertErrorWithContext, ErrorContext},
     ConvertError,
 };
@@ -67,7 +67,7 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
     ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
     SF: FnMut(
         ApiName,
-        ItemStruct,
+        Box<StructDetails>,
         A::StructAnalysis,
     ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
     EF: FnMut(
@@ -165,9 +165,9 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                         } => func_conversion(name, fun, analysis, name_for_gc),
                         Api::Struct {
                             name,
-                            item,
+                            details,
                             analysis,
-                        } => struct_conversion(name, item, analysis),
+                        } => struct_conversion(name, details, analysis),
                     };
                 api_or_error(tn, result)
             })

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -7341,6 +7341,31 @@ fn test_class_having_protected_method() {
 }
 
 #[test]
+fn test_protected_inner_class() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    inline uint32_t DoMath(uint32_t a)  {
+        return a * 3;
+    }
+
+    class A {
+    protected:
+        inline uint32_t protected_method() { return 0; }
+
+        struct B {
+            int x;
+        };
+
+        inline B protected_method_2() {
+            return { .x = 0 };
+        }
+    };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["A"], &[]);
+}
+
+#[test]
 fn test_class_having_private_method() {
     let hdr = indoc! {"
     #include <cstdint>


### PR DESCRIPTION
@adetaylor just dropping the type at parse time might be too big of a hammer, but it seems to do the trick. Also this depends on adetaylor/rust-bindgen#7; I left the `[patch]` directive in Cargo.toml in case you want to get a CI run on this before merging the bindgen change.

Fix #709.
Supersedes #710.

Co-authored-by: Nikhil Benesch <nikhil.benesch@gmail.com>

- [x] Tests pass
- [x] Appropriate changes to README are included in PR