### PR TITLE
Regularize bindgen annotations.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.59.9"
+autocxx-bindgen = "=0.59.10"
 #autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "rvalue-references" }
 itertools = "0.10"
 cc = { version = "1.0", optional = true }

--- a/engine/src/conversion/analysis/mod.rs
+++ b/engine/src/conversion/analysis/mod.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use syn::{Attribute, Ident};
-
-use crate::conversion::convert_error::ErrorContext;
-
-use super::{convert_error::ConvertErrorWithContext, ConvertError};
-
 pub(crate) mod abstract_types;
 pub(crate) mod casts;
 pub(crate) mod ctypes;
@@ -30,37 +24,3 @@ pub(crate) mod tdef;
 mod type_converter;
 
 pub(crate) use name_check::check_names;
-
-// Remove `bindgen_` attributes. They don't have a corresponding macro defined anywhere,
-// so they will cause compilation errors if we leave them in.
-// We may return an error if one of the bindgen attributes shows that the
-// item can't be processed.
-fn remove_bindgen_attrs(
-    attrs: &mut Vec<Attribute>,
-    id: Ident,
-) -> Result<(), ConvertErrorWithContext> {
-    if has_attr(attrs, "bindgen_unused_template_param") {
-        return Err(ConvertErrorWithContext(
-            ConvertError::UnusedTemplateParam,
-            Some(ErrorContext::Item(id)),
-        ));
-    }
-
-    fn is_bindgen_attr(attr: &Attribute) -> bool {
-        let segments = &attr.path.segments;
-        segments.len() == 1
-            && segments
-                .first()
-                .unwrap()
-                .ident
-                .to_string()
-                .starts_with("bindgen_")
-    }
-
-    attrs.retain(|a| !is_bindgen_attr(a));
-    Ok(())
-}
-
-fn has_attr(attrs: &[Attribute], attr_name: &str) -> bool {
-    attrs.iter().any(|at| at.path.is_ident(attr_name))
-}

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -23,12 +23,11 @@ use crate::{
         api::{AnalysisPhase, Api, ApiName, TypedefKind, UnanalyzedApi},
         convert_error::{ConvertErrorWithContext, ErrorContext},
         error_reporter::convert_apis,
+        parse::BindgenSemanticAttributes,
         ConvertError,
     },
     types::QualifiedName,
 };
