### PR TITLE
dont run postcompile_step when gen_cmd failed

### DIFF
--- a/tools/reduce/src/main.rs
+++ b/tools/reduce/src/main.rs
@@ -415,7 +415,7 @@ fn create_interestingness_test(
         mv concat.h concat-body.h
         echo Codegen
         (echo \"#ifndef __CONCAT_H__\"; echo \"#define __CONCAT_H__\"; echo '#include \"concat-body.h\"'; echo \"#endif\") > concat.h
-        ({} {} 2>&1 && cat gen.complete.rs && cat autocxxgen*.h ; {} 2>&1 ) | grep \"{}\"  >/dev/null 2>&1
+        ({} {} 2>&1 && cat gen.complete.rs && cat autocxxgen*.h && {} 2>&1 ) | grep \"{}\"  >/dev/null 2>&1
         echo Remove
         rm concat.h
         echo Swap back


### PR DESCRIPTION
reduce noise in the error generator

this assumes that `postcompile_step` is never empty

before

> ```thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/autocxx-bindgen-0.59.13/src/lib.rs:2200:31```
> ```note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace```
> ```g++: error: gen0.cc: No such file or directory```
> ```g++: fatal error: no input files```
> ```compilation terminated.```

after

> ```thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/autocxx-bindgen-0.59.13/src/lib.rs:2200:31```
> ```note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace```
