### PR TITLE
Ignore rvalue references.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -36,7 +36,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.59.8"
+#autocxx-bindgen = "=0.59.8"
+autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "rvalue-references" }
 itertools = "0.10"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -36,8 +36,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-#autocxx-bindgen = "=0.59.8"
-autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "rvalue-references" }
+autocxx-bindgen = "=0.59.9"
+#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "rvalue-references" }
 itertools = "0.10"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -17,7 +17,7 @@ use quote::quote;
 use syn::{parse_quote, FnArg};
 
 use crate::{
-    conversion::api::{Api, ApiName, CastMutability, Synthesis},
+    conversion::api::{Api, ApiName, CastMutability, References, Synthesis},
     types::{make_ident, QualifiedName},
 };
 
@@ -111,8 +111,7 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             cpp_vis: crate::conversion::api::CppVisibility::Public,
             is_move_constructor: false,
             unused_template_param: false,
-            return_type_is_reference: true,
-            reference_args: [make_ident("this")].into_iter().collect(),
+            references: References::new_with_this_as_reference(),
             original_name: None,
             self_ty: Some(from.clone()),
             synthesized_this_type: None,

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -111,7 +111,7 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             cpp_vis: crate::conversion::api::CppVisibility::Public,
             is_move_constructor: false,
             unused_template_param: false,
-            references: References::new_with_this_as_reference(),
+            references: References::new_with_this_and_return_as_reference(),
             original_name: None,
             self_ty: Some(from.clone()),
             synthesized_this_type: None,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -701,13 +701,6 @@ impl<'a> FnAnalyzer<'a> {
         if fun.unused_template_param {
             return Err(contextualize_error(ConvertError::UnusedTemplateParam));
         }
-        if fun.references.rvalue_ref_return {
-            return Err(contextualize_error(ConvertError::RValueReturn));
-        }
-        if !fun.references.rvalue_ref_params.is_empty() {
-            return Err(contextualize_error(ConvertError::RValueParam));
-        }
-
         match kind {
             FnKind::Method(_, MethodKind::Static) => {}
             FnKind::Method(ref self_ty, _) => {
@@ -725,6 +718,13 @@ impl<'a> FnAnalyzer<'a> {
             }
             _ => {}
         };
+        if fun.references.rvalue_ref_return {
+            return Err(contextualize_error(ConvertError::RValueReturn));
+        }
+        // Ensure we do this _after_ recording the presence of move constructors.
+        if !fun.references.rvalue_ref_params.is_empty() {
+            return Err(contextualize_error(ConvertError::RValueParam));
+        }
 
         // Analyze the return type, just as we previously did for the
         // parameters.

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -25,8 +25,8 @@ use crate::{
             type_converter::{self, add_analysis, TypeConversionContext, TypeConverter},
         },
         api::{
-            ApiName, CastMutability, CppVisibility, FuncToConvert, SubclassName, Synthesis,
-            Virtualness,
+            ApiName, CastMutability, CppVisibility, FuncToConvert, References, SubclassName,
+            Synthesis, Virtualness,
         },
         convert_error::ConvertErrorWithContext,
         convert_error::ErrorContext,
@@ -478,7 +478,7 @@ impl<'a> FnAnalyzer<'a> {
                     ns,
                     diagnostic_display_name,
                     &fun.synthesized_this_type,
-                    &fun.reference_args,
+                    &fun.references,
                     true,
                 )
             })
@@ -645,7 +645,7 @@ impl<'a> FnAnalyzer<'a> {
                     ns,
                     &rust_name,
                     &fun.synthesized_this_type,
-                    &fun.reference_args,
+                    &fun.references,
                     false,
                 )
                 .map_err(contextualize_error)?;
