### PR TITLE
Bump to autocxx-bindgen 0.59.5.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -34,7 +34,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "0.59.4"
+autocxx-bindgen = "=0.59.5"
 itertools = "0.10"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"


### PR DESCRIPTION
Also specify an exact version, since autocxx is only tested when closely
paired with a specific version of autocxx-bindgen. Other semver pairings
may work, but it seems best to insist.

Pre-requisite for #711
