### PR TITLE
Fix some windows tests

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -378,7 +378,7 @@ pub fn do_run_test_manual(
         .host(&target)
         .target(&target)
         .opt_level(1)
-        .flag_if_supported("-std=c++14") // For clang
+        .flag("-std=c++14") // For clang
         .flag_if_supported("/GX"); // Enable C++ exceptions for msvc
     let b = if let Some(builder_modifier) = builder_modifier {
         builder_modifier.modify_cc_builder(b)

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -378,7 +378,7 @@ pub fn do_run_test_manual(
         .host(&target)
         .target(&target)
         .opt_level(1)
-        .flag("-std=c++14") // For clang
+        .flag_if_supported("-std=c++14") // For clang
         .flag_if_supported("/GX"); // Enable C++ exceptions for msvc
     let b = if let Some(builder_modifier) = builder_modifier {
         builder_modifier.modify_cc_builder(b)

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -6394,7 +6394,6 @@ fn test_pv_subclass_ptr_param() {
     );
 }
 
-#[cfg_attr(skip_windows_msvc_failing_tests, ignore)]
 #[test]
 fn test_pv_subclass_return() {
     let hdr = indoc! {"
@@ -7786,7 +7785,6 @@ fn test_various_emplacement() {
     run_test("", hdr, rs, &["A"], &[]);
 }
 
-#[cfg_attr(skip_windows_msvc_failing_tests, ignore)]
 #[test]
 fn test_emplace_uses_overridden_new_and_delete() {
     let hdr = indoc! {"

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -3513,8 +3513,6 @@ fn test_root_ns_meth_ret_nonpod() {
     run_test("", hdr, rs, &["Bob"], &["B::C"]);
 }
 
-#[cfg_attr(skip_windows_gnu_failing_tests, ignore)]
-#[cfg_attr(skip_windows_msvc_failing_tests, ignore)]
 #[test]
 fn test_forward_declaration() {
     let hdr = indoc! {"
@@ -3525,7 +3523,6 @@ fn test_forward_declaration() {
             B() {}
             uint32_t a;
             void daft(const A&) const {}
-            void daft2(std::unique_ptr<A>) const {}
             static B daft3(const A&) { B b; return b; }
         };
         A* get_a();
@@ -5464,7 +5461,6 @@ fn test_include_cpp_in_path() {
     do_run_test_manual("", hdr, rs, None, None).unwrap();
 }
 
-#[cfg_attr(skip_windows_msvc_failing_tests, ignore)]
 #[test]
 fn test_bitset() {
     let hdr = indoc! {"
@@ -5479,7 +5475,7 @@ fn test_bitset() {
         };
 
         template <size_t _Size>
-        class __attribute__ ((__type_visibility__(\"default\"))) bitset
+        class bitset
             : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * 8) + 1, _Size>
         {
         public:
@@ -8014,7 +8010,6 @@ fn test_class_having_protected_method() {
     run_test("", hdr, rs, &[], &["A"]);
 }
 
-#[cfg_attr(skip_windows_msvc_failing_tests, ignore)]
 #[test]
 fn test_protected_inner_class() {
     let hdr = indoc! {"
@@ -8032,7 +8027,7 @@ fn test_protected_inner_class() {
         };
 
         inline B protected_method_2() {
-            return { .x = 0 };
+            return { 0 };
         }
     };
     "};
@@ -8040,7 +8035,6 @@ fn test_protected_inner_class() {
     run_test("", hdr, rs, &["A"], &[]);
 }
 
-#[cfg_attr(skip_windows_msvc_failing_tests, ignore)]
 #[test]
 fn test_private_inner_class() {
     let hdr = indoc! {"
@@ -8059,7 +8053,7 @@ fn test_private_inner_class() {
         };
 
         inline B private_method_2() {
-            return { .x = 0 };
+            return { 0 };
         }
     };
     "};


### PR DESCRIPTION
Partial fixes for #819 
Fixes #840

* remove `unique_ptr<A>` where `A` is an incomplete type from being passed as a parameter as this invokes the destructor for `unique_ptr<A>` and this is non-compliant C++
* remove Clang-specific `__attribute__` syntax as it's not needed for the test
* remove use of designated initializers as they C++20-specific and not needed for the test
* stop ignoring two tests that do pass on `msvc`