### PR TITLE
Clarify handling of trivial types.

### DIFF
--- a/book/src/cpp_types.md
+++ b/book/src/cpp_types.md
@@ -29,9 +29,10 @@ Non-POD types are awkward:
 
 * You can't just _have_ one as a Rust variable. Normally you hold them in a [`cxx::UniquePtr`], though there are other options.
 * There is no access to fields (yet).
-* You can't even have a `&mut` reference to one, because then you might be able to use [`std::mem::swap`] or similara. You can have a `Pin<&mut>` reference, which is more fiddly.
+* You can't even have a `&mut` reference to one, because then you might be able to use [`std::mem::swap`] or similar. You can have a `Pin<&mut>` reference, which is more fiddly.
 
-By default, `autocxx` generates non-POD types. You can request a POD type using [`generate_pod!`](https://docs.rs/autocxx/latest/autocxx/macro.generate_pod.html). Don't worry: you can't mess this up. If the C++ type doesn't in fact comply with the requirements for a POD type, your build will fail thanks to some static assertions generated in the C++.
+By default, `autocxx` generates non-POD types. You can request a POD type using [`generate_pod!`](https://docs.rs/autocxx/latest/autocxx/macro.generate_pod.html). Don't worry: you can't mess this up. If the C++ type doesn't in fact comply with the requirements for a POD type, and if you _use_ it as a POD type
+at the C++ boundary, your build will fail thanks to some static assertions generated in the C++.
 
 See [the chapter on storage](storage.md) for lots more detail on how you can hold onto non-POD types.
 

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5253,22 +5253,27 @@ fn test_error_generated_for_array_dependent_method() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/835
 fn test_error_generated_for_pod_with_nontrivial_destructor() {
+    // take_a is necessary here because cxx won't generate the required
+    // static assertions unless the type is actually used in some context
+    // where cxx needs to decide it's trivial or non-trivial.
     let hdr = indoc! {"
         #include <cstdint>
         #include <functional>
         struct A {
             ~A() {}
         };
+        inline void take_a(A) {}
     "};
     let rs = quote! {};
-    run_test_expect_fail("", hdr, rs, &[], &["A"]);
+    run_test_expect_fail("", hdr, rs, &["take_a"], &["A"]);
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/835
 fn test_error_generated_for_pod_with_nontrivial_move_constructor() {
+    // take_a is necessary here because cxx won't generate the required
+    // static assertions unless the type is actually used in some context
+    // where cxx needs to decide it's trivial or non-trivial.
     let hdr = indoc! {"
         #include <cstdint>
         #include <functional>
@@ -5276,9 +5281,10 @@ fn test_error_generated_for_pod_with_nontrivial_move_constructor() {
             A() = default;
             A(A&&) {}
         };
+        inline void take_a(A) {}
     "};
     let rs = quote! {};
-    run_test_expect_fail("", hdr, rs, &[], &["A"]);
+    run_test_expect_fail("", hdr, rs, &["take_a"], &["A"]);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #835.

This turns out to be slightly imprecise documentation.