### PR TITLE
Add failing tests for google/autocxx#835

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5251,6 +5251,35 @@ fn test_error_generated_for_array_dependent_method() {
 }
 
 #[test]
+#[ignore] // https://github.com/google/autocxx/issues/835
+fn test_error_generated_for_pod_with_nontrivial_destructor() {
+    let hdr = indoc! {"
+        #include <cstdint>
+        #include <functional>
+        struct A {
+            ~A() {}
+        };
+    "};
+    let rs = quote! {};
+    run_test_expect_fail("", hdr, rs, &[], &["A"]);
+}
+
+#[test]
+#[ignore] // https://github.com/google/autocxx/issues/835
+fn test_error_generated_for_pod_with_nontrivial_move_constructor() {
+    let hdr = indoc! {"
+        #include <cstdint>
+        #include <functional>
+        struct A {
+            A() = default;
+            A(A&&) {}
+        };
+    "};
+    let rs = quote! {};
+    run_test_expect_fail("", hdr, rs, &[], &["A"]);
+}
+
+#[test]
 fn test_keyword_function() {
     let hdr = indoc! {"
         inline void move(int a) {};


### PR DESCRIPTION
Add a few things which should fail (either at code generation time or C++ compilation time, I'm not sure) but don't due to #835, with the tests ignored for now.