### PR TITLE
Workaround problem with nested type implicit constructors

### DIFF
--- a/book/src/naming.md
+++ b/book/src/naming.md
@@ -44,6 +44,34 @@ There is support for generating bindings of nested types, with some
 restrictions. Currently the C++ type `A::B` will be given the Rust name
 `A_B` in the same module as its enclosing namespace.
 
+```rust,ignore,autocxx,hidecpp
+autocxx_integration_tests::doctest(
+"",
+"
+struct Turkey {
+    struct Duck {
+        struct Hen {
+            int wings;
+        };
+    };
+};
+",
+{
+use autocxx::prelude::*;
+
+include_cpp! {
+    #include "input.h"
+    safety!(unsafe_ffi)
+    generate_pod!("Turkey_Duck_Hen")
+}
+
+fn main() {
+    let turducken = ffi::Turkey_Duck_Hen::make_unique();
+}
+}
+)
+```
+
 ## Overloads
 
 See [the chapter on C++ functions](cpp_functions.md).

--- a/book/src/naming.md
+++ b/book/src/naming.md
@@ -38,7 +38,7 @@ fn main() {
 )
 ```
 
-## Nested classes
+## Nested types
 
 There is support for generating bindings of nested types, with some
 restrictions. Currently the C++ type `A::B` will be given the Rust name
@@ -51,6 +51,7 @@ autocxx_integration_tests::doctest(
 struct Turkey {
     struct Duck {
         struct Hen {
+            Hen() {}
             int wings;
         };
     };
@@ -71,6 +72,8 @@ fn main() {
 }
 )
 ```
+
+(Currently, only explicit constructors are supported for such nested types.)
 
 ## Overloads
 

--- a/engine/src/conversion/analysis/fun/implicit_constructors.rs
+++ b/engine/src/conversion/analysis/fun/implicit_constructors.rs
@@ -71,6 +71,11 @@ pub(super) fn find_missing_constructors(
             ..
         } = api
         {
+            if name.cpp_name_if_present().is_some() {
+                // For now we do not generate implicit constructors for nested structs - see
+                // https://github.com/google/autocxx/issues/884
+                continue;
+            }
             let name = &name.name;
             let find = |kind: ExplicitKind| -> bool {
                 explicits.contains(&ExplicitFound {

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5417,13 +5417,14 @@ fn test_multiply_nested_inner_type() {
         struct Turkey {
             struct Duck {
                 struct Hen {
+                    Hen() {}
                     int wings;
                 };
             };
         };
         "};
     let rs = quote! {
-        ffi::Turkey_Duck_Hen::make_unique()
+        ffi::Turkey_Duck_Hen::make_unique();
     };
     run_test("", hdr, rs, &[], &["Turkey_Duck_Hen"]);
 }

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5412,6 +5412,23 @@ fn test_closure() {
 }
 
 #[test]
+fn test_multiply_nested_inner_type() {
+    let hdr = indoc! {"
+        struct Turkey {
+            struct Duck {
+                struct Hen {
+                    int wings;
+                };
+            };
+        };
+        "};
+    let rs = quote! {
+        ffi::Turkey_Duck_Hen::make_unique()
+    };
+    run_test("", hdr, rs, &[], &["Turkey_Duck_Hen"]);
+}
+
+#[test]
 fn test_underscored_namespace_for_inner_type() {
     let hdr = indoc! {"
         namespace __foo {


### PR DESCRIPTION
As described in #884, the machinery for creating implicit constructors is not compatible with nested (inner) types. For now, cease to generate any implicit constructors for such types.