@@ -701,6 +701,12 @@ impl<'a> FnAnalyzer<'a> {
         if fun.unused_template_param {
             return Err(contextualize_error(ConvertError::UnusedTemplateParam));
         }
+        if fun.references.rvalue_ref_return {
+            return Err(contextualize_error(ConvertError::RValueReturn));
+        }
+        if !fun.references.rvalue_ref_params.is_empty() {
+            return Err(contextualize_error(ConvertError::RValueParam));
+        }
 
         match kind {
             FnKind::Method(_, MethodKind::Static) => {}
@@ -736,7 +742,7 @@ impl<'a> FnAnalyzer<'a> {
                 deps: std::iter::once(self_ty).cloned().collect(),
             }
         } else {
-            self.convert_return_type(&fun.output, ns, fun.return_type_is_reference)
+            self.convert_return_type(&fun.output, ns, &fun.references)
                 .map_err(contextualize_error)?
         };
         let mut deps = params_deps;
@@ -984,7 +990,7 @@ impl<'a> FnAnalyzer<'a> {
         ns: &Namespace,
         fn_name: &str,
         virtual_this: &Option<QualifiedName>,
-        reference_args: &HashSet<Ident>,
+        references: &References,
         treat_this_as_reference: bool,
     ) -> Result<(FnArg, ArgumentAnalysis), ConvertError> {
         Ok(match arg {
@@ -1038,7 +1044,7 @@ impl<'a> FnAnalyzer<'a> {
                     }
                     syn::Pat::Ident(pp) => {
                         validate_ident_ok_for_cxx(&pp.ident.to_string())?;
-                        treat_as_reference = reference_args.contains(&pp.ident);
+                        treat_as_reference = references.ref_params.contains(&pp.ident);
                         syn::Pat::Ident(pp)
                     }
                     _ => old_pat,
@@ -1125,7 +1131,7 @@ impl<'a> FnAnalyzer<'a> {
         &mut self,
         rt: &ReturnType,
         ns: &Namespace,
-        convert_ptr_to_reference: bool,
+        references: &References,
     ) -> Result<ReturnTypeAnalysis, ConvertError> {
         let result = match rt {
             ReturnType::Default => ReturnTypeAnalysis {
@@ -1137,7 +1143,7 @@ impl<'a> FnAnalyzer<'a> {
             ReturnType::Type(rarrow, boxed_type) => {
                 // TODO remove the below clone
                 let annotated_type =
-                    self.convert_boxed_type(boxed_type.clone(), ns, convert_ptr_to_reference)?;
+                    self.convert_boxed_type(boxed_type.clone(), ns, references.ref_return)?;
                 let boxed_type = annotated_type.ty;
                 let was_reference = matches!(boxed_type.as_ref(), Type::Reference(_));
                 let conversion = self.return_type_conversion_details(boxed_type.as_ref());
@@ -1204,8 +1210,7 @@ impl<'a> FnAnalyzer<'a> {
                         cpp_vis: CppVisibility::Public,
                         is_move_constructor: false,
                         unused_template_param: false,
-                        return_type_is_reference: false,
-                        reference_args: HashSet::new(),
+                        references: References::default(),
                         original_name: None,
                         synthesized_this_type: None,
                         synthesis: None,

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -68,8 +68,7 @@ pub(super) fn create_subclass_fn_wrapper(
         is_move_constructor: false,
         unused_template_param: fun.unused_template_param,
         original_name: None,
-        return_type_is_reference: fun.return_type_is_reference,
-        reference_args: fun.reference_args.clone(),
+        references: fun.references.clone(),
         synthesis: fun.synthesis.clone(),
     })
 }
@@ -205,8 +204,7 @@ pub(super) fn create_subclass_constructor(
         is_move_constructor: false,
         original_name: None,
         unused_template_param: fun.unused_template_param,
-        return_type_is_reference: fun.return_type_is_reference,
-        reference_args: fun.reference_args.clone(),
+        references: fun.references.clone(),
         synthesized_this_type: Some(cpp.clone()),
         self_ty: Some(cpp),
         synthesis,

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -128,8 +128,9 @@ pub(crate) struct References {
 }
 
 impl References {
-    pub(crate) fn new_with_this_as_reference() -> Self {
+    pub(crate) fn new_with_this_and_return_as_reference() -> Self {
         let mut results = Self::default();
+        results.ref_return = true;
         results.ref_params.insert(make_ident("this"));
         results
     }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -116,6 +116,25 @@ pub(crate) enum Synthesis {
     },
 }
 
+/// Information about references (as opposed to pointers) to be found
+/// within the function signature. This is derived from bindgen annotations
+/// which is why it's not within `FuncToConvert::inputs`
+#[derive(Default, Clone)]
+pub(crate) struct References {
+    pub(crate) rvalue_ref_params: HashSet<Ident>,
+    pub(crate) ref_params: HashSet<Ident>,
+    pub(crate) ref_return: bool,
+    pub(crate) rvalue_ref_return: bool,
+}
+
+impl References {
+    pub(crate) fn new_with_this_as_reference() -> Self {
+        let mut results = Self::default();
+        results.ref_params.insert(make_ident("this"));
+        results
+    }
+}
+
 /// A C++ function for which we need to generate bindings, but haven't
 /// yet analyzed in depth. This is little more than a `ForeignItemFn`
 /// broken down into its constituent parts, plus some metadata from the
@@ -137,8 +156,7 @@ pub(crate) struct FuncToConvert {
     pub(crate) cpp_vis: CppVisibility,
     pub(crate) is_move_constructor: bool,
     pub(crate) unused_template_param: bool,
-    pub(crate) return_type_is_reference: bool,
-    pub(crate) reference_args: HashSet<Ident>,
+    pub(crate) references: References,
     pub(crate) original_name: Option<String>,
     /// Used for static functions only. For all other functons,
     /// this is figured out from the receiver type in the inputs.

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -53,6 +53,8 @@ pub enum ConvertError {
     RustTypeWithAPath(QualifiedName),
     AbstractNestedType,
     NonPublicNestedType,
+    RValueParam,
+    RValueReturn,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -98,6 +100,8 @@ impl Display for ConvertError {
             ConvertError::RustTypeWithAPath(ty) => write!(f, "A qualified Rust type was found (i.e. one containing ::): {}. Rust types must always be a simple identifier.", ty.to_cpp_name())?,
             ConvertError::AbstractNestedType => write!(f, "This type is nested within another struct/class, yet is abstract (or is not on the allowlist so we can't be sure). This is not yet supported by autocxx. If you don't believe this type is abstract, add it to the allowlist.")?,
             ConvertError::NonPublicNestedType => write!(f, "This type is nested within another struct/class with protected or private visibility.")?,
+            ConvertError::RValueParam => write!(f, "This function takes an rvalue reference parameter (&&) which is not yet supported.")?,
+            ConvertError::RValueReturn => write!(f, "This function returns an rvalue reference (&&) which is not yet supported.")?,
         }
         Ok(())
     }

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -152,7 +152,7 @@ impl ParseForeignMod {
             } else if a.path.is_ident("bindgen_arg_type_rvalue_reference") {
                 let r: Result<Ident, syn::Error> = a.parse_args();
                 if let Ok(ls) = r {
-                    results.ref_params.insert(ls);
+                    results.rvalue_ref_params.insert(ls);
                 }
             }
         }

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::conversion::api::ApiName;
+use crate::conversion::api::{ApiName, References};
 use crate::conversion::doc_attr::get_doc_attr;
 use crate::conversion::error_reporter::report_any_error;
 use crate::conversion::{
@@ -24,7 +24,7 @@ use crate::{
     conversion::ConvertError,
     types::{Namespace, QualifiedName},
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use syn::{
     Block, Expr, ExprCall, ForeignItem, ForeignItemFn, Ident, ImplItem, ItemImpl, LitStr, Stmt,
     Type,
@@ -84,8 +84,7 @@ impl ParseForeignMod {
                     "bindgen_unused_template_param_in_arg_or_return",
                 );
                 let is_move_constructor = Self::is_move_constructor(&item);
-                let (reference_args, return_type_is_reference) =
-                    Self::get_reference_parameters_and_return(&item);
+                let references = Self::get_reference_parameters_and_return(&item);
                 let original_name = get_bindgen_original_name_annotation(&item.attrs);
                 let doc_attr = get_doc_attr(&item.attrs);
                 self.funcs_to_convert.push(FuncToConvert {
@@ -99,8 +98,7 @@ impl ParseForeignMod {
                     cpp_vis,
                     is_move_constructor,
                     unused_template_param,
-                    return_type_is_reference,
-                    reference_args,
+                    references,
                     original_name,
                     synthesized_this_type: None,
                     synthesis: None,
@@ -139,20 +137,26 @@ impl ParseForeignMod {
         Self::get_bindgen_special_member_annotation(fun).map_or(false, |val| val == "move_ctor")
     }
 
-    fn get_reference_parameters_and_return(fun: &ForeignItemFn) -> (HashSet<Ident>, bool) {
-        let mut ref_params = HashSet::new();
-        let mut ref_return = false;
+    fn get_reference_parameters_and_return(fun: &ForeignItemFn) -> References {
+        let mut results = References::default();
         for a in &fun.attrs {
             if a.path.is_ident("bindgen_ret_type_reference") {
-                ref_return = true;
+                results.ref_return = true;
             } else if a.path.is_ident("bindgen_arg_type_reference") {
                 let r: Result<Ident, syn::Error> = a.parse_args();
                 if let Ok(ls) = r {
-                    ref_params.insert(ls);
+                    results.ref_params.insert(ls);
+                }
+            } else if a.path.is_ident("bindgen_ret_type_rvalue_reference") {
+                results.rvalue_ref_return = true;
+            } else if a.path.is_ident("bindgen_arg_type_rvalue_reference") {
+                let r: Result<Ident, syn::Error> = a.parse_args();
+                if let Ok(ls) = r {
+                    results.ref_params.insert(ls);
                 }
             }
         }
-        (ref_params, ref_return)
+        results
     }
 
     /// Record information from impl blocks encountered in bindgen

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -5363,7 +5363,6 @@ fn test_ignore_move_constructor() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/712
 fn test_ignore_function_with_rvalue_ref() {
     let hdr = indoc! {"
         #include <string>


### PR DESCRIPTION
Fixes #712.

Needs adjustment because at the moment this uses a special autocxx-bindgen branch.
