### PR TITLE
Cease to turn commits red based on cargo outdated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/install@cargo-outdated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/install@cargo-outdated
-      - run: cargo outdated --exit-code 1
+      - run: cargo outdated -R -w


### PR DESCRIPTION
This was bothersome because it means nearly all commits end up with a red cross next to them, which harms the signal-to-noise ratio of the github actions.

I do not want to upgrade to the most recent compatible version: some users of autocxx have crate trees with hard-coded versions requirements elsewhere in the tree. Upgrading to the versions reported by 'cargo outdated' is currently a non-goal; that would reduce flexibility for those users.

In an ideal world, 'cargo outdated' would report a failure if (and only if) there's a new version of a dependency which is not semver-compatible, but that facility is not currently offered.

This change also:
* Ceases to report on transitive deps, about which we can do
  nothing; but
* Starts to report on deps of all packages in our workspace.


@philipcraig could you take a look and see if you have any comments?