### PR TITLE
Disable pass-by-&T for now.

### DIFF
--- a/book/src/cpp_functions.md
+++ b/book/src/cpp_functions.md
@@ -38,9 +38,9 @@ include_cpp! {
 fn main() {
     let mut goat = ffi::Goat::make_unique(); // returns a cxx::UniquePtr, i.e. a std::unique_ptr
     // C++-like semantics...
-    ffi::feed_goat(&goat);
+    // ffi::feed_goat(&goat); // temporarily disabled, bug #852
     // ... you've still got the goat!
-    ffi::feed_goat(&goat);
+    // ffi::feed_goat(&goat); // temporarily disabled, bug #852
     // Or, Rust-like semantics, where the goat is consumed.
     ffi::feed_goat(goat);
     // No goat any more...

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -7877,6 +7877,7 @@ fn test_emplace_uses_overridden_new_and_delete() {
 }
 
 #[test]
+#[ignore] // https://github.com/google/autocxx/issues/833
 fn test_pass_by_reference_to_value_param() {
     let hdr = indoc! {"
     #include <stdint.h>

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -7667,6 +7667,7 @@ fn test_implicit_constructor_moveit() {
 }
 
 #[test]
+#[ignore] // https://github.com/google/autocxx/pull/852
 fn test_pass_by_value_moveit() {
     let hdr = indoc! {"
     #include <stdint.h>

--- a/src/value_param.rs
+++ b/src/value_param.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cxx::{memory::UniquePtrTarget, UniquePtr};
-use moveit::{CopyNew, New};
+// use moveit::{CopyNew, New};
 use std::{marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
 
 /// A trait representing a parameter to a C++ function which is received
@@ -76,24 +76,24 @@ pub trait ValueParam<T> {
     fn get_ptr(&mut self) -> *mut T;
 }
 
-impl<T> ValueParam<T> for &T
-where
-    T: CopyNew,
-{
-    type StackStorage = T;
+// impl<T> ValueParam<T> for &T
+// where
+//     T: CopyNew,
+// {
+//     type StackStorage = T;
 
-    fn needs_stack_space(&self) -> bool {
-        true
-    }
+//     fn needs_stack_space(&self) -> bool {
+//         true
+//     }
 
-    fn populate_stack_space(&self, this: Pin<&mut MaybeUninit<Self::StackStorage>>) {
-        unsafe { crate::moveit::new::copy(*self).new(this) }
-    }
+//     fn populate_stack_space(&self, this: Pin<&mut MaybeUninit<Self::StackStorage>>) {
+//         unsafe { crate::moveit::new::copy(*self).new(this) }
+//     }
 
-    fn get_ptr(&mut self) -> *mut T {
-        unreachable!()
-    }
-}
+//     fn get_ptr(&mut self) -> *mut T {
+//         unreachable!()
+//     }
+// }
 
 impl<T> ValueParam<T> for UniquePtr<T>
 where
@@ -117,32 +117,32 @@ where
     }
 }
 
-impl<T> ValueParam<T> for &UniquePtr<T>
-where
-    T: UniquePtrTarget + CopyNew,
-{
-    type StackStorage = T;
+// impl<T> ValueParam<T> for &UniquePtr<T>
+// where
+//     T: UniquePtrTarget + CopyNew,
+// {
+//     type StackStorage = T;
 
-    fn needs_stack_space(&self) -> bool {
-        true
-    }
+//     fn needs_stack_space(&self) -> bool {
+//         true
+//     }
 
-    fn populate_stack_space(&self, this: Pin<&mut MaybeUninit<Self::StackStorage>>) {
-        // Invoke a copy constructor on the Rust side, because we'll use std::move on the C++
-        // side.
-        unsafe {
-            crate::moveit::new::copy(
-                self.as_ref()
-                    .expect("Passed a NULL &UniquePtr as a C++ value parameter"),
-            )
-            .new(this)
-        }
-    }
+//     fn populate_stack_space(&self, this: Pin<&mut MaybeUninit<Self::StackStorage>>) {
+//         // Invoke a copy constructor on the Rust side, because we'll use std::move on the C++
+//         // side.
+//         unsafe {
+//             crate::moveit::new::copy(
+//                 self.as_ref()
+//                     .expect("Passed a NULL &UniquePtr as a C++ value parameter"),
+//             )
+//             .new(this)
+//         }
+//     }
 
-    fn get_ptr(&mut self) -> *mut T {
-        unreachable!()
-    }
-}
+//     fn get_ptr(&mut self) -> *mut T {
+//         unreachable!()
+//     }
+// }
 
 /// Implementation detail for how we pass value parameters into C++.
 /// This type is instantiated by auto-generated autocxx code each time we

--- a/src/value_param.rs
+++ b/src/value_param.rs
@@ -37,7 +37,7 @@ use std::{marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
 /// # Use of `moveit` traits
 ///
 /// Most of the implementations of this trait require the type to implement
-/// [`CopyNew`], which is simply the `autocxx`/`moveit` way of saying that
+/// [`moveit::CopyNew`], which is simply the `autocxx`/`moveit` way of saying that
 /// the type has a copy constructor in C++.
 ///
 /// # Performance


### PR DESCRIPTION
This had a pinning error which is fixable, but not immediately,
so disable faulty code for now.
