### PR TITLE
check if autocxx-gen exists

### DIFF
--- a/tools/reduce/src/main.rs
+++ b/tools/reduce/src/main.rs
@@ -269,6 +269,9 @@ fn do_run(matches: ArgMatches, tmp_dir: &TempDir) -> Result<(), std::io::Error> 
         .unwrap()
         .to_string();
     let gen_cmd = matches.value_of("gen-cmd").unwrap_or(&default_gen_cmd);
+    if Path::new(gen_cmd).exists() == false {
+        panic!("autocxx-gen not found in {}. hint: autocxx-reduce --gen-cmd /path/to/autocxx-gen", gen_cmd);
+    }
     run_sample_gen_cmd(gen_cmd, &rs_path, tmp_dir.path(), &extra_clang_args)?;
     let interestingness_test = tmp_dir.path().join("test.sh");
     create_interestingness_test(


### PR DESCRIPTION
### before

`autocxx-reduce` throws mysterious "no such file" error

> ```=== Running sample gen cmd: ...```
> ```thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', tools/reduce/src/main.rs:184:18```

main.rs:184 is

```rs
    run(matches).unwrap();
```

### after

panic when autocxx-gen is missing

> ```thread 'main' panicked at 'autocxx-gen not found in .../autocxx/target/debug/autocxx-gen. hint: autocxx-reduce --gen-cmd /path/to/autocxx-gen', tools/reduce/src/main.rs:289:9```

### background

only part of my workspace was compiled

solution: `cargo build --workspace`
