### PR TITLE
Disable incremenental compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
       CARGO_TERM_COLOR: always
       CXXFLAGS: ${{matrix.flags}}
       RUSTFLAGS: --cfg deny_warnings -Dwarnings
+      CARGO_INCREMENTAL: 0
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -38,7 +40,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
-          components: rustfmt
       # For operating systems that have it packaged, install creduce
       - name: Install creduce (Linux)
         if: matrix.os == ''


### PR DESCRIPTION
* Disable incremental compilation as it causes intermittent compiler panics
on the integration tests
* Remove unnecessary `rustfmt` component install