### PR TITLE
ignore `test_abstract_private` on beta channel

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -7965,6 +7965,7 @@ fn test_abstract_up() {
     run_test("", hdr, rs, &["A", "get_a"], &[]);
 }
 
+#[cfg_attr(skip_beta_failing_tests, ignore)]
 #[test]
 fn test_abstract_private() {
     let hdr = indoc! {"


### PR DESCRIPTION
Fixes https://github.com/google/autocxx/pull/823

Relates to #818 