### PR TITLE
Try passing uncopyable types by value

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -7740,6 +7740,9 @@ fn test_pass_by_value_moveit() {
     #include <stdint.h>
     #include <string>
     struct A {
+        A() = default;
+        A(const A&) = delete;
+        A(A&&) = default;
         void set(uint32_t val) { a = val; }
         uint32_t a;
         std::string so_we_are_non_trivial;
@@ -7951,6 +7954,8 @@ fn test_pass_by_reference_to_value_param() {
     #include <string>
     struct A {
         A() : count(0) {}
+        A(const A&) = delete;
+        A(A&&) = default;
         std::string so_we_are_non_trivial;
         uint32_t count;
     };


### PR DESCRIPTION
It results in generated Rust code that doesn't compile. Not sure if
there's an easy fix, or if this would make more sense as copies of these
tests which are skipped. Also not sure if there's an existing bug that
is intended to include this one, or of it should be a new bug.