### PR TITLE
Two fns for subclass constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ autocxx-engine = { path="engine", version="0.15.0" } # so that
   # we can refer to autocxx_engine::cxx. But even that isn't sufficient...
 cxx = "1.0.54" # ... also needed because expansion of type_id refers to ::cxx
 aquamarine = "0.1" # docs
-moveit = "0.3"
+#moveit = "0.3"
+moveit = { git = "https://github.com/adetaylor/moveit", branch = "cxx-support", features=["cxx"] }
 
 [workspace]
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce", "integration-tests"]
@@ -44,3 +45,4 @@ exclude = ["examples/s2", "examples/steam-mini", "examples/subclass", "examples/
 #cxx = { path="../cxx" }
 #cxx-gen = { path="../cxx/gen/lib" }
 #autocxx-bindgen = { path="../bindgen" }
+#moveit = { path="../moveit" }

--- a/engine/src/conversion/analysis/abstract_types.rs
+++ b/engine/src/conversion/analysis/abstract_types.rs
@@ -84,7 +84,7 @@ pub(crate) fn mark_types_abstract(
         Api::Function {
             analysis:
                 FnAnalysis {
-                    kind: FnKind::Method(self_ty, MethodKind::MakeUnique | MethodKind::Constructor),
+                    kind: FnKind::Method(self_ty, MethodKind::Constructor),
                     ..
                 },
                 ..

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -53,14 +53,14 @@ fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<Pod
             get_alloc_name(&ty_name),
             Punctuated::new(),
             alloc_return,
-            CppFunctionBody::AllocUninitialized(ty_name.to_cpp_name()),
+            CppFunctionBody::AllocUninitialized(ty_name.clone()),
         ),
         (
             TraitSynthesis::FreeUninitialized(ty_name.clone()),
             get_free_name(&ty_name),
             free_inputs,
             ReturnType::Default,
-            CppFunctionBody::FreeUninitialized(ty_name.to_cpp_name()),
+            CppFunctionBody::FreeUninitialized(ty_name.clone()),
         ),
     ]
     .into_iter()

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -91,6 +91,7 @@ fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<Pod
                     synthetic_cpp: Some((cpp_function_body, CppFunctionKind::Function)),
                     add_to_trait: Some(synthesis),
                     is_deleted: false,
+                    cpp_only: false,
                 }),
                 analysis: (),
             }

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -76,7 +76,7 @@ fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<Pod
                 name_for_gc: None,
                 fun: Box::new(FuncToConvert {
                     ident,
-                    doc_attr: None, // TODO consider filling in
+                    doc_attr: None,
                     inputs,
                     output,
                     vis: parse_quote! { pub },
@@ -91,6 +91,7 @@ fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<Pod
                     synthetic_cpp: Some((cpp_function_body, CppFunctionKind::Function)),
                     add_to_trait: Some(synthesis),
                     is_deleted: false,
+                    is_subclass_constructor: None,
                 }),
                 analysis: (),
             }

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -91,7 +91,6 @@ fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<Pod
                     synthetic_cpp: Some((cpp_function_body, CppFunctionKind::Function)),
                     add_to_trait: Some(synthesis),
                     is_deleted: false,
-                    is_subclass_constructor: None,
                 }),
                 analysis: (),
             }

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -34,6 +34,10 @@ pub(crate) fn create_alloc_and_frees(apis: Vec<Api<PodPhase>>) -> Vec<Api<PodPha
                 .chain(std::iter::once(api))
                 .collect_vec()
                 .into_iter(),
