### PR TITLE
Repro problem with copy assignment operators.

### DIFF
--- a/engine/src/conversion/analysis/fun/implicit_constructors.rs
+++ b/engine/src/conversion/analysis/fun/implicit_constructors.rs
@@ -573,11 +573,8 @@ fn find_explicit_items(apis: &ApiVec<FnPrePhase1>) -> HashMap<ExplicitType, Expl
                         let receiver_mutability = &param_details
                             .iter()
                             .next()
-                            .unwrap()
-                            .self_type
-                            .as_ref()
-                            .unwrap()
-                            .1;
+                            .map(|p| p.self_type.as_ref().unwrap().1.clone())
+                            .unwrap_or(ReceiverMutability::Const);
                         match receiver_mutability {
                             ReceiverMutability::Const => ExplicitKind::ConstCopyAssignmentOperator,
                             ReceiverMutability::Mutable => {

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1973,6 +1973,12 @@ impl Api<FnPhase> {
                 }
             },
             Api::RustSubclassFn { subclass, .. } => subclass.0.name.clone(),
+            Api::IgnoredItem { name, ctx, .. } => match ctx {
+                ErrorContext::Method { self_ty, .. } => {
+                    QualifiedName::new(name.name.get_namespace(), self_ty.clone())
+                }
+                _ => name.name.clone(),
+            },
             _ => self.name().clone(),
         }
     }

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1970,7 +1970,11 @@ impl Api<FnPhase> {
                 }
             },
             Api::RustSubclassFn { subclass, .. } => subclass.0.name.clone(),
-            Api::IgnoredItem { name, ctx, .. } => match ctx.get_type() {
+            Api::IgnoredItem {
+                name,
+                ctx: Some(ctx),
+                ..
+            } => match ctx.get_type() {
                 ErrorContextType::Method { self_ty, .. } => {
                     QualifiedName::new(name.name.get_namespace(), self_ty.clone())
                 }

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -135,7 +135,7 @@ fn analyze_struct(
     if details.vis != CppVisibility::Public {
         return Err(ConvertErrorWithContext(
             ConvertError::NonPublicNestedType,
-            Some(ErrorContext::Item(id)),
+            Some(ErrorContext::new_for_item(id)),
         ));
     }
     let metadata = BindgenSemanticAttributes::new_retaining_others(&mut details.item.attrs);
@@ -157,11 +157,14 @@ fn analyze_struct(
         if details.has_rvalue_reference_fields {
             return Err(ConvertErrorWithContext(
                 ConvertError::RValueReferenceField,
-                Some(ErrorContext::Item(id)),
+                Some(ErrorContext::new_for_item(id)),
             ));
         }
         if let Some(err) = field_conversion_errors.into_iter().next() {
-            return Err(ConvertErrorWithContext(err, Some(ErrorContext::Item(id))));
+            return Err(ConvertErrorWithContext(
+                err,
+                Some(ErrorContext::new_for_item(id)),
+            ));
         }
         TypeKind::Pod
     } else {

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -77,7 +77,7 @@ fn create_ignore_item(api: Api<FnPhase>, err: ConvertError) -> Api<FnPhase> {
                         ..
                     },
                 ..
-            } => ErrorContext::new_without_code(),
+            } => None,
             Api::Function {
                 analysis:
                     FnAnalysis {
@@ -88,8 +88,8 @@ fn create_ignore_item(api: Api<FnPhase>, err: ConvertError) -> Api<FnPhase> {
                         ..
                     },
                 ..
-            } => ErrorContext::new_for_method(self_ty.get_final_ident(), id),
-            _ => ErrorContext::new_for_item(id),
+            } => Some(ErrorContext::new_for_method(self_ty.get_final_ident(), id)),
+            _ => Some(ErrorContext::new_for_item(id)),
         },
     }
 }

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -77,7 +77,7 @@ fn create_ignore_item(api: Api<FnPhase>, err: ConvertError) -> Api<FnPhase> {
                         ..
                     },
                 ..
-            } => ErrorContext::NoCode,
+            } => ErrorContext::new_without_code(),
             Api::Function {
                 analysis:
                     FnAnalysis {
@@ -88,11 +88,8 @@ fn create_ignore_item(api: Api<FnPhase>, err: ConvertError) -> Api<FnPhase> {
                         ..
                     },
                 ..
-            } => ErrorContext::Method {
-                self_ty: self_ty.get_final_ident(),
-                method: id,
-            },
-            _ => ErrorContext::Item(id),
+            } => ErrorContext::new_for_method(self_ty.get_final_ident(), id),
+            _ => ErrorContext::new_for_item(id),
         },
     }
 }

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -19,15 +19,9 @@ use crate::{conversion::api::Api, known_types};
 /// know about at all. In either case, we don't simply remove the type, but instead
 /// replace it with an error marker.
 pub(crate) fn filter_apis_by_ignored_dependents(mut apis: ApiVec<FnPhase>) -> ApiVec<FnPhase> {
-    let (ignored_items, valid_items): (Vec<&Api<_>>, Vec<&Api<_>>) = apis.iter().partition(|api| {
-        matches!(
-            api,
-            Api::IgnoredItem {
-                ctx: ErrorContext::Item(..),
-                ..
-            }
-        )
-    });
+    let (ignored_items, valid_items): (Vec<&Api<_>>, Vec<&Api<_>>) = apis
+        .iter()
+        .partition(|api| matches!(api, Api::IgnoredItem { .. }));
     let mut ignored_items: HashSet<_> = ignored_items
         .into_iter()
         .map(|api| api.name().clone())

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -96,14 +96,14 @@ fn get_replacement_typedef(
     match type_conversion_results {
         Err(err) => Err(ConvertErrorWithContext(
             err,
-            Some(ErrorContext::Item(name.name.get_final_ident())),
+            Some(ErrorContext::new_for_item(name.name.get_final_ident())),
         )),
         Ok(Annotated {
             ty: syn::Type::Path(ref typ),
             ..
         }) if QualifiedName::from_type_path(typ) == name.name => Err(ConvertErrorWithContext(
             ConvertError::InfinitelyRecursiveTypedef(name.name.clone()),
-            Some(ErrorContext::Item(name.name.get_final_ident())),
+            Some(ErrorContext::new_for_item(name.name.get_final_ident())),
         )),
         Ok(mut final_type) => {
             converted_type.ty = Box::new(final_type.ty.clone());

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -467,7 +467,7 @@ pub(crate) enum Api<T: AnalysisPhase> {
     IgnoredItem {
         name: ApiName,
         err: ConvertError,
-        ctx: ErrorContext,
+        ctx: Option<ErrorContext>,
     },
     /// A Rust type which is not a C++ type.
     RustType { name: ApiName, path: RustPath },

--- a/engine/src/conversion/apivec.rs
+++ b/engine/src/conversion/apivec.rs
@@ -65,7 +65,7 @@ impl<P: AnalysisPhase> ApiVec<P> {
                 self.push(Api::IgnoredItem {
                     name: ApiName::new_from_qualified_name(name.clone()),
                     err: ConvertError::DuplicateItemsFoundInParsing,
-                    ctx: ErrorContext::Item(name.get_final_ident()),
+                    ctx: ErrorContext::new_for_item(name.get_final_ident()),
                 })
             }
         } else {

--- a/engine/src/conversion/apivec.rs
+++ b/engine/src/conversion/apivec.rs
@@ -65,7 +65,7 @@ impl<P: AnalysisPhase> ApiVec<P> {
                 self.push(Api::IgnoredItem {
                     name: ApiName::new_from_qualified_name(name.clone()),
                     err: ConvertError::DuplicateItemsFoundInParsing,
-                    ctx: ErrorContext::new_for_item(name.get_final_ident()),
+                    ctx: Some(ErrorContext::new_for_item(name.get_final_ident())),
                 })
             }
         } else {

--- a/engine/src/conversion/apivec.rs
+++ b/engine/src/conversion/apivec.rs
@@ -53,32 +53,21 @@ impl<P: AnalysisPhase> ApiVec<P> {
         let already_contains = self.already_contains(name);
         if already_contains {
             if api.discard_duplicates() {
+                // This is already an IgnoredItem or something else where
+                // we can silently drop it.
                 log::info!("Discarding duplicate API for {}", name);
             } else {
-                panic!(
-                    "Already have an API with that name: {}. API was {:?}",
-                    name, api
+                log::info!(
+                    "Duplicate API for {} - removing all of them and replacing with an IgnoredItem.",
+                    name
                 );
+                self.retain(|api| api.name() != name);
+                self.push(Api::IgnoredItem {
+                    name: ApiName::new_from_qualified_name(name.clone()),
+                    err: ConvertError::DuplicateItemsFoundInParsing,
+                    ctx: ErrorContext::Item(name.get_final_ident()),
+                })
             }
-        }
-        self.names.insert(name.clone());
-        self.apis.push(api)
-    }
-
-    pub(crate) fn push_eliminating_duplicates(&mut self, api: Api<P>) {
-        let name = api.name();
-        let already_contains = self.already_contains(name);
-        if already_contains {
-            log::info!(
-                "Duplicate API for {} - removing all of them and replacing with an IgnoredItem.",
-                name
-            );
-            self.retain(|api| api.name() != name);
-            self.push(Api::IgnoredItem {
-                name: ApiName::new_from_qualified_name(name.clone()),
-                err: ConvertError::DuplicateItemsFoundInParsing,
-                ctx: ErrorContext::Item(name.get_final_ident()),
-            })
         } else {
             self.names.insert(name.clone());
             self.apis.push(api)

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -942,7 +942,7 @@ impl<'a> RsCodeGenerator<'a> {
                     #[doc = #err]
                     pub struct #id;
                 }),
-                Some(Use::UsedFromBindgen),
+                Some(Use::SpecificNameFromBindgen(id)),
             ),
             ErrorContextType::SanitizedItem(id) => (
                 // Guaranteed to be no impl blocks - populate directly in output mod.

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -564,8 +564,12 @@ impl<'a> RsCodeGenerator<'a> {
                     subclasses_with_a_single_trivial_constructor.contains(&name.0.name);
                 self.generate_subclass(name, &superclass, methods, generate_peer_constructor)
             }
-            Api::IgnoredItem { err, ctx, .. } => Self::generate_error_entry(err, ctx),
-            Api::SubclassTraitItem { .. } => RsCodegenResult::default(),
+            Api::IgnoredItem {
+                err,
+                ctx: Some(ctx),
+                ..
+            } => Self::generate_error_entry(err, ctx),
+            Api::IgnoredItem { .. } | Api::SubclassTraitItem { .. } => RsCodegenResult::default(),
         }
     }
 
@@ -961,7 +965,6 @@ impl<'a> RsCodeGenerator<'a> {
                 None,
                 None,
             ),
-            ErrorContextType::NoCode => (None, None, None),
         };
         RsCodegenResult {
             impl_entry,

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -130,17 +130,6 @@ pub(crate) enum ErrorContext {
     NoCode,
 }
 
-impl ErrorContext {
-    /// Return the ID in the output mod with which this should be associated
-    pub(crate) fn get_id(&self) -> Option<&Ident> {
-        match self {
-            ErrorContext::Item(id) => Some(id),
-            ErrorContext::Method { self_ty, method: _ } => Some(self_ty),
-            ErrorContext::NoCode => None,
-        }
-    }
-}
-
 impl std::fmt::Display for ErrorContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -136,14 +136,7 @@ pub(crate) struct ErrorContext(ErrorContextType, PhantomSanitized);
 pub(crate) enum ErrorContextType {
     Item(Ident),
     SanitizedItem(Ident),
-    Method {
-        self_ty: Ident,
-        method: Ident,
-    },
-    /// This error means the context where the code would be generated doesn't exist, so there's
-    /// nowhere to attach the error, but we still want to record that we had an error generating
-    /// it.
-    NoCode,
+    Method { self_ty: Ident, method: Ident },
 }
 
 impl ErrorContext {
@@ -173,10 +166,6 @@ impl ErrorContext {
         }
     }
 
-    pub(crate) fn new_without_code() -> Self {
-        Self(ErrorContextType::NoCode, PhantomSanitized)
-    }
-
     /// Because errors may be generated for invalid types or identifiers,
     /// we may need to scrub the name
     fn sanitize_error_ident(id: &Ident) -> Option<Ident> {
@@ -202,7 +191,6 @@ impl std::fmt::Display for ErrorContext {
         match &self.0 {
             ErrorContextType::Item(id) | ErrorContextType::SanitizedItem(id) => write!(f, "{}", id),
             ErrorContextType::Method { self_ty, method } => write!(f, "{}::{}", self_ty, method),
-            ErrorContextType::NoCode => write!(f, "<not generated>"),
         }
     }
 }

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -14,7 +14,7 @@ use super::{
     convert_error::{ConvertErrorWithContext, ErrorContext},
     ConvertError,
 };
-use crate::types::{Namespace, QualifiedName};
+use crate::types::{make_ident, Namespace, QualifiedName};
 
 /// Run some code which may generate a ConvertError.
 /// If it does, try to note the problem in our output APIs
@@ -35,7 +35,15 @@ where
         }
         Err(ConvertErrorWithContext(err, Some(ctx))) => {
             eprintln!("Ignored item {}: {}", ctx, err);
-            if let Some(item) = ignored_item(ns, ctx, err) {
+            let id = match &ctx {
+                ErrorContext::Item(id) => id.clone(),
+                ErrorContext::Method { self_ty, method } => {
+                    make_ident(format!("{}_{}", self_ty, method))
+                }
+                ErrorContext::NoCode => panic!("Shouldn't happen"),
+            };
+            let api_name = ApiName::new_from_qualified_name(QualifiedName::new(ns, id));
+            if let Some(item) = ignored_item(api_name, ctx, err) {
                 apis.push(item);
             }
             None
@@ -78,7 +86,7 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
     ) -> Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext>,
 {
     out_apis.extend(in_apis.into_iter().flat_map(|api| {
-        let tn = api.name().clone();
+        let fullname = api.name_info().clone();
         let result: Result<Box<dyn Iterator<Item = Api<B>>>, ConvertErrorWithContext> = match api {
             // No changes to any of these...
             Api::ConcreteType {
@@ -153,23 +161,23 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                 analysis,
             } => struct_conversion(name, details, analysis),
         };
-        api_or_error(tn, result)
+        api_or_error(fullname, result)
     }))
 }
 
 fn api_or_error<T: AnalysisPhase + 'static>(
-    name: QualifiedName,
+    name: ApiName,
     api_or_error: Result<Box<dyn Iterator<Item = Api<T>>>, ConvertErrorWithContext>,
 ) -> Box<dyn Iterator<Item = Api<T>>> {
     match api_or_error {
         Ok(opt) => opt,
         Err(ConvertErrorWithContext(err, None)) => {
-            eprintln!("Ignored {}: {}", name, err);
+            eprintln!("Ignored {}: {}", name.cpp_name(), err);
             Box::new(std::iter::empty())
         }
         Err(ConvertErrorWithContext(err, Some(ctx))) => {
-            eprintln!("Ignored {}: {}", name, err);
-            Box::new(ignored_item(name.get_namespace(), ctx, err).into_iter())
+            eprintln!("Ignored {}: {}", name.cpp_name(), err);
+            Box::new(ignored_item(name, ctx, err).into_iter())
         }
     }
 }
@@ -188,22 +196,19 @@ pub(crate) fn convert_item_apis<F, A, B: 'static>(
     B: AnalysisPhase,
 {
     out_apis.extend(in_apis.into_iter().flat_map(|api| {
+        let fullname = api.name_info().clone();
         let tn = api.name().clone();
         let result = fun(api).map_err(|e| {
             ConvertErrorWithContext(e, Some(ErrorContext::Item(tn.get_final_ident())))
         });
-        api_or_error(tn, result)
+        api_or_error(fullname, result)
     }))
 }
 
 fn ignored_item<A: AnalysisPhase>(
-    ns: &Namespace,
+    name: ApiName,
     ctx: ErrorContext,
     err: ConvertError,
 ) -> Option<Api<A>> {
-    ctx.get_id().cloned().map(|id| Api::IgnoredItem {
-        name: ApiName::new(ns, id),
-        err,
-        ctx,
-    })
+    Some(Api::IgnoredItem { name, err, ctx })
 }

--- a/engine/src/conversion/parse/bindgen_semantic_attributes.rs
+++ b/engine/src/conversion/parse/bindgen_semantic_attributes.rs
@@ -59,7 +59,7 @@ impl BindgenSemanticAttributes {
         if self.has_attr("unused_template_param") {
             Err(ConvertErrorWithContext(
                 ConvertError::UnusedTemplateParam,
-                Some(ErrorContext::Item(id_for_context.clone())),
+                Some(ErrorContext::new_for_item(id_for_context.clone())),
             ))
         } else {
             Ok(())

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -183,7 +183,7 @@ impl<'a> ParseBindgen<'a> {
                 };
                 if let Some(api) = api {
                     if !self.config.is_on_blocklist(&api.name().to_cpp_name()) {
-                        self.apis.push_eliminating_duplicates(api);
+                        self.apis.push(api);
                     }
                 }
                 Ok(())
@@ -195,7 +195,7 @@ impl<'a> ParseBindgen<'a> {
                     item: e,
                 };
                 if !self.config.is_on_blocklist(&api.name().to_cpp_name()) {
-                    self.apis.push_eliminating_duplicates(api);
+                    self.apis.push(api);
                 }
                 Ok(())
             }
@@ -252,15 +252,14 @@ impl<'a> ParseBindgen<'a> {
                                 ));
                             }
                             let annotations = BindgenSemanticAttributes::new(&use_item.attrs);
-                            self.apis
-                                .push_eliminating_duplicates(UnanalyzedApi::Typedef {
-                                    name: api_name(ns, new_id.clone(), &annotations),
-                                    item: TypedefKind::Use(parse_quote! {
-                                        pub use #old_path as #new_id;
-                                    }),
-                                    old_tyname: Some(old_tyname),
-                                    analysis: (),
-                                });
+                            self.apis.push(UnanalyzedApi::Typedef {
+                                name: api_name(ns, new_id.clone(), &annotations),
+                                item: TypedefKind::Use(parse_quote! {
+                                    pub use #old_path as #new_id;
+                                }),
+                                old_tyname: Some(old_tyname),
+                                analysis: (),
+                            });
                             break;
                         }
                         _ => {
@@ -275,7 +274,7 @@ impl<'a> ParseBindgen<'a> {
             }
             Item::Const(const_item) => {
                 let annotations = BindgenSemanticAttributes::new(&const_item.attrs);
-                self.apis.push_eliminating_duplicates(UnanalyzedApi::Const {
+                self.apis.push(UnanalyzedApi::Const {
                     name: api_name(ns, const_item.ident.clone(), &annotations),
                     const_item,
                 });
@@ -285,13 +284,12 @@ impl<'a> ParseBindgen<'a> {
                 let annotations = BindgenSemanticAttributes::new(&ity.attrs);
                 // It's known that sometimes bindgen will give us duplicate typedefs with the
                 // same name - see test_issue_264.
-                self.apis
-                    .push_eliminating_duplicates(UnanalyzedApi::Typedef {
-                        name: api_name(ns, ity.ident.clone(), &annotations),
-                        item: TypedefKind::Type(ity),
-                        old_tyname: None,
-                        analysis: (),
-                    });
+                self.apis.push(UnanalyzedApi::Typedef {
+                    name: api_name(ns, ity.ident.clone(), &annotations),
+                    item: TypedefKind::Type(ity),
+                    old_tyname: None,
+                    analysis: (),
+                });
                 Ok(())
             }
             _ => Err(ConvertErrorWithContext(

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -50,7 +50,7 @@ pub(crate) fn api_name_qualified(
 ) -> Result<ApiName, ConvertErrorWithContext> {
     match validate_ident_ok_for_cxx(&id.to_string()) {
         Err(e) => {
-            let ctx = ErrorContext::Item(id);
+            let ctx = ErrorContext::new_for_item(id);
             Err(ConvertErrorWithContext(e, Some(ctx)))
         }
         Ok(..) => Ok(api_name(ns, id, attrs)),
@@ -248,7 +248,7 @@ impl<'a> ParseBindgen<'a> {
                             if new_tyname == old_tyname {
                                 return Err(ConvertErrorWithContext(
                                     ConvertError::InfinitelyRecursiveTypedef(new_tyname),
-                                    Some(ErrorContext::Item(new_id.clone())),
+                                    Some(ErrorContext::new_for_item(new_id.clone())),
                                 ));
                             }
                             let annotations = BindgenSemanticAttributes::new(&use_item.attrs);

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -131,7 +131,7 @@ impl ParseForeignMod {
         while !self.funcs_to_convert.is_empty() {
             let mut fun = self.funcs_to_convert.remove(0);
             fun.self_ty = self.method_receivers.get(&fun.ident).cloned();
-            apis.push_eliminating_duplicates(UnanalyzedApi::Function {
+            apis.push(UnanalyzedApi::Function {
                 name: ApiName::new_with_cpp_name(
                     &self.ns,
                     fun.ident.clone(),

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -93,7 +93,7 @@ impl ParseForeignMod {
             }
             ForeignItem::Static(item) => Err(ConvertErrorWithContext(
                 ConvertError::StaticData(item.ident.to_string()),
-                Some(ErrorContext::Item(item.ident)),
+                Some(ErrorContext::new_for_item(item.ident)),
             )),
             _ => Err(ConvertErrorWithContext(
                 ConvertError::UnexpectedForeignItem,

--- a/integration-tests/tests/code_checkers.rs
+++ b/integration-tests/tests/code_checkers.rs
@@ -12,6 +12,7 @@ use std::{
     path::PathBuf,
 };
 
+use itertools::{Either, Itertools};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::Item;
@@ -49,17 +50,33 @@ impl CodeCheckerFns for ErrorFinder {
 }
 
 fn find_ffi_items(f: syn::File) -> Result<Vec<Item>, TestError> {
-    Ok(f.items
+    let md = f
+        .items
         .into_iter()
         .filter_map(|i| match i {
             Item::Mod(itm) => Some(itm),
             _ => None,
         })
         .next()
-        .ok_or(TestError::RsCodeExaminationFail)?
+        .ok_or(TestError::RsCodeExaminationFail)?;
+    let mut items = Vec::new();
+    find_all_non_mod_items(md, &mut items);
+    Ok(items)
+}
+
+fn find_all_non_mod_items(md: syn::ItemMod, items: &mut Vec<Item>) {
+    let (more_mods, mut these_items): (Vec<_>, Vec<_>) = md
         .content
-        .ok_or(TestError::RsCodeExaminationFail)?
-        .1)
+        .into_iter()
+        .flat_map(|(_, more_items)| more_items.into_iter())
+        .partition_map(|i| match i {
+            Item::Mod(itm) => Either::Left(itm),
+            _ => Either::Right(i),
+        });
+    items.append(&mut these_items);
+    for md in more_mods.into_iter() {
+        find_all_non_mod_items(md, items);
+    }
 }
 
 struct StringFinder(Vec<&'static str>);

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5849,6 +5849,12 @@ fn test_no_impl() {
 fn test_generate_all() {
     let hdr = indoc! {"
         #include <cstdint>
+        #include <string>
+        struct Foo {
+            Foo() {}
+            std::string a;
+        };
+        inline void autocxx_deliberate_fail(Foo) {}
         inline uint32_t give_int() {
             return 5;
         }


### PR DESCRIPTION
This test case currently hits the problem being fixed in #911,
but after that's fixed, we seem to instead see a panic caused by
a copy assignment operator having too few parameters.