### PR TITLE
Use implicit special members for nested types

### DIFF
--- a/book/src/naming.md
+++ b/book/src/naming.md
@@ -51,7 +51,6 @@ autocxx_integration_tests::doctest(
 struct Turkey {
     struct Duck {
         struct Hen {
-            Hen() {}
             int wings;
         };
     };
@@ -72,8 +71,6 @@ fn main() {
 }
 )
 ```
-
-(Currently, only explicit constructors are supported for such nested types.)
 
 ## Overloads
 


### PR DESCRIPTION
Have to pass around more context to properly default constructors.

Fixes google/autocxx#884

- [x] Tests pass
- [x] Appropriate changes to README are included in PR