### PR TITLE
Make test_utils available outside test projects.

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.1.0"
 autotests = false
 edition = "2021"
 
-[dev-dependencies]
+[dependencies]
 proc-macro2 = "1.0.11"
 trybuild = "1.0.53"
 test-log = "0.2.2"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#![cfg(test)]
 
 use std::{
     fs::File,
@@ -131,7 +129,7 @@ pub fn run_test(
 
 // A trait for objects which can check the output of the code creation
 // process.
-pub(crate) trait CodeCheckerFns {
+pub trait CodeCheckerFns {
     fn check_rust(&self, _rs: syn::File) -> Result<(), TestError> {
         Ok(())
     }
@@ -145,10 +143,10 @@ pub(crate) trait CodeCheckerFns {
 
 // A function applied to the resultant generated Rust code
 // which can be used to inspect that code.
-pub(crate) type CodeChecker = Box<dyn CodeCheckerFns>;
+pub type CodeChecker = Box<dyn CodeCheckerFns>;
 
 // A trait for objects which can modify builders for testing purposes.
-pub(crate) trait BuilderModifierFns {
+pub trait BuilderModifierFns {
     fn modify_autocxx_builder(
         &self,
         builder: Builder<TestBuilderContext>,
@@ -158,11 +156,11 @@ pub(crate) trait BuilderModifierFns {
     }
 }
 
-pub(crate) type BuilderModifier = Box<dyn BuilderModifierFns>;
+pub type BuilderModifier = Box<dyn BuilderModifierFns>;
 
 /// A positive test, we expect to pass.
 #[allow(clippy::too_many_arguments)] // least typing for each test
-pub(crate) fn run_test_ex(
+pub fn run_test_ex(
     cxx_code: &str,
     header_code: &str,
     rust_code: TokenStream,
@@ -183,7 +181,7 @@ pub(crate) fn run_test_ex(
     .unwrap()
 }
 
-pub(crate) fn run_test_expect_fail(
+pub fn run_test_expect_fail(
     cxx_code: &str,
     header_code: &str,
     rust_code: TokenStream,
@@ -202,7 +200,7 @@ pub(crate) fn run_test_expect_fail(
     .expect_err("Unexpected success");
 }
 
-pub(crate) fn run_test_expect_fail_ex(
+pub fn run_test_expect_fail_ex(
     cxx_code: &str,
     header_code: &str,
     rust_code: TokenStream,
@@ -225,7 +223,7 @@ pub(crate) fn run_test_expect_fail_ex(
 
 /// In the future maybe the tests will distinguish the exact type of failure expected.
 #[derive(Debug)]
-pub(crate) enum TestError {
+pub enum TestError {
     AutoCxx(BuilderError),
     CppBuild(cc::Error),
     RsBuild,
@@ -237,7 +235,7 @@ pub(crate) enum TestError {
     CppCodeExaminationFail,
 }
 
-pub(crate) fn directives_from_lists(
+pub fn directives_from_lists(
     generate: &[&str],
     generate_pods: &[&str],
     extra_directives: Option<TokenStream>,
@@ -295,7 +293,8 @@ fn do_run_test(
     )
 }
 
-pub(crate) struct TestBuilderContext;
+/// The [`BuilderContext`] used in autocxx's integration tests.
+pub struct TestBuilderContext;
 
 impl BuilderContext for TestBuilderContext {
     fn get_dependency_recorder() -> Option<Box<dyn RebuildDependencyRecorder>> {
@@ -303,7 +302,7 @@ impl BuilderContext for TestBuilderContext {
     }
 }
 
-pub(crate) fn do_run_test_manual(
+pub fn do_run_test_manual(
     cxx_code: &str,
     header_code: &str,
     mut rust_code: TokenStream,

--- a/integration-tests/tests/builder_modifiers.rs
+++ b/integration-tests/tests/builder_modifiers.rs
@@ -14,7 +14,7 @@
 
 use autocxx_engine::Builder;
 
-use crate::test_utils::{BuilderModifier, BuilderModifierFns, TestBuilderContext};
+use autocxx_integration_tests::{BuilderModifier, BuilderModifierFns, TestBuilderContext};
 
 struct ClangArgAdder(Vec<String>);
 

--- a/integration-tests/tests/code_checkers.rs
+++ b/integration-tests/tests/code_checkers.rs
@@ -22,7 +22,7 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::Item;
 
-use crate::test_utils::{CodeChecker, CodeCheckerFns, TestError};
+use autocxx_integration_tests::{CodeChecker, CodeCheckerFns, TestError};
 
 /// Generates a closure which can be used to ensure that the given symbol
 /// is mentioned in the output and has documentation attached.

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -19,10 +19,10 @@ use crate::{
     code_checkers::{
         make_error_finder, make_string_finder, CppCounter, CppMatcher, NoSystemHeadersChecker,
     },
-    test_utils::{
-        directives_from_lists, do_run_test_manual, run_test, run_test_ex, run_test_expect_fail,
-        run_test_expect_fail_ex,
-    },
+};
+use autocxx_integration_tests::{
+    directives_from_lists, do_run_test_manual, run_test, run_test_ex, run_test_expect_fail,
+    run_test_expect_fail_ex,
 };
 use indoc::indoc;
 use itertools::Itertools;

--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -15,4 +15,3 @@
 mod builder_modifiers;
 mod code_checkers;
 mod integration_test;
-mod test_utils;


### PR DESCRIPTION
This is a pre-requisite for a subsequent change which will
start to use the same trybuild-based infrastructure to build
doctests in a forthcoming autocxx mdbook.
