### PR TITLE
Work towards spotting deleted move constructors.

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -36,8 +36,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.59.10"
-#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "rvalue-references" }
+autocxx-bindgen = "=0.59.11"
+#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "denote-deleted-move-constructors" }
 itertools = "0.10"
 cc = { version = "1.0", optional = true }
 unzip-n = "0.1.2"

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -109,7 +109,7 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             vis: parse_quote! { pub },
             virtualness: crate::conversion::api::Virtualness::None,
             cpp_vis: crate::conversion::api::CppVisibility::Public,
-            is_move_constructor: false,
+            special_member: None,
             unused_template_param: false,
             references: References::new_with_this_and_return_as_reference(),
             original_name: None,
@@ -119,6 +119,7 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
                 to_type: to.clone(),
                 mutable,
             }),
+            is_deleted: false,
         }),
         analysis: (),
     }

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -456,6 +456,13 @@ impl<'a> FnAnalyzer<'a> {
         let mut cpp_name = name.cpp_name_if_present().cloned();
         let ns = name.name.get_namespace();
 
+        // Disregard any deleted functions. We cared about them previously
+        // because they influence our behavior in whether types can be used in
+        // vectors, but that was all recorded in the POD analysis phase.
+        if fun.is_deleted {
+            return Ok(None);
+        }
+
         // Let's gather some pre-wisdom about the name of the function.
         // We're shortly going to plunge into analyzing the parameters,
         // and it would be nice to have some idea of the function name

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -25,8 +25,8 @@ use crate::{
             type_converter::{self, add_analysis, TypeConversionContext, TypeConverter},
         },
         api::{
-            ApiName, CastMutability, CppVisibility, FuncToConvert, References, SubclassName,
-            Synthesis, Virtualness,
+            ApiName, CastMutability, CppVisibility, FuncToConvert, References, SpecialMemberKind,
+            SubclassName, Synthesis, Virtualness,
         },
         convert_error::ConvertErrorWithContext,
         convert_error::ErrorContext,
@@ -705,7 +705,7 @@ impl<'a> FnAnalyzer<'a> {
             FnKind::Method(_, MethodKind::Static) => {}
             FnKind::Method(ref self_ty, _) => {
                 // Reject move constructors.
-                if fun.is_move_constructor {
+                if matches!(fun.special_member, Some(SpecialMemberKind::MoveConstructor)) {
                     self.has_unrepresentable_constructors
                         .insert(self_ty.clone());
                     return Err(contextualize_error(
@@ -1208,12 +1208,13 @@ impl<'a> FnAnalyzer<'a> {
                         vis: parse_quote! { pub },
                         virtualness: Virtualness::None,
                         cpp_vis: CppVisibility::Public,
-                        is_move_constructor: false,
+                        special_member: None,
                         unused_template_param: false,
                         references: References::default(),
                         original_name: None,
                         synthesized_this_type: None,
                         synthesis: None,
+                        is_deleted: false,
                     }),
                 )
             });

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -65,11 +65,12 @@ pub(super) fn create_subclass_fn_wrapper(
         vis: fun.vis.clone(),
         virtualness: Virtualness::None,
         cpp_vis: CppVisibility::Public,
-        is_move_constructor: false,
+        special_member: None,
         unused_template_param: fun.unused_template_param,
         original_name: None,
         references: fun.references.clone(),
         synthesis: fun.synthesis.clone(),
+        is_deleted: fun.is_deleted,
     })
 }
 
@@ -201,13 +202,14 @@ pub(super) fn create_subclass_constructor(
         vis: fun.vis.clone(),
         virtualness: Virtualness::None,
         cpp_vis: CppVisibility::Public,
-        is_move_constructor: false,
+        special_member: fun.special_member.clone(),
         original_name: None,
         unused_template_param: fun.unused_template_param,
         references: fun.references.clone(),
         synthesized_this_type: Some(cpp.clone()),
         self_ty: Some(cpp),
         synthesis,
+        is_deleted: fun.is_deleted,
     });
     let subclass_constructor_name = ApiName::new_with_cpp_name(
         &Namespace::new(),

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -136,6 +136,14 @@ impl References {
     }
 }
 
+#[derive(Clone)]
+pub(crate) enum SpecialMemberKind {
+    DefaultConstructor,
+    CopyConstructor,
+    MoveConstructor,
+    Destructor,
+}
+
 /// A C++ function for which we need to generate bindings, but haven't
 /// yet analyzed in depth. This is little more than a `ForeignItemFn`
 /// broken down into its constituent parts, plus some metadata from the
@@ -155,7 +163,7 @@ pub(crate) struct FuncToConvert {
     pub(crate) vis: Visibility,
     pub(crate) virtualness: Virtualness,
     pub(crate) cpp_vis: CppVisibility,
-    pub(crate) is_move_constructor: bool,
+    pub(crate) special_member: Option<SpecialMemberKind>,
     pub(crate) unused_template_param: bool,
     pub(crate) references: References,
     pub(crate) original_name: Option<String>,
@@ -169,6 +177,7 @@ pub(crate) struct FuncToConvert {
     /// If Some, this function didn't really exist in the original
     /// C++ and instead we're synthesizing it.
     pub(crate) synthesis: Option<Synthesis>,
+    pub(crate) is_deleted: bool,
 }
 
 /// Layers of analysis which may be applied to decorate each API.

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -129,10 +129,11 @@ pub(crate) struct References {
 
 impl References {
     pub(crate) fn new_with_this_and_return_as_reference() -> Self {
-        let mut results = Self::default();
-        results.ref_return = true;
-        results.ref_params.insert(make_ident("this"));
-        results
+        Self {
+            ref_return: true,
+            ref_params: [make_ident("this")].into_iter().collect(),
+            ..Default::default()
+        }
     }
 }
 

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -253,7 +253,7 @@ impl<'a> CppCodeGenerator<'a> {
             .collect(); // uniqify
         cpp_headers
             .iter()
-            .map(|x| x.include_stmt(&self.cpp_codegen_options))
+            .map(|x| x.include_stmt(self.cpp_codegen_options))
             .join("\n")
     }
 

--- a/engine/src/conversion/codegen_rs/impl_item_creator.rs
+++ b/engine/src/conversion/codegen_rs/impl_item_creator.rs
@@ -15,11 +15,11 @@
 use autocxx_parser::IncludeCppConfig;
 use syn::{parse_quote, Ident, Item};
 
-pub(crate) fn create_impl_items(id: &Ident, config: &IncludeCppConfig) -> Vec<Item> {
+pub(crate) fn create_impl_items(id: &Ident, movable: bool, config: &IncludeCppConfig) -> Vec<Item> {
     if config.exclude_impls {
         return vec![];
     }
-    vec![
+    let mut results = vec![
         Item::Impl(parse_quote! {
             impl UniquePtr<#id> {}
         }),
@@ -29,8 +29,11 @@ pub(crate) fn create_impl_items(id: &Ident, config: &IncludeCppConfig) -> Vec<It
         Item::Impl(parse_quote! {
             impl WeakPtr<#id> {}
         }),
-        Item::Impl(parse_quote! {
+    ];
+    if movable {
+        results.push(Item::Impl(parse_quote! {
             impl CxxVector<#id> {}
-        }),
-    ]
+        }))
+    }
+    results
 }

--- a/engine/src/conversion/parse/bindgen_semantic_attributes.rs
+++ b/engine/src/conversion/parse/bindgen_semantic_attributes.rs
@@ -20,7 +20,7 @@ use syn::{
 };
 
 use crate::conversion::{
-    api::{CppVisibility, Layout, References, Virtualness},
+    api::{CppVisibility, Layout, References, SpecialMemberKind, Virtualness},
     convert_error::{ConvertErrorWithContext, ErrorContext},
     ConvertError,
 };
@@ -121,14 +121,16 @@ impl BindgenSemanticAttributes {
         self.string_if_present("original_name")
     }
 
-    fn get_bindgen_special_member_annotation(&self) -> Option<String> {
+    /// Whether this is a move constructor or other special member.
+    pub(super) fn special_member_kind(&self) -> Option<SpecialMemberKind> {
         self.string_if_present("special_member")
-    }
-
-    /// Whether this is a move constructor.
-    pub(super) fn is_move_constructor(&self) -> bool {
-        self.get_bindgen_special_member_annotation()
-            .map_or(false, |val| val == "move_ctor")
+            .map(|kind| match kind.as_str() {
+                "default_ctor" => SpecialMemberKind::DefaultConstructor,
+                "copy_ctor" => SpecialMemberKind::CopyConstructor,
+                "move_ctor" => SpecialMemberKind::MoveConstructor,
+                "dtor" => SpecialMemberKind::Destructor,
+                _ => panic!("unexpected special_member_kind"),
+            })
     }
 
     /// Any reference parameters or return values.

--- a/engine/src/conversion/parse/bindgen_semantic_attributes.rs
+++ b/engine/src/conversion/parse/bindgen_semantic_attributes.rs
@@ -37,7 +37,7 @@ impl BindgenSemanticAttributes {
     // item can't be processed.
     pub(crate) fn new_retaining_others(attrs: &mut Vec<Attribute>) -> Self {
         let metadata = Self::new(attrs);
-        attrs.retain(|a| !(a.path.segments.last().unwrap().ident == "cpp_semantics"));
+        attrs.retain(|a| a.path.segments.last().unwrap().ident != "cpp_semantics");
         metadata
     }
 

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -83,13 +83,14 @@ impl ParseForeignMod {
                     vis: item.vis,
                     virtualness: annotations.get_virtualness(),
                     cpp_vis: annotations.get_cpp_visibility(),
-                    is_move_constructor: annotations.is_move_constructor(),
+                    special_member: annotations.special_member_kind(),
                     unused_template_param: annotations
                         .has_attr("unused_template_param_in_arg_or_return"),
                     references: annotations.get_reference_parameters_and_return(),
                     original_name: annotations.get_original_name(),
                     synthesized_this_type: None,
                     synthesis: None,
+                    is_deleted: annotations.has_attr("deleted"),
                 });
                 Ok(())
             }
@@ -113,13 +114,9 @@ impl ParseForeignMod {
         };
         for i in imp.items {
             if let ImplItem::Method(itm) = i {
-                let effective_fun_name = if itm.sig.ident == "new" {
-                    ty_id.clone()
-                } else {
-                    match get_called_function(&itm.block) {
-                        Some(id) => id.clone(),
-                        None => itm.sig.ident,
-                    }
+                let effective_fun_name = match get_called_function(&itm.block) {
+                    Some(id) => id.clone(),
+                    None => itm.sig.ident,
                 };
                 self.method_receivers.insert(
                     effective_fun_name,

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -4897,7 +4897,6 @@ fn test_issue_490() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/489
 fn test_immovable_object() {
     let hdr = indoc! {"
         class A {
@@ -4914,6 +4913,27 @@ fn test_immovable_object() {
     "};
     let rs = quote! {};
     run_test("", hdr, rs, &["A", "B"], &[]);
+}
+
+#[test]
+fn test_immovable_nested_object() {
+    let hdr = indoc! {"
+        struct C {
+            class A {
+            public:
+                A();
+                A(A&&) = delete;
+            };
+
+            class B{
+            public:
+                B();
+                B(const B&) = delete;
+            };
+        };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["C_A", "C_B"], &[]);
 }
 
 #[test]


### PR DESCRIPTION
This works but it turns out we need to do the same for copy constructors.
It's also a bit messy thus far.

Work towards #489.
