### PR TITLE
Implement an option for not generating `cxx::bridge` sources

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -179,6 +179,13 @@ impl<CTX: BuilderContext> Builder<CTX> {
         self
     }
 
+    /// Whether to skip using [`cxx_gen`] to generate the C++ code,
+    /// so that some other process can handle that.
+    pub fn skip_cxx_gen(mut self, skip_cxx_gen: bool) -> Self {
+        self.cpp_codegen_options.skip_cxx_gen = skip_cxx_gen;
+        self
+    }
+
     /// Build autocxx C++ files and return a cc::Build you can use to build
     /// more from a build.rs file.
     pub fn build(self) -> Result<BuilderBuild, BuilderError> {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -570,7 +570,9 @@ impl CppBuildable for IncludeCppEngine {
             State::NotGenerated => panic!("Call generate() first"),
             State::Generated(gen_results) => {
                 let rs = gen_results.item_mod.to_token_stream();
-                files.push(do_cxx_cpp_generation(rs, cpp_codegen_options)?);
+                if !cpp_codegen_options.skip_cxx_gen {
+                    files.push(do_cxx_cpp_generation(rs, cpp_codegen_options)?);
+                }
                 if let Some(cpp_file_pair) = &gen_results.cpp {
                     files.push(cpp_file_pair.clone());
                 }
@@ -642,4 +644,7 @@ pub struct CppCodegenOptions {
     /// An annotation optionally to include on each C++ function.
     /// For example to export the symbol from a library.
     pub cxx_impl_annotations: Option<String>,
+    /// Whether to skip using [`cxx_gen`] to generate the C++ code,
+    /// so that some other process can handle that.
+    pub skip_cxx_gen: bool,
 }

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -133,9 +133,9 @@ fn main() {
             .arg("gen-rs-include")
         )
         .arg(
-            Arg::with_name("cxx-gen")
-                .long("cxx-gen")
-                .help("Perform C++ codegen also for #[cxx::bridge] blocks. Only applies for --gen-cpp")
+            Arg::with_name("skip-cxx-gen")
+                .long("skip-cxx-gen")
+                .help("Skip performing C++ codegen for #[cxx::bridge] blocks. Only applies for --gen-cpp")
                 .requires("gen-cpp")
         )
         .arg(
@@ -211,6 +211,7 @@ fn main() {
     cpp_codegen_options.cxx_impl_annotations = get_option_string("cxx-impl-annotations", &matches);
     cpp_codegen_options.path_to_cxx_h = get_option_string("cxx-h-path", &matches);
     cpp_codegen_options.path_to_cxxgen_h = get_option_string("cxxgen-h-path", &matches);
+    cpp_codegen_options.skip_cxx_gen = matches.is_present("skip-cxx-gen");
     // In future, we should provide an option to write a .d file here
     // by passing a callback into the dep_recorder parameter here.
     // https://github.com/google/autocxx/issues/56

--- a/integration-tests/src/test_utils.rs
+++ b/integration-tests/src/test_utils.rs
@@ -539,6 +539,17 @@ impl BuilderModifierFns for EnableAutodiscover {
     }
 }
 
+pub(crate) struct SkipCxxGen;
+
+impl BuilderModifierFns for SkipCxxGen {
+    fn modify_autocxx_builder(
+        &self,
+        builder: Builder<TestBuilderContext>,
+    ) -> Builder<TestBuilderContext> {
+        builder.skip_cxx_gen(true)
+    }
+}
+
 /// Searches generated C++ for strings we want to find, or want _not_ to find,
 /// or both.
 pub(crate) struct CppMatcher<'a> {
@@ -573,5 +584,30 @@ impl<'a> CodeCheckerFns for CppMatcher<'a> {
         } else {
             Err(TestError::CppCodeExaminationFail)
         }
+    }
+}
+
+/// Counts the number of generated C++ files.
+pub(crate) struct CppCounter {
+    cpp_count: usize,
+}
+
+impl CppCounter {
+    pub(crate) fn new(cpp_count: usize) -> Self {
+        Self { cpp_count }
+    }
+}
+
+impl CodeCheckerFns for CppCounter {
+    fn check_cpp(&self, cpp: &[PathBuf]) -> Result<(), TestError> {
+        if cpp.len() == self.cpp_count {
+            Ok(())
+        } else {
+            Err(TestError::CppCodeExaminationFail)
+        }
+    }
+
+    fn skip_build(&self) -> bool {
+        true
     }
 }

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -15,7 +15,8 @@
 use crate::test_utils::{
     directives_from_lists, do_run_test_manual, make_clang_arg_adder, make_error_finder,
     make_string_finder, run_test, run_test_ex, run_test_expect_fail, run_test_expect_fail_ex,
-    CppMatcher, EnableAutodiscover, NoSystemHeadersChecker, SetSuppressSystemHeaders,
+    CppCounter, CppMatcher, EnableAutodiscover, NoSystemHeadersChecker, SetSuppressSystemHeaders,
+    SkipCxxGen,
 };
 use indoc::indoc;
 use itertools::Itertools;
@@ -7908,6 +7909,27 @@ fn test_issue486_multi_types() {
         rs,
         &["spanner::Key", "a::spanner::Key", "b::spanner::Key"],
         &[],
+    );
+}
+
+#[test]
+fn test_skip_cxx_gen() {
+    let cxx = indoc! {"
+        void do_nothing() {
+        }
+    "};
+    let hdr = indoc! {"
+        void do_nothing();
+    "};
+    let rs = quote! {};
+    run_test_ex(
+        cxx,
+        hdr,
+        rs,
+        directives_from_lists(&["do_nothing"], &[], None),
+        Some(Box::new(SkipCxxGen)),
+        Some(Box::new(CppCounter::new(1))),
+        None,
     );
 }
 


### PR DESCRIPTION
It's documented for autocxx-gen, but confusingly didn't do anything. I
flipped the truth value of it so the default is the same as the old
behavior.

Also document another gotcha which combined with this one to confuse me
even more.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR