### PR TITLE
Remove strum_macros and use full #[derive(Debug)]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "strum_macros",
  "syn",
  "tempfile",
  "unzip-n",
@@ -380,15 +379,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -697,12 +687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustversion"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,19 +734,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -856,12 +827,6 @@ dependencies = [
  "termcolor",
  "toml",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -51,13 +51,11 @@ version_check = "0.9"
 aquamarine = "0.1" # docs
 tempfile = "3.1"
 once_cell = "1.7"
-strum_macros = "0.23"
 serde_json = { version = "1.0", optional = true }
 
 [dependencies.syn]
 version = "1.0.39"
-features = [ "full", "printing" ]
-#features = [ "full", "printing", "extra-traits" ]
+features = [ "full", "printing", "extra-traits" ]
 
 [package.metadata.docs.rs]
 features = ["build", "nightly"]

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -67,7 +67,7 @@ impl RustConversionType {
 /// * Finally, the actual C++ API receives a `std::string` by value.
 /// The implementation here is distributed across this file, and
 /// `function_wrapper_rs` and `function_wrapper_cpp`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct TypeConversionPolicy {
     pub(crate) unwrapped_type: Type,
     pub(crate) cpp_conversion: CppConversionType,
@@ -129,7 +129,7 @@ impl TypeConversionPolicy {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 
 pub(crate) enum CppFunctionBody {
     FunctionCall(Namespace, Ident),
@@ -141,7 +141,7 @@ pub(crate) enum CppFunctionBody {
     Destructor(Namespace, Ident),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 
 pub(crate) enum CppFunctionKind {
     Function,
@@ -151,7 +151,7 @@ pub(crate) enum CppFunctionKind {
     SynthesizedConstructor,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct CppFunction {
     pub(crate) payload: CppFunctionBody,
     pub(crate) wrapper_function_name: Ident,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -78,7 +78,7 @@ pub(crate) enum ReceiverMutability {
     Mutable,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum MethodKind {
     Normal(ReceiverMutability),
     Constructor,
@@ -88,7 +88,7 @@ pub(crate) enum MethodKind {
     PureVirtual(ReceiverMutability),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum TraitMethodKind {
     CopyConstructor,
     MoveConstructor,
@@ -96,7 +96,7 @@ pub(crate) enum TraitMethodKind {
     Destructor,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct TraitMethodDetails {
     pub(crate) impl_for_specifics: TokenStream,
     pub(crate) trait_signature: TokenStream,
@@ -113,7 +113,7 @@ pub(crate) struct TraitMethodDetails {
     pub(crate) trait_call_is_unsafe: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum FnKind {
     Function,
     Method(QualifiedName, MethodKind),
@@ -130,7 +130,7 @@ pub(crate) enum FnKind {
 
 /// Strategy for ensuring that the final, callable, Rust name
 /// is what the user originally expected.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 
 pub(crate) enum RustRenameStrategy {
     /// cxx::bridge name matches user expectations
@@ -140,14 +140,14 @@ pub(crate) enum RustRenameStrategy {
     RenameInOutputMod(Ident),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum UnsafetyNeeded {
     None,
     JustBridge,
     Always,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct FnAnalysis {
     pub(crate) cxxbridge_name: Ident,
     pub(crate) rust_name: String,
@@ -171,7 +171,7 @@ pub(crate) struct FnAnalysis {
     pub(crate) externally_callable: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct ArgumentAnalysis {
     pub(crate) conversion: TypeConversionPolicy,
     pub(crate) name: Pat,
@@ -199,6 +199,7 @@ impl Default for ReturnTypeAnalysis {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct FnPhase;
 
 impl AnalysisPhase for FnPhase {

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -37,6 +37,7 @@ use crate::{
 
 use super::tdef::{TypedefAnalysis, TypedefPhase};
 
+#[derive(Debug)]
 pub(crate) struct PodAnalysis {
     pub(crate) kind: TypeKind,
     pub(crate) bases: HashSet<QualifiedName>,
@@ -50,6 +51,7 @@ pub(crate) struct PodAnalysis {
     pub(crate) is_generic: bool,
 }
 
+#[derive(Debug)]
 pub(crate) struct PodPhase;
 
 impl AnalysisPhase for PodPhase {

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -29,6 +29,7 @@ use crate::{
     types::QualifiedName,
 };
 
+#[derive(Debug)]
 pub(crate) struct TypedefAnalysis {
     pub(crate) kind: TypedefKind,
     pub(crate) deps: HashSet<QualifiedName>,
@@ -36,6 +37,7 @@ pub(crate) struct TypedefAnalysis {
 
 /// Analysis phase where typedef analysis has been performed but no other
 /// analyses just yet.
+#[derive(Debug)]
 pub(crate) struct TypedefPhase;
 
 impl AnalysisPhase for TypedefPhase {

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -117,7 +117,7 @@ impl Display for ConvertError {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum ErrorContext {
     Item(Ident),
     Method { self_ty: Ident, method: Ident },

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -24,6 +24,8 @@ mod error_reporter;
 mod parse;
 mod utilities;
 
+use std::fmt::Debug;
+
 use analysis::fun::FnAnalyzer;
 use autocxx_parser::IncludeCppConfig;
 pub(crate) use codegen_cpp::CppCodeGenerator;
@@ -82,7 +84,12 @@ impl<'a> BridgeConverter<'a> {
         }
     }
 
-    fn dump_apis<T: AnalysisPhase>(label: &str, apis: &[Api<T>]) {
+    fn dump_apis<T: AnalysisPhase + Debug>(label: &str, apis: &[Api<T>])
+    where
+        T::FunAnalysis: Debug,
+        T::StructAnalysis: Debug,
+        T::TypedefAnalysis: Debug,
+    {
         if LOG_APIS {
             log::info!(
                 "APIs after {}:\n{}",


### PR DESCRIPTION
Simpler but the debug output is incomprehensibly huge. We need to wrap all `syn` things in a newtype wrapper which outputs more concise debug output.