### PR TITLE
Pass thru static/runtime features.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -28,6 +28,8 @@ default = [ "reproduction_case" ]
 build = ["cc"]
 nightly = [] # for doc generation purposes only; used by docs.rs
 reproduction_case = [ "serde_json", "autocxx-parser/reproduction_case" ]
+runtime = [ "autocxx-bindgen/runtime" ]
+static = [ "autocxx-bindgen/static" ]
 
 [dependencies]
 log = "0.4"

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -23,6 +23,10 @@ repository = "https://github.com/google/autocxx"
 keywords = ["ffi"]
 categories = ["development-tools::ffi", "api-bindings"]
 
+[features]
+runtime = [ "autocxx-engine/runtime" ]
+static = [ "autocxx-engine/static" ]
+
 [dependencies]
 autocxx-engine = { version="=0.14.0", path="../../engine", features = ["build"] }
 env_logger = "0.9.0"

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -23,6 +23,10 @@ repository = "https://github.com/google/autocxx"
 keywords = ["ffi"]
 categories = ["development-tools::ffi", "api-bindings"]
 
+[features]
+runtime = [ "autocxx-engine/runtime" ]
+static = [ "autocxx-engine/static" ]
+
 [dependencies]
 autocxx-engine = { version="=0.14.0", path="../../engine" }
 clap = "~2.33"


### PR DESCRIPTION
bindgen provides the ability to choose between three different
methods of finding libclang from clang-sys:
* dynamic (the default)
* runtime
* static

This change allows users of autocxx-build or autocxx-gen
to make equivalent choices.

Fixes #707.