-
-use super::remove_bindgen_attrs;
 
 pub(crate) struct TypedefAnalysis {
     pub(crate) kind: TypedefKind,
@@ -92,8 +91,8 @@ fn get_replacement_typedef(
     extra_apis: &mut Vec<UnanalyzedApi>,
 ) -> Result<Api<TypedefPhase>, ConvertErrorWithContext> {
     let mut converted_type = ity.clone();
-    let id = ity.ident.clone();
-    remove_bindgen_attrs(&mut converted_type.attrs, id)?;
+    let metadata = BindgenSemanticAttributes::new_retaining_others(&mut converted_type.attrs);
+    metadata.check_for_fatal_attrs(&ity.ident)?;
     let type_conversion_results = type_converter.convert_type(
         (*ity.ty).clone(),
         name.name.get_namespace(),

--- a/engine/src/conversion/parse/bindgen_semantic_attributes.rs
+++ b/engine/src/conversion/parse/bindgen_semantic_attributes.rs
@@ -1,0 +1,193 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::{Ident, TokenStream};
+use syn::{
+    parenthesized,
+    parse::{Parse, Parser},
+    Attribute, LitStr,
+};
+
+use crate::conversion::{
+    api::{CppVisibility, Layout, References, Virtualness},
+    convert_error::{ConvertErrorWithContext, ErrorContext},
+    ConvertError,
+};
+
+/// The set of all annotations that autocxx_bindgen has added
+/// for our benefit.
+#[derive(Debug)]
+pub(crate) struct BindgenSemanticAttributes(Vec<BindgenSemanticAttribute>);
+
+impl BindgenSemanticAttributes {
+    // Remove `bindgen_` attributes. They don't have a corresponding macro defined anywhere,
+    // so they will cause compilation errors if we leave them in.
+    // We may return an error if one of the bindgen attributes shows that the
+    // item can't be processed.
+    pub(crate) fn new_retaining_others(attrs: &mut Vec<Attribute>) -> Self {
+        let metadata = Self::new(attrs);
+        attrs.retain(|a| !(a.path.segments.last().unwrap().ident == "cpp_semantics"));
+        metadata
+    }
+
+    pub(crate) fn new(attrs: &[Attribute]) -> Self {
+        Self(
+            attrs
+                .iter()
+                .filter_map(|attr| {
+                    if attr.path.segments.last().unwrap().ident == "cpp_semantics" {
+                        let r: Result<BindgenSemanticAttribute, syn::Error> = attr.parse_args();
+                        r.ok()
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    /// Some attributes indicate we can never handle a given item. Check for those.
+    pub(crate) fn check_for_fatal_attrs(
+        &self,
+        id_for_context: &Ident,
+    ) -> Result<(), ConvertErrorWithContext> {
+        if self.has_attr("unused_template_param") {
+            Err(ConvertErrorWithContext(
+                ConvertError::UnusedTemplateParam,
+                Some(ErrorContext::Item(id_for_context.clone())),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Whether the given attribute is present.
+    pub(super) fn has_attr(&self, attr_name: &str) -> bool {
+        self.0.iter().any(|a| a.is_ident(attr_name))
+    }
+
+    /// The C++ visibility of the item.
+    pub(super) fn get_cpp_visibility(&self) -> CppVisibility {
+        if self.has_attr("visibility_private") {
+            CppVisibility::Private
+        } else if self.has_attr("visibility_protected") {
+            CppVisibility::Protected
+        } else {
+            CppVisibility::Public
+        }
+    }
+
+    /// Whether the item is virtual.
+    pub(super) fn get_virtualness(&self) -> Virtualness {
+        if self.has_attr("pure_virtual") {
+            Virtualness::PureVirtual
+        } else if self.has_attr("bindgen_virtual") {
+            Virtualness::Virtual
+        } else {
+            Virtualness::None
+        }
+    }
+
+    fn parse_if_present<T: Parse>(&self, annotation: &str) -> Option<T> {
+        self.0
+            .iter()
+            .find(|a| a.is_ident(annotation))
+            .map(|a| a.parse_args().unwrap())
+    }
+
+    fn string_if_present(&self, annotation: &str) -> Option<String> {
+        let ls: Option<LitStr> = self.parse_if_present(annotation);
+        ls.map(|ls| ls.value())
+    }
+
+    /// The in-memory layout of the item.
+    pub(super) fn get_layout(&self) -> Option<Layout> {
+        self.parse_if_present("layout")
+    }
+
+    /// The original C++ name, which bindgen may have changed.
+    pub(super) fn get_original_name(&self) -> Option<String> {
+        self.string_if_present("original_name")
+    }
+
+    fn get_bindgen_special_member_annotation(&self) -> Option<String> {
+        self.string_if_present("special_member")
+    }
+
+    /// Whether this is a move constructor.
+    pub(super) fn is_move_constructor(&self) -> bool {
+        self.get_bindgen_special_member_annotation()
+            .map_or(false, |val| val == "move_ctor")
+    }
+
+    /// Any reference parameters or return values.
+    pub(super) fn get_reference_parameters_and_return(&self) -> References {
+        let mut results = References::default();
+        for a in &self.0 {
+            if a.is_ident("ret_type_reference") {
+                results.ref_return = true;
+            } else if a.is_ident("ret_type_rvalue_reference") {
+                results.rvalue_ref_return = true;
+            } else if a.is_ident("arg_type_reference") {
+                let r: Result<Ident, syn::Error> = a.parse_args();
+                if let Ok(ls) = r {
+                    results.ref_params.insert(ls);
+                }
+            } else if a.is_ident("arg_type_rvalue_reference") {
+                let r: Result<Ident, syn::Error> = a.parse_args();
+                if let Ok(ls) = r {
+                    results.rvalue_ref_params.insert(ls);
+                }
+            }
+        }
+        results
+    }
+}
+
+#[derive(Debug)]
+struct BindgenSemanticAttribute {
+    annotation_name: Ident,
+    body: Option<TokenStream>,
+}
+
+impl BindgenSemanticAttribute {
+    fn is_ident(&self, name: &str) -> bool {
+        self.annotation_name == name
+    }
+
+    fn parse_args<T: Parse>(&self) -> Result<T, syn::Error> {
+        T::parse.parse2(self.body.as_ref().unwrap().clone())
+    }
+}
+
+impl Parse for BindgenSemanticAttribute {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let annotation_name: Ident = input.parse()?;
+        if input.peek(syn::token::Paren) {
+            let body_contents;
+            parenthesized!(body_contents in input);
+            Ok(Self {
+                annotation_name,
+                body: Some(body_contents.parse()?),
+            })
+        } else if !input.is_empty() {
+            Err(input.error("expected nothing"))
+        } else {
+            Ok(Self {
+                annotation_name,
+                body: None,
+            })
+        }
+    }
+}

--- a/engine/src/conversion/parse/mod.rs
+++ b/engine/src/conversion/parse/mod.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod bindgen_semantic_attributes;
 mod parse_bindgen;
 mod parse_foreign_mod;
 
+pub(crate) use bindgen_semantic_attributes::BindgenSemanticAttributes;
 pub(crate) use parse_bindgen::ParseBindgen;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -298,6 +298,7 @@ impl IncludeCppEngine {
             .generate_inline_functions(true)
             .respect_cxx_access_specs(true)
             .use_specific_virtual_function_receiver(true)
+            .cpp_semantic_attributes(true)
             .layout_tests(false); // TODO revisit later
         for item in known_types().get_initial_blocklist() {
             builder = builder.blocklist_item(item);

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -118,3 +118,18 @@ pub fn extern_rust_function(attr: TokenStream, input: TokenStream) -> TokenStrea
     }
     input
 }
+
+/// Attribute which should never be encountered in real life.
+/// This is something which features in the Rust source code generated
+/// by autocxx-bindgen and passed to autocxx-engine, which should never
+/// normally be compiled by rustc before it undergoes further processing.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn cpp_semantics(_attr: TokenStream, _input: TokenStream) -> TokenStream {
+    abort!(
+        Span::call_site(),
+        "Please do not attempt to compile this code. \n\
+        This code is the output from the autocxx-specific version of bindgen, \n\
+        and should be interpreted by autocxx-engine before further usage."
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,6 +685,9 @@ macro_rules! usage {
 #[doc(hidden)]
 pub use autocxx_macro::include_cpp_impl;
 
+#[doc(hidden)]
+pub use autocxx_macro::cpp_semantics;
+
 macro_rules! ctype_wrapper {
     ($r:ident, $c:expr, $d:expr) => {
         #[doc=$d]
@@ -811,6 +814,7 @@ pub mod prelude {
     pub use crate::c_ulonglong;
     pub use crate::c_ushort;
     pub use crate::c_void;
+    pub use crate::cpp_semantics;
     pub use crate::include_cpp;
     pub use crate::PinMut;
     pub use moveit::moveit;


### PR DESCRIPTION
Previously autocxx_bindgen added annotations which
were not valid Rust code.

It now generates annotations which correspond to a
real autocxx macro, and thus can more plausibly be
upstreamed to the real bindgen.

This also extracts a better encapsulated framework
for parsing these attributes.

Relates to #124.