### PR TITLE
Run mdbook doctests in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ dependencies = [
  "cc",
  "cxx",
  "env_logger 0.9.0",
- "gag",
  "indoc",
  "itertools 0.10.3",
  "link-cplusplus",
@@ -201,9 +200,11 @@ dependencies = [
  "anyhow",
  "autocxx-integration-tests",
  "clap 3.1.2",
+ "gag",
  "itertools 0.10.3",
  "mdbook",
  "proc-macro2",
+ "rayon",
  "regex",
  "serde_json",
  "syn",
@@ -375,6 +376,50 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
@@ -724,6 +769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +820,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -970,6 +1034,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1131,12 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -31,7 +31,6 @@ indoc = "1.0"
 log = "0.4"
 cxx = "1.0.54"
 itertools = "0.10"
-gag = "1.0"
 
 [dependencies.syn]
 version = "1.0.39"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -33,19 +33,9 @@ pub fn doctest(
     rust_code: TokenStream,
     manifest_dir: &OsStr,
 ) -> Result<(), TestError> {
-    let stdout_gag = gag::BufferRedirect::stdout().unwrap();
     std::env::set_var("CARGO_PKG_NAME", "autocxx-integration-tests");
     std::env::set_var("CARGO_MANIFEST_DIR", manifest_dir);
-    let r = do_run_test_manual(cxx_code, header_code, rust_code, None, None);
-    let mut stdout_str = String::new();
-    stdout_gag
-        .into_inner()
-        .read_to_string(&mut stdout_str)
-        .unwrap();
-    if !stdout_str.is_empty() {
-        eprintln!("Stdout from test:\n{}", stdout_str);
-    }
-    r
+    do_run_test_manual(cxx_code, header_code, rust_code, None, None)
 }
 
 fn get_builder() -> &'static Mutex<LinkableTryBuilder> {

--- a/tools/mdbook-preprocessor/Cargo.toml
+++ b/tools/mdbook-preprocessor/Cargo.toml
@@ -19,6 +19,8 @@ itertools = "0.10"
 anyhow = "1"
 regex = "1"
 autocxx-integration-tests = { path = "../../integration-tests", version="0.1"}
+rayon = "1.5"
+gag = "1.0"
 
 [dependencies.syn]
 version = "1.0.39"


### PR DESCRIPTION
Run doctests in parallel.
May currently not be worthwhile due to overhead of building rayon in the first place.