### PR TITLE
Implement 'Drop' trait to call to C++ destructors.

### DIFF
--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -44,6 +44,7 @@ pub(crate) enum RustConversionType {
     ToBoxedUpHolder(SubclassName),
     FromPinMaybeUninitToPtr,
     FromPinMoveRefToPtr,
+    FromTypeToPtr,
 }
 
 impl RustConversionType {
@@ -137,6 +138,7 @@ pub(crate) enum CppFunctionBody {
     MakeUnique,
     ConstructSuperclass(String),
     Cast,
+    Destructor(Namespace, Ident),
 }
 
 #[derive(Clone)]

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -25,7 +25,9 @@ use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use type_to_cpp::{original_name_map_from_apis, type_to_cpp, CppNameMap};
 
-use self::type_to_cpp::namespaced_name_using_original_name_map;
+use self::type_to_cpp::{
+    identifier_using_original_name_map, namespaced_name_using_original_name_map,
+};
 
 use super::{
     analysis::fun::{
@@ -426,6 +428,11 @@ impl<'a> CppCodeGenerator<'a> {
                     format!("new ({}) {}({})", receiver.unwrap(), ty_id, arg_list),
                     "".to_string(),
                 )
+            }
+            CppFunctionBody::Destructor(ns, id) => {
+                let ty_id = QualifiedName::new(ns, id.clone());
+                let ty_id = identifier_using_original_name_map(&ty_id, &self.original_name_map);
+                (format!("{}->~{}()", arg_list, ty_id), "".to_string())
             }
             CppFunctionBody::FunctionCall(ns, id) => match receiver {
                 Some(receiver) => (format!("{}.{}({})", receiver, id, arg_list), "".to_string()),

--- a/engine/src/conversion/codegen_cpp/type_to_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/type_to_cpp.rs
@@ -52,6 +52,16 @@ pub(crate) fn namespaced_name_using_original_name_map(
     }
 }
 
+pub(crate) fn identifier_using_original_name_map(
+    qual_name: &QualifiedName,
+    original_name_map: &CppNameMap,
+) -> String {
+    original_name_map
+        .get(qual_name)
+        .cloned()
+        .unwrap_or_else(|| qual_name.get_final_cpp_item())
+}
+
 pub(crate) fn type_to_cpp(ty: &Type, cpp_name_map: &CppNameMap) -> Result<String, ConvertError> {
     match ty {
         Type::Path(typ) => {

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -109,7 +109,8 @@ pub(super) fn gen_function(
         .iter()
         .any(|pd| pd.conversion.rust_work_needed());
     let rust_wrapper_needed = any_param_needs_rust_conversion
-        || (cxxbridge_name != rust_name && matches!(kind, FnKind::Method(..)));
+        || (cxxbridge_name != rust_name && matches!(kind, FnKind::Method(..)))
+        || matches!(kind, FnKind::TraitMethod { .. });
     if rust_wrapper_needed {
         match kind {
             FnKind::Method(ref type_name, MethodKind::Constructor) => {

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -263,11 +263,23 @@ impl<'a> FnGenerator<'a> {
         let trait_unsafety = &details.trait_unsafety;
         let impl_for_specifics = &details.impl_for_specifics;
         let method_name = &details.method_name;
+        let call_body = quote! {
+            cxxbridge::#cxxbridge_name ( #(#arg_list),* )
+        };
+        let call_body = if details.trait_call_is_unsafe {
+            quote! {
+                unsafe {
+                    #call_body
+                }
+            }
+        } else {
+            call_body
+        };
         Some(Use::Custom(Box::new(parse_quote! {
             #trait_unsafety impl #lifetime_tokens #trait_signature for #impl_for_specifics {
                 #doc_attr
                 #unsafety fn #method_name ( #wrapper_params ) #ret_type {
-                    cxxbridge::#cxxbridge_name ( #(#arg_list),* )
+                    #call_body
                 }
             }
         })))

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -108,9 +108,11 @@ pub(super) fn gen_function(
     let any_param_needs_rust_conversion = param_details
         .iter()
         .any(|pd| pd.conversion.rust_work_needed());
-    let rust_wrapper_needed = any_param_needs_rust_conversion
-        || (cxxbridge_name != rust_name && matches!(kind, FnKind::Method(..)))
-        || matches!(kind, FnKind::TraitMethod { .. });
+    let rust_wrapper_needed = match kind {
+        FnKind::TraitMethod { .. } => true,
+        FnKind::Method(..) => any_param_needs_rust_conversion || cxxbridge_name != rust_name,
+        _ => any_param_needs_rust_conversion,
+    };
     if rust_wrapper_needed {
         match kind {
             FnKind::Method(ref type_name, MethodKind::Constructor) => {

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -50,6 +50,13 @@ impl TypeConversionPolicy {
                     std::pin::Pin<autocxx::moveit::MoveRef< '_, #ty >>
                 }
             }
+            RustConversionType::FromTypeToPtr => {
+                let ty = match &self.unwrapped_type {
+                    Type::Ptr(TypePtr { elem, .. }) => &*elem,
+                    _ => panic!("Not a ptr"),
+                };
+                parse_quote! { &mut #ty }
+            }
         }
     }
 
@@ -70,6 +77,9 @@ impl TypeConversionPolicy {
                 { let r: &mut _ = std::pin::Pin::into_inner_unchecked(#var.as_mut());
                 r
                 }
+            },
+            RustConversionType::FromTypeToPtr => quote! {
+                #var
             },
         }
     }

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -55,6 +55,7 @@ pub enum ConvertError {
     RValueParam,
     RValueReturn,
     PrivateMethod,
+    Destructor,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -102,6 +103,7 @@ impl Display for ConvertError {
             ConvertError::RValueParam => write!(f, "This function takes an rvalue reference parameter (&&) which is not yet supported.")?,
             ConvertError::RValueReturn => write!(f, "This function returns an rvalue reference (&&) which is not yet supported.")?,
             ConvertError::PrivateMethod => write!(f, "This method is private")?,
+            ConvertError::Destructor => write!(f, "autocxx does not yet generate bindings to destructors")?, // TODO must do for moveit!
         }
         Ok(())
     }

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -186,6 +186,14 @@ impl QualifiedName {
         }
     }
 
+    pub(crate) fn get_final_cpp_item(&self) -> String {
+        let special_cpp_name = known_types().special_cpp_name(self);
+        match special_cpp_name {
+            Some(name) => name,
+            None => self.1.to_string(),
+        }
+    }
+
     pub(crate) fn to_type_path(&self) -> TypePath {
         if let Some(known_type_path) = known_types().known_type_type_path(self) {
             known_type_path


### PR DESCRIPTION
Not needed for cxx::UniquePtr, but is needed for moveit!

Part of #379.
