### PR TITLE
Cease to require bases to be allowlisted.

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -382,25 +382,21 @@ impl<'a> FnAnalyzer<'a> {
             FnKind::Method(sup, MethodKind::Constructor) => {
                 // Create a make_unique too
                 let make_unique_func = self.create_make_unique(&fun);
-                self.analyze_and_add_if_necessary(initial_name, make_unique_func, &mut results);
+                self.analyze_and_add(initial_name, make_unique_func, &mut results);
 
                 for sub in self.subclasses_by_superclass(sup) {
                     // Create a subclass constructor. This is a synthesized function
                     // which didn't exist in the original C++.
                     let (subclass_constructor_func, subclass_constructor_name) =
                         create_subclass_constructor(sub, &analysis, sup, &fun);
-                    self.analyze_and_add_if_necessary(
+                    self.analyze_and_add(
                         subclass_constructor_name.clone(),
                         subclass_constructor_func.clone(),
                         &mut results,
                     );
                     // and its corresponding make_unique
                     let make_unique_func = self.create_make_unique(&subclass_constructor_func);
-                    self.analyze_and_add_if_necessary(
-                        subclass_constructor_name,
-                        make_unique_func,
-                        &mut results,
-                    );
+                    self.analyze_and_add(subclass_constructor_name, make_unique_func, &mut results);
                 }
             }
             FnKind::Method(
@@ -437,7 +433,7 @@ impl<'a> FnAnalyzer<'a> {
                     if !is_pure_virtual {
                         let maybe_wrap = create_subclass_fn_wrapper(sub, &super_fn_name, &fun);
                         let super_fn_name = ApiName::new_from_qualified_name(super_fn_name);
-                        self.analyze_and_add_if_necessary(super_fn_name, maybe_wrap, &mut results);
+                        self.analyze_and_add(super_fn_name, maybe_wrap, &mut results);
                     }
                 }
             }
@@ -454,7 +450,7 @@ impl<'a> FnAnalyzer<'a> {
         Ok(Box::new(results.into_iter()))
     }
 
-    fn analyze_and_add_if_necessary(
+    fn analyze_and_add(
         &mut self,
         name: ApiName,
         new_func: Box<FuncToConvert>,

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -47,6 +47,7 @@ pub(crate) struct PodAnalysis {
     pub(crate) castable_bases: HashSet<QualifiedName>,
     pub(crate) field_types: HashSet<QualifiedName>,
     pub(crate) movable: bool,
+    pub(crate) is_generic: bool,
 }
 
 pub(crate) struct PodPhase;
@@ -180,6 +181,7 @@ fn analyze_struct(
         .filter(|base| config.is_on_allowlist(&base.to_cpp_name()))
         .cloned()
         .collect();
+    let is_generic = !details.item.generics.params.is_empty();
     Ok(Box::new(std::iter::once(Api::Struct {
         name,
         details,
@@ -189,6 +191,7 @@ fn analyze_struct(
             castable_bases,
             field_types,
             movable,
+            is_generic,
         },
     })))
 }

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -59,6 +59,7 @@ pub enum ConvertError {
     Deleted,
     RValueReferenceField,
     MethodOfNonAllowlistedType,
+    MethodOfGenericType,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -110,6 +111,7 @@ impl Display for ConvertError {
             ConvertError::Deleted => write!(f, "This function was marked =delete")?,
             ConvertError::RValueReferenceField => write!(f, "This structure has an rvalue reference field (&&) which is not yet supported.")?,
             ConvertError::MethodOfNonAllowlistedType => write!(f, "This type was not on the allowlist, so we are not generating methods for it.")?,
+            ConvertError::MethodOfGenericType => write!(f, "This type is templated, so we can't generate bindings. We will instead generate bindings for each instantiation.")?,
         }
         Ok(())
     }

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -58,6 +58,7 @@ pub enum ConvertError {
     AssignmentOperator,
     Deleted,
     RValueReferenceField,
+    MethodOfNonAllowlistedType,
 }
 
 fn format_maybe_identifier(id: &Option<Ident>) -> String {
@@ -108,6 +109,7 @@ impl Display for ConvertError {
             ConvertError::AssignmentOperator => write!(f, "autocxx does not know how to generate bindings to operator=")?,
             ConvertError::Deleted => write!(f, "This function was marked =delete")?,
             ConvertError::RValueReferenceField => write!(f, "This structure has an rvalue reference field (&&) which is not yet supported.")?,
+            ConvertError::MethodOfNonAllowlistedType => write!(f, "This type was not on the allowlist, so we are not generating methods for it.")?,
         }
         Ok(())
     }

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -154,7 +154,7 @@ impl<'a> BridgeConverter<'a> {
                 // to generate UniquePtr implementations for the type, since it can't
                 // be instantiated.
                 Self::dump_apis_with_deps("analyze fns", &analyzed_apis);
-                let analyzed_apis = mark_types_abstract(self.config, analyzed_apis);
+                let analyzed_apis = mark_types_abstract(analyzed_apis);
                 Self::dump_apis_with_deps("marking abstract", &analyzed_apis);
                 let analyzed_apis = discard_ignored_functions(analyzed_apis);
                 Self::dump_apis_with_deps("ignoring ignorable fns", &analyzed_apis);


### PR DESCRIPTION
Previously we required base classes to be on the allowlist,
on the assumption that we were otherwise unable to see functions
belonging to base classes and thus determine whether they
were abstract.

This was possibly a wrong assumption - it looks like bindgen
fully generates base classes for anything on the allowlist.
Let's test that.

Relates to #774 ("bug 2" in its terms)