### PR TITLE
Document how nested classes are named

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,12 @@ use autocxx_engine::IncludeCppEngine;
 /// This is useful primarily if you want to listen out for messages broadcast
 /// using the C++ observer/listener pattern.
 ///
+/// # Nested classes
+///
+/// There is support for generating bindings of nested types, with some
+/// restrictions. Currently the C++ type `A::B` will be given the Rust name
+/// `A_B` in the same module as its enclosing namespace.
+///
 /// # Mixing manual and automated bindings
 ///
 /// `autocxx` uses [cxx] underneath, and its build process will happily spot and


### PR DESCRIPTION
I spent a while chasing this down when I tried wrapping a type `A::B` as
`A_B` and ran into mysterious errors about multiple types with the same
name.

- [X ] Tests pass
- [X ] Appropriate changes to README are included in PR