### PR TITLE
Break circular dependency in casts.

### DIFF
--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -73,13 +73,6 @@ fn cast_types() -> impl Iterator<Item = CastMutability> {
     }
 }
 
-pub(crate) fn all_cast_names<'a>(
-    from: &'a QualifiedName,
-    to: &'a QualifiedName,
-) -> impl Iterator<Item = QualifiedName> + 'a {
-    cast_types().map(|mutable| name_for_cast(from, to, mutable))
-}
-
 fn create_cast(from: &QualifiedName, to: &QualifiedName, mutable: CastMutability) -> Api<PodPhase> {
     let name = name_for_cast(from, to, mutable);
     let ident = name.get_final_ident();

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -66,7 +66,6 @@ use self::{
 };
 
 use super::{
-    casts::all_cast_names,
     pod::{PodAnalysis, PodPhase},
     tdef::TypedefAnalysis,
     type_converter::Annotated,
@@ -1583,14 +1582,7 @@ impl Api<FnPhase> {
                 analysis: TypedefAnalysis { deps, .. },
                 ..
             } => Box::new(old_tyname.iter().chain(deps.iter()).cloned()),
-            Api::Struct { analysis, name, .. } => Box::new(
-                analysis.field_deps.iter().cloned().chain(
-                    analysis
-                        .castable_bases
-                        .iter()
-                        .flat_map(|base| all_cast_names(&name.name, base)),
-                ),
-            ),
+            Api::Struct { analysis, .. } => Box::new(analysis.field_deps.iter().cloned()),
             Api::Function { analysis, .. } => Box::new(analysis.deps.iter().cloned()),
             Api::Subclass {
                 name: _,


### PR DESCRIPTION
Previously due to a thinko, the function API which did a cast from A->B
would depend on the type A, and the type A would depend on the cast function
A->B. This later caused problems for #379 but might have caused problems
in any case meanwhile.

This removes the latter dependency relationship.