+            Api::Subclass { name, .. } => create_alloc_and_free(name.cpp())
+                .chain(std::iter::once(api))
+                .collect_vec()
+                .into_iter(),
             _ => vec![api].into_iter(),
         })
         .collect()

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -1,0 +1,110 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Code to create functions to alloc and free while unitialized.
+
+use itertools::Itertools;
+use syn::{parse_quote, punctuated::Punctuated, token::Comma, FnArg, ReturnType};
+
+use crate::{
+    conversion::api::{Api, ApiName, CppVisibility, FuncToConvert, References, TraitSynthesis},
+    types::{make_ident, QualifiedName},
+};
+
+use super::{
+    fun::function_wrapper::{CppFunctionBody, CppFunctionKind},
+    pod::PodPhase,
+};
+
+pub(crate) fn create_alloc_and_frees(apis: Vec<Api<PodPhase>>) -> Vec<Api<PodPhase>> {
+    apis.into_iter()
+        .flat_map(|api| match &api {
+            Api::Struct { name, .. } => create_alloc_and_free(name.name.clone())
+                .chain(std::iter::once(api))
+                .collect_vec()
+                .into_iter(),
+            _ => vec![api].into_iter(),
+        })
+        .collect()
+}
+
+fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<PodPhase>> {
+    let typ = ty_name.to_type_path();
+    let free_inputs: Punctuated<FnArg, Comma> = parse_quote! {
+        arg0: *mut #typ
+    };
+    let alloc_return: ReturnType = parse_quote! {
+        -> *mut #typ
+    };
+    [
+        (
+            TraitSynthesis::AllocUninitialized(ty_name.clone()),
+            get_alloc_name(&ty_name),
+            Punctuated::new(),
+            alloc_return,
+            CppFunctionBody::AllocUninitialized(ty_name.to_cpp_name()),
+        ),
+        (
+            TraitSynthesis::FreeUninitialized(ty_name.clone()),
+            get_free_name(&ty_name),
+            free_inputs,
+            ReturnType::Default,
+            CppFunctionBody::FreeUninitialized(ty_name.to_cpp_name()),
+        ),
+    ]
+    .into_iter()
+    .map(
+        move |(synthesis, name, inputs, output, cpp_function_body)| {
+            let ident = name.get_final_ident();
+            let api_name = ApiName::new_from_qualified_name(name);
+            Api::Function {
+                name: api_name,
+                name_for_gc: None,
+                fun: Box::new(FuncToConvert {
+                    ident,
+                    doc_attr: None, // TODO consider filling in
+                    inputs,
+                    output,
+                    vis: parse_quote! { pub },
+                    virtualness: crate::conversion::api::Virtualness::None,
+                    cpp_vis: CppVisibility::Public,
+                    special_member: None,
+                    unused_template_param: false,
+                    references: References::default(),
+                    original_name: None,
+                    self_ty: None,
+                    synthesized_this_type: None,
+                    synthetic_cpp: Some((cpp_function_body, CppFunctionKind::Function)),
+                    add_to_trait: Some(synthesis),
+                    is_deleted: false,
+                }),
+                analysis: (),
+            }
+        },
+    )
+}
+
+pub(crate) fn get_alloc_name(ty_name: &QualifiedName) -> QualifiedName {
+    get_name(ty_name, "alloc")
+}
+
+pub(crate) fn get_free_name(ty_name: &QualifiedName) -> QualifiedName {
+    get_name(ty_name, "free")
+}
+
+fn get_name(ty_name: &QualifiedName, label: &str) -> QualifiedName {
+    let name = format!("{}_{}", ty_name.get_final_item(), label);
+    let name_id = make_ident(name);
+    QualifiedName::new(ty_name.get_namespace(), name_id)
+}

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -124,6 +124,7 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             }),
             synthetic_cpp: Some((CppFunctionBody::Cast, CppFunctionKind::Function)),
             is_deleted: false,
+            cpp_only: false,
         }),
         analysis: (),
     }

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -124,6 +124,7 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             }),
             synthetic_cpp: Some((CppFunctionBody::Cast, CppFunctionKind::Function)),
             is_deleted: false,
+            is_subclass_constructor: None,
         }),
         analysis: (),
     }

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -124,7 +124,6 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             }),
             synthetic_cpp: Some((CppFunctionBody::Cast, CppFunctionKind::Function)),
             is_deleted: false,
-            is_subclass_constructor: None,
         }),
         analysis: (),
     }

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -17,7 +17,7 @@ use quote::quote;
 use syn::{parse_quote, FnArg};
 
 use crate::{
-    conversion::api::{Api, ApiName, CastMutability, References, Synthesis},
+    conversion::api::{Api, ApiName, CastMutability, References, TraitSynthesis},
     types::{make_ident, QualifiedName},
 };
 
@@ -28,7 +28,10 @@ use crate::{
 /// But the related code may be useful in future so I'm keeping it around.
 const SUPPORT_MUTABLE_CASTS: bool = false;
 
-use super::pod::{PodAnalysis, PodPhase};
+use super::{
+    fun::function_wrapper::{CppFunctionBody, CppFunctionKind},
+    pod::{PodAnalysis, PodPhase},
+};
 
 pub(crate) fn add_casts(apis: Vec<Api<PodPhase>>) -> Vec<Api<PodPhase>> {
     apis.into_iter()
@@ -115,10 +118,11 @@ fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability
             original_name: None,
             self_ty: Some(from.clone()),
             synthesized_this_type: None,
-            synthesis: Some(Synthesis::Cast {
+            add_to_trait: Some(TraitSynthesis::Cast {
                 to_type: to.clone(),
                 mutable,
             }),
+            synthetic_cpp: Some((CppFunctionBody::Cast, CppFunctionKind::Function)),
             is_deleted: false,
         }),
         analysis: (),

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -146,8 +146,8 @@ pub(crate) enum CppFunctionBody {
     PlacementNew(Namespace, Ident),
     ConstructSuperclass(String),
     Cast,
-    AllocUninitialized(String),
-    FreeUninitialized(String),
+    AllocUninitialized(QualifiedName),
+    FreeUninitialized(QualifiedName),
 }
 
 #[derive(Clone)]

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -140,18 +140,17 @@ impl TypeConversionPolicy {
 }
 
 #[derive(Clone)]
-
 pub(crate) enum CppFunctionBody {
     FunctionCall(Namespace, Ident),
     StaticMethodCall(Namespace, Ident, Ident),
     PlacementNew(Namespace, Ident),
-    MakeUnique,
     ConstructSuperclass(String),
     Cast,
+    AllocUninitialized(String),
+    FreeUninitialized(String),
 }
 
 #[derive(Clone)]
-
 pub(crate) enum CppFunctionKind {
     Function,
     Method,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -335,11 +335,12 @@ impl<'a> FnAnalyzer<'a> {
         // Consider whether we need to synthesize subclass items.
         match &analysis.kind {
             FnKind::Method(sup, MethodKind::Constructor) => {
-                for sub in self.subclasses_by_superclass(sup) {
+                for (subclass_constructor_func, subclass_constructor_name) in self
+                    .subclasses_by_superclass(sup)
+                    .flat_map(|sub| create_subclass_constructor(sub, sup, &fun))
+                {
                     // Create a subclass constructor. This is a synthesized function
                     // which didn't exist in the original C++.
-                    let (subclass_constructor_func, subclass_constructor_name) =
-                        create_subclass_constructor(sub, &analysis, sup, &fun);
                     self.analyze_and_add_if_necessary(
                         subclass_constructor_name.clone(),
                         subclass_constructor_func.clone(),
@@ -1222,7 +1223,6 @@ impl<'a> FnAnalyzer<'a> {
                         add_to_trait: None,
                         is_deleted: false,
                         synthetic_cpp: None,
-                        is_subclass_constructor: None,
                     }),
                 )
             });

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -949,7 +949,6 @@ impl<'a> FnAnalyzer<'a> {
                 "free_uninitialized_cpp_storage",
                 false,
             ),
-            _ => None,
         })
     }
 
@@ -1223,6 +1222,7 @@ impl<'a> FnAnalyzer<'a> {
                         add_to_trait: None,
                         is_deleted: false,
                         synthetic_cpp: None,
+                        is_subclass_constructor: None,
                     }),
                 )
             });

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1223,6 +1223,7 @@ impl<'a> FnAnalyzer<'a> {
                         add_to_trait: None,
                         is_deleted: false,
                         synthetic_cpp: None,
+                        cpp_only: false,
                     }),
                 )
             });

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -168,6 +168,7 @@ pub(super) fn create_subclass_constructor(
     let mut actual_constructor = fun.clone();
     actual_constructor.inputs = existing_params.clone();
     actual_constructor.ident = sub.cpp().get_final_ident();
+    actual_constructor.synthesized_this_type = Some(sub.cpp());
     actual_constructor.self_ty = Some(sub.cpp());
     actual_constructor.synthetic_cpp = Some((
         CppFunctionBody::ConstructSuperclass(sup.to_cpp_name()),

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -72,6 +72,7 @@ pub(super) fn create_subclass_fn_wrapper(
         add_to_trait: fun.add_to_trait.clone(),
         is_deleted: fun.is_deleted,
         synthetic_cpp: None,
+        cpp_only: false,
     })
 }
 
@@ -187,6 +188,7 @@ pub(super) fn create_subclass_constructor(
         CppFunctionKind::SynthesizedConstructor,
     ));
     actual_constructor.original_name = Some(cpp.get_final_item().to_string());
+    actual_constructor.cpp_only = true;
 
     // Second, the API which bridges Rust and C++ to call this constructor.
 
@@ -210,6 +212,7 @@ pub(super) fn create_subclass_constructor(
         add_to_trait: None,
         is_deleted: fun.is_deleted,
         synthetic_cpp: None,
+        cpp_only: false,
     });
     let wrapper_name = ApiName::new_with_cpp_name(
         &Namespace::new(),

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -19,7 +19,7 @@ use syn::{parse_quote, FnArg, PatType, Type, TypePtr};
 use crate::conversion::analysis::fun::{FnKind, MethodKind, ReceiverMutability};
 use crate::conversion::analysis::pod::PodPhase;
 use crate::conversion::api::{
-    CppVisibility, FuncToConvert, RustSubclassFnDetails, SubclassName, Synthesis, Virtualness,
+    CppVisibility, FuncToConvert, RustSubclassFnDetails, SubclassName, TraitSynthesis, Virtualness,
 };
 use crate::{
     conversion::{
@@ -69,8 +69,9 @@ pub(super) fn create_subclass_fn_wrapper(
         unused_template_param: fun.unused_template_param,
         original_name: None,
         references: fun.references.clone(),
-        synthesis: fun.synthesis.clone(),
+        add_to_trait: fun.add_to_trait.clone(),
         is_deleted: fun.is_deleted,
+        synthetic_cpp: None,
     })
 }
 
@@ -164,7 +165,7 @@ pub(super) fn create_subclass_constructor(
             qualification: Some(cpp.clone()),
             original_cpp_name: cpp.to_cpp_name(),
         };
-        Synthesis::SubclassConstructor {
+        TraitSynthesis::SubclassConstructor {
             subclass: sub.clone(),
             cpp_impl: Box::new(cpp_impl),
             is_trivial: analysis.param_details.len() == 1, // just placement new
@@ -208,8 +209,9 @@ pub(super) fn create_subclass_constructor(
         references: fun.references.clone(),
         synthesized_this_type: Some(cpp.clone()),
         self_ty: Some(cpp),
-        synthesis,
+        add_to_trait: synthesis,
         is_deleted: fun.is_deleted,
+        synthetic_cpp: fun.synthetic_cpp.clone(),
     });
     let subclass_constructor_name = ApiName::new_with_cpp_name(
         &Namespace::new(),

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -19,7 +19,8 @@ use syn::{parse_quote, FnArg, PatType, Type, TypePtr};
 use crate::conversion::analysis::fun::{FnKind, MethodKind, ReceiverMutability};
 use crate::conversion::analysis::pod::PodPhase;
 use crate::conversion::api::{
-    CppVisibility, FuncToConvert, RustSubclassFnDetails, SubclassName, TraitSynthesis, Virtualness,
+    CppVisibility, FuncToConvert, RustSubclassFnDetails, SubclassConstructorDetails, SubclassName,
+    Virtualness,
 };
 use crate::{
     conversion::{
@@ -72,6 +73,7 @@ pub(super) fn create_subclass_fn_wrapper(
         add_to_trait: fun.add_to_trait.clone(),
         is_deleted: fun.is_deleted,
         synthetic_cpp: None,
+        is_subclass_constructor: None,
     })
 }
 
@@ -143,36 +145,33 @@ pub(super) fn create_subclass_constructor(
 ) -> (Box<FuncToConvert>, ApiName) {
     let holder = sub.holder();
     let cpp = sub.cpp();
-    let synthesis = Some({
-        let wrapper_function_name = cpp.get_final_ident();
-        let initial_arg = TypeConversionPolicy::new_unconverted(parse_quote! {
-            rust::Box< #holder >
-        });
-        let args = std::iter::once(initial_arg).chain(
-            analysis
-                .param_details
-                .iter()
-                .skip(1) // skip placement new destination
-                .map(|aa| aa.conversion.clone()),
-        );
-        let cpp_impl = CppFunction {
-            payload: CppFunctionBody::ConstructSuperclass(sup.to_cpp_name()),
-            wrapper_function_name,
-            return_conversion: None,
-            argument_conversion: args.collect(),
-            kind: CppFunctionKind::SynthesizedConstructor,
-            pass_obs_field: false,
-            qualification: Some(cpp.clone()),
-            original_cpp_name: cpp.to_cpp_name(),
-        };
-        TraitSynthesis::SubclassConstructor {
-            subclass: sub.clone(),
-            cpp_impl: Box::new(cpp_impl),
-            is_trivial: analysis.param_details.len() == 1, // just placement new
-                                                           // destination, no other parameters
-        }
+    let wrapper_function_name = cpp.get_final_ident();
+    let initial_arg = TypeConversionPolicy::new_unconverted(parse_quote! {
+        rust::Box< #holder >
     });
-
+    let args = std::iter::once(initial_arg).chain(
+        analysis
+            .param_details
+            .iter()
+            .skip(1) // skip placement new destination
+            .map(|aa| aa.conversion.clone()),
+    );
+    let cpp_impl = CppFunction {
+        payload: CppFunctionBody::ConstructSuperclass(sup.to_cpp_name()),
+        wrapper_function_name,
+        return_conversion: None,
+        argument_conversion: args.collect(),
+        kind: CppFunctionKind::SynthesizedConstructor,
+        pass_obs_field: false,
+        qualification: Some(cpp.clone()),
+        original_cpp_name: cpp.to_cpp_name(),
+    };
+    let is_subclass_constructor = Some(SubclassConstructorDetails {
+        subclass: sub.clone(),
+        is_trivial: analysis.param_details.len() == 1, // just placement new
+        // destination, no other parameters
+        cpp_impl,
+    });
     let subclass_constructor_name =
         make_ident(format!("{}_{}", cpp.get_final_item(), cpp.get_final_item()));
     let mut existing_params = fun.inputs.clone();
@@ -209,9 +208,10 @@ pub(super) fn create_subclass_constructor(
         references: fun.references.clone(),
         synthesized_this_type: Some(cpp.clone()),
         self_ty: Some(cpp),
-        add_to_trait: synthesis,
+        add_to_trait: None,
         is_deleted: fun.is_deleted,
-        synthetic_cpp: fun.synthetic_cpp.clone(),
+        synthetic_cpp: None,
+        is_subclass_constructor,
     });
     let subclass_constructor_name = ApiName::new_with_cpp_name(
         &Namespace::new(),

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -23,15 +23,13 @@ use crate::conversion::api::{
 };
 use crate::{
     conversion::{
-        analysis::fun::function_wrapper::{
-            CppFunction, CppFunctionBody, CppFunctionKind,
-        },
+        analysis::fun::function_wrapper::{CppFunction, CppFunctionBody, CppFunctionKind},
         api::{Api, ApiName},
     },
     types::{make_ident, Namespace, QualifiedName},
 };
 
-use super::{FnPhase};
+use super::FnPhase;
 
 pub(super) fn subclasses_by_superclass(
     apis: &[Api<PodPhase>],

--- a/engine/src/conversion/analysis/mod.rs
+++ b/engine/src/conversion/analysis/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) mod abstract_types;
+pub(crate) mod allocators;
 pub(crate) mod casts;
 pub(crate) mod ctypes;
 pub(crate) mod fun;

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -215,6 +215,11 @@ pub(crate) struct FuncToConvert {
     /// C++ and instead we're synthesizing it.
     pub(crate) synthetic_cpp: Option<(CppFunctionBody, CppFunctionKind)>,
     pub(crate) is_deleted: bool,
+    /// This function is created purely in C++ and should not be mentioned
+    /// in the cxx::bridge or in the Rust code. This is sometimes needed
+    /// where a single Rust API requires instantiation of two or more C++
+    /// functions, e.g. a constructor and code to call that constructor.
+    pub(crate) cpp_only: bool,
 }
 
 /// Layers of analysis which may be applied to decorate each API.

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -104,17 +104,23 @@ pub(crate) enum CastMutability {
 /// be a trait implementation rather than a method or free function.
 #[derive(Clone)]
 pub(crate) enum TraitSynthesis {
-    SubclassConstructor {
-        subclass: SubclassName,
-        cpp_impl: Box<CppFunction>,
-        is_trivial: bool,
-    },
     Cast {
         to_type: QualifiedName,
         mutable: CastMutability,
     },
     AllocUninitialized(QualifiedName),
     FreeUninitialized(QualifiedName),
+}
+
+/// Details of a subclass constructor.
+/// TODO: zap this; replace with an extra API.
+#[derive(Clone)]
+pub(crate) struct SubclassConstructorDetails {
+    pub(crate) subclass: SubclassName,
+    pub(crate) is_trivial: bool,
+    /// Implementation of the constructor _itself_ as distinct
+    /// from any wrapper function we create to call it.
+    pub(crate) cpp_impl: CppFunction,
 }
 
 /// Information about references (as opposed to pointers) to be found
@@ -220,6 +226,7 @@ pub(crate) struct FuncToConvert {
     /// C++ and instead we're synthesizing it.
     pub(crate) synthetic_cpp: Option<(CppFunctionBody, CppFunctionKind)>,
     pub(crate) is_deleted: bool,
+    pub(crate) is_subclass_constructor: Option<SubclassConstructorDetails>,
 }
 
 /// Layers of analysis which may be applied to decorate each API.

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -112,17 +112,6 @@ pub(crate) enum TraitSynthesis {
     FreeUninitialized(QualifiedName),
 }
 
-/// Details of a subclass constructor.
-/// TODO: zap this; replace with an extra API.
-#[derive(Clone)]
-pub(crate) struct SubclassConstructorDetails {
-    pub(crate) subclass: SubclassName,
-    pub(crate) is_trivial: bool,
-    /// Implementation of the constructor _itself_ as distinct
-    /// from any wrapper function we create to call it.
-    pub(crate) cpp_impl: CppFunction,
-}
-
 /// Information about references (as opposed to pointers) to be found
 /// within the function signature. This is derived from bindgen annotations
 /// which is why it's not within `FuncToConvert::inputs`
@@ -226,7 +215,6 @@ pub(crate) struct FuncToConvert {
     /// C++ and instead we're synthesizing it.
     pub(crate) synthetic_cpp: Option<(CppFunctionBody, CppFunctionKind)>,
     pub(crate) is_deleted: bool,
-    pub(crate) is_subclass_constructor: Option<SubclassConstructorDetails>,
 }
 
 /// Layers of analysis which may be applied to decorate each API.
@@ -329,6 +317,12 @@ impl SubclassName {
     /// Generate the name for the 'Cpp' type
     pub(crate) fn cpp(&self) -> QualifiedName {
         let id = self.with_suffix("Cpp");
+        QualifiedName::new(self.0.name.get_namespace(), id)
+    }
+    /// Generate the name for the function representing the
+    /// synthesized constructor
+    pub(crate) fn synthesized_constructor(&self) -> QualifiedName {
+        let id = self.with_suffix("Cpp_synthesized_constructor");
         QualifiedName::new(self.0.name.get_namespace(), id)
     }
     pub(crate) fn cpp_remove_ownership(&self) -> Ident {

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -32,7 +32,7 @@ use super::{
         function_wrapper::{CppFunction, CppFunctionBody},
         FnPhase,
     },
-    api::{Api, SubclassName, TraitSynthesis},
+    api::{Api, SubclassConstructorDetails, SubclassName},
     ConvertError,
 };
 
@@ -158,9 +158,9 @@ impl<'a> CppCodeGenerator<'a> {
                     fun,
                     ..
                 } => {
-                    if let Some(TraitSynthesis::SubclassConstructor {
+                    if let Some(SubclassConstructorDetails {
                         subclass, cpp_impl, ..
-                    }) = &fun.add_to_trait
+                    }) = &fun.is_subclass_constructor
                     {
                         constructors_by_subclass
                             .entry(subclass.clone())

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -419,8 +419,7 @@ impl<'a> CppCodeGenerator<'a> {
             CppFunctionBody::Cast => (arg_list, "".to_string()),
             CppFunctionBody::PlacementNew(ns, id) => {
                 let ty_id = QualifiedName::new(ns, id.clone());
-                let ty_id =
-                    namespaced_name_using_original_name_map(&ty_id, &self.original_name_map);
+                let ty_id = self.namespaced_name(&ty_id);
                 (
                     format!("new ({}) {}({})", receiver.unwrap(), ty_id, arg_list),
                     "".to_string(),
@@ -453,11 +452,14 @@ impl<'a> CppCodeGenerator<'a> {
             }
             CppFunctionBody::ConstructSuperclass(_) => ("".to_string(), arg_list),
             CppFunctionBody::AllocUninitialized(ty) => (
-                format!("std::allocator<{}>().allocate(1)", ty),
+                format!("std::allocator<{}>().allocate(1)", self.namespaced_name(ty)),
                 "".to_string(),
             ),
             CppFunctionBody::FreeUninitialized(ty) => (
-                format!("std::allocator<{}>().deallocate(arg0, 1)", ty),
+                format!(
+                    "std::allocator<{}>().deallocate(arg0, 1)",
+                    self.namespaced_name(ty)
+                ),
                 "".to_string(),
             ),
         };
@@ -516,6 +518,10 @@ impl<'a> CppCodeGenerator<'a> {
             headers: vec![Header::System("memory")],
             cpp_headers: Vec::new(),
         })
+    }
+
+    fn namespaced_name(&self, name: &QualifiedName) -> String {
+        namespaced_name_using_original_name_map(name, &self.original_name_map)
     }
 
     fn generate_ctype_typedef(&mut self, tn: &QualifiedName) {

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -62,7 +62,7 @@ pub(super) fn gen_function(
     analysis: FnAnalysis,
     cpp_call_name: String,
 ) -> RsCodegenResult {
-    if !analysis.generate_code {
+    if !analysis.generate_code || fun.cpp_only {
         return RsCodegenResult::default();
     }
     let cxxbridge_name = analysis.cxxbridge_name;

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -86,35 +86,32 @@ impl Eq for TraitDetails {}
 
 impl PartialEq for TraitDetails {
     fn eq(&self, other: &Self) -> bool {
-        let unsafety_a = &self.unsafety;
-        let unsafety_b = &other.unsafety;
-        self.ty.to_token_stream().to_string() == other.ty.to_token_stream().to_string()
-            && self.trt.to_token_stream().to_string() == other.trt.to_token_stream().to_string()
-            && quote! { #unsafety_a }.to_string() == quote! { #unsafety_b }.to_string()
-            && self
-                .lifetime_tokens
-                .as_ref()
-                .unwrap_or(&TokenStream::new())
-                .to_string()
-                == other
-                    .lifetime_tokens
-                    .as_ref()
-                    .unwrap_or(&TokenStream::new())
-                    .to_string()
+        totokens_equal(&self.unsafety, &other.unsafety)
+            && totokens_equal(&self.ty, &other.ty)
+            && totokens_equal(&self.trt, &other.trt)
+            && totokens_equal(&self.lifetime_tokens, &other.lifetime_tokens)
     }
+}
+
+fn totokens_to_string<T: ToTokens>(a: &T) -> String {
+    a.to_token_stream().to_string()
+}
+
+fn totokens_equal<T: ToTokens>(a: &T, b: &T) -> bool {
+    totokens_to_string(a) == totokens_to_string(b)
+}
+
+fn hash_totokens<T: ToTokens, H: std::hash::Hasher>(a: &T, state: &mut H) {
+    use std::hash::Hash;
+    totokens_to_string(a).hash(state)
 }
 
 impl std::hash::Hash for TraitDetails {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.ty.to_token_stream().to_string().hash(state);
-        self.trt.to_token_stream().to_string().hash(state);
-        let unsafety = &self.unsafety;
-        quote! { #unsafety }.to_string().hash(state);
-        self.lifetime_tokens
-            .as_ref()
-            .unwrap_or(&TokenStream::new())
-            .to_string()
-            .hash(state);
+        hash_totokens(&self.ty, state);
+        hash_totokens(&self.trt, state);
+        hash_totokens(&self.unsafety, state);
+        hash_totokens(&self.lifetime_tokens, state);
     }
 }
 

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -51,7 +51,7 @@ use self::{
 
 use super::{
     analysis::fun::{FnAnalysis, FnKind},
-    api::{Layout, RustSubclassFnDetails, TraitDetails, TraitSynthesis},
+    api::{Layout, RustSubclassFnDetails, SubclassConstructorDetails, TraitDetails},
     codegen_cpp::type_to_cpp::{
         namespaced_name_using_original_name_map, original_name_map_from_apis, CppNameMap,
     },
@@ -1136,8 +1136,8 @@ fn find_trivially_constructed_subclasses(apis: &[Api<FnPhase>]) -> HashSet<Quali
     let (simple_constructors, complex_constructors): (Vec<_>, Vec<_>) = apis
         .iter()
         .filter_map(|api| match api {
-            Api::Function { fun, .. } => match &fun.add_to_trait {
-                Some(TraitSynthesis::SubclassConstructor {
+            Api::Function { fun, .. } => match &fun.is_subclass_constructor {
+                Some(SubclassConstructorDetails {
                     subclass,
                     is_trivial,
                     ..

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -35,9 +35,10 @@ use crate::{CppCodegenOptions, CppFilePair, UnsafePolicy};
 
 use self::{
     analysis::{
-        abstract_types::mark_types_abstract, casts::add_casts, check_names, fun::FnPhase,
-        gc::filter_apis_by_following_edges_from_allowlist, pod::analyze_pod_apis,
-        remove_ignored::filter_apis_by_ignored_dependents, tdef::convert_typedef_targets,
+        abstract_types::mark_types_abstract, allocators::create_alloc_and_frees, casts::add_casts,
+        check_names, fun::FnPhase, gc::filter_apis_by_following_edges_from_allowlist,
+        pod::analyze_pod_apis, remove_ignored::filter_apis_by_ignored_dependents,
+        tdef::convert_typedef_targets,
     },
     api::{AnalysisPhase, Api},
     codegen_rs::RsCodeGenerator,
@@ -135,6 +136,7 @@ impl<'a> BridgeConverter<'a> {
                 // by subsequent phases to work out which objects are POD.
                 let analyzed_apis = analyze_pod_apis(apis, self.config)?;
                 let analyzed_apis = add_casts(analyzed_apis);
+                let analyzed_apis = create_alloc_and_frees(analyzed_apis);
                 // Next, figure out how we materialize different functions.
                 // Some will be simple entries in the cxx::bridge module; others will
                 // require C++ wrapper functions. This is probably the most complex

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -92,6 +92,7 @@ impl ParseForeignMod {
                     add_to_trait: None,
                     is_deleted: annotations.has_attr("deleted"),
                     synthetic_cpp: None,
+                    is_subclass_constructor: None,
                 });
                 Ok(())
             }

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -92,6 +92,7 @@ impl ParseForeignMod {
                     add_to_trait: None,
                     is_deleted: annotations.has_attr("deleted"),
                     synthetic_cpp: None,
+                    cpp_only: false,
                 });
                 Ok(())
             }

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -92,7 +92,6 @@ impl ParseForeignMod {
                     add_to_trait: None,
                     is_deleted: annotations.has_attr("deleted"),
                     synthetic_cpp: None,
-                    is_subclass_constructor: None,
                 });
                 Ok(())
             }

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -89,8 +89,9 @@ impl ParseForeignMod {
                     references: annotations.get_reference_parameters_and_return(),
                     original_name: annotations.get_original_name(),
                     synthesized_this_type: None,
-                    synthesis: None,
+                    add_to_trait: None,
                     is_deleted: annotations.has_attr("deleted"),
+                    synthetic_cpp: None,
                 });
                 Ok(())
             }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -15,10 +15,14 @@
 use autocxx_parser::{IncludeCpp, SubclassAttrs};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
-use proc_macro_error::{abort, proc_macro_error};
-use quote::quote;
+use proc_macro_error::{abort, abort_call_site, proc_macro_error};
+use quote::{quote, ToTokens};
 use syn::parse::Parser;
-use syn::{parse_macro_input, parse_quote, Fields, Item, ItemStruct, Visibility};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{
+    parse_macro_input, parse_quote, Expr, Fields, FnArg, Item, ItemFn, ItemStruct, Visibility,
+};
 
 /// Implementation of the `include_cpp` macro. See documentation for `autocxx` crate.
 #[proc_macro_error]
@@ -132,4 +136,47 @@ pub fn cpp_semantics(_attr: TokenStream, _input: TokenStream) -> TokenStream {
         This code is the output from the autocxx-specific version of bindgen, \n\
         and should be interpreted by autocxx-engine before further usage."
     );
+}
+
+/// Derive a `make_unique` method for any constructor which implements `New`
+/// and `UniquePtrTarget`.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn derive_make_unique(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    // Expect to parse:
+    // pub fn new() -> impl autocxx::moveit::new::New<Output = Self> {
+    // Need
+    // pub fn make_unique() -> impl autocxx::cxx::UniquePtr<Self>
+    let mut input: proc_macro2::TokenStream = input.into();
+    let mut extra_fn: ItemFn =
+        syn::parse2(input.clone()).unwrap_or_else(|_| abort_call_site!("Expected function"));
+    let orig_ident = extra_fn.sig.ident;
+    let name = orig_ident.to_string().replace("new", "make_unique");
+    extra_fn.sig.output = parse_quote! {
+        -> autocxx::cxx::UniquePtr<Self>
+    };
+    extra_fn.sig.ident = Ident::new(&name, orig_ident.span());
+    let arg_list = args_from_sig(&extra_fn.sig.inputs);
+    extra_fn.block = parse_quote! {
+        {
+            use autocxx::moveit::EmplaceUnpinned;
+            autocxx::cxx::UniquePtr::emplace(Self::#orig_ident(#(#arg_list),*))
+        }
+    };
+    extra_fn.to_tokens(&mut input);
+    input.into()
+}
+
+fn args_from_sig(params: &Punctuated<FnArg, Comma>) -> impl Iterator<Item = Expr> + '_ {
+    params.iter().filter_map(|fnarg| match fnarg {
+        syn::FnArg::Receiver(_) => None,
+        syn::FnArg::Typed(fnarg) => match &*fnarg.pat {
+            syn::Pat::Ident(id) => Some(id_to_expr(&id.ident)),
+            _ => None,
+        },
+    })
+}
+
+fn id_to_expr(id: &Ident) -> Expr {
+    parse_quote! { #id }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,6 +688,9 @@ pub use autocxx_macro::include_cpp_impl;
 #[doc(hidden)]
 pub use autocxx_macro::cpp_semantics;
 
+#[doc(hidden)]
+pub use autocxx_macro::derive_make_unique;
+
 macro_rules! ctype_wrapper {
     ($r:ident, $c:expr, $d:expr) => {
         #[doc=$d]
@@ -823,3 +826,6 @@ pub mod prelude {
 
 /// Re-export moveit for ease of consumers.
 pub use moveit;
+
+/// And cxx too...
+pub use cxx;


### PR DESCRIPTION
This attempts to remove the various layering violations with subclass constructors, where previously we were instantiating the results of the C++ analysis somewhere totally other than the C++ code generator.

It doesn't quite work yet because we end up with a constructor called `new1` instead of `new`.

Builds on top of #742.