### PR TITLE
Force generating wrappers for test functions taking reference parameters

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -7888,6 +7888,10 @@ fn test_nonconst_reference_parameter() {
     let hdr = indoc! {"
     #include <stdint.h>
     #include <string>
+
+    // Force generating a wrapper for the second `take_a`.
+    struct NOP { void take_a(); };
+
     struct A {
         std::string so_we_are_non_trivial;
     };
@@ -7897,7 +7901,7 @@ fn test_nonconst_reference_parameter() {
         let mut heap_obj = ffi::A::make_unique();
         ffi::take_a(heap_obj.pin_mut());
     };
-    run_test("", hdr, rs, &["A", "take_a"], &[]);
+    run_test("", hdr, rs, &["NOP", "A", "take_a"], &[]);
 }
 
 #[test]
@@ -7905,6 +7909,10 @@ fn test_nonconst_reference_method_parameter() {
     let hdr = indoc! {"
     #include <stdint.h>
     #include <string>
+
+    // Force generating a wrapper for the second `take_a`.
+    struct NOP { void take_a(); };
+
     struct A {
         std::string so_we_are_non_trivial;
     };
@@ -7917,7 +7925,7 @@ fn test_nonconst_reference_method_parameter() {
         let b = ffi::B::make_unique();
         b.take_a(a.pin_mut());
     };
-    run_test("", hdr, rs, &["A", "B"], &[]);
+    run_test("", hdr, rs, &["NOP", "A", "B"], &[]);
 }
 
 #[test]


### PR DESCRIPTION
They don't work, as I reported in google/autocxx#873.