### PR TITLE
Restore `rustfmt` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
+          components: rustfmt
       # For operating systems that have it packaged, install creduce
       - name: Install creduce (Linux)
         if: matrix.os == ''

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.vscode/


### PR DESCRIPTION
Surprisingly, the CI test steps complain when `rustfmt` is missing. Restore it
Add Visual Studio Code settings directory to `.gitignore`