### PR TITLE
Ignore dependents of ignored methods.

### DIFF
--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -19,15 +19,9 @@ use crate::{conversion::api::Api, known_types};
 /// know about at all. In either case, we don't simply remove the type, but instead
 /// replace it with an error marker.
 pub(crate) fn filter_apis_by_ignored_dependents(mut apis: ApiVec<FnPhase>) -> ApiVec<FnPhase> {
-    let (ignored_items, valid_items): (Vec<&Api<_>>, Vec<&Api<_>>) = apis.iter().partition(|api| {
-        matches!(
-            api,
-            Api::IgnoredItem {
-                ctx: ErrorContext::Item(..),
-                ..
-            }
-        )
-    });
+    let (ignored_items, valid_items): (Vec<&Api<_>>, Vec<&Api<_>>) = apis
+        .iter()
+        .partition(|api| matches!(api, Api::IgnoredItem { .. }));
     let mut ignored_items: HashSet<_> = ignored_items
         .into_iter()
         .map(|api| api.name().clone())


### PR DESCRIPTION
Previously, a dependency on an ignored _item_ would cause dependent items to also
be ignored, but there was no such allowance for dependence on ignored methods.
Previously we never had dependencies on methods, but in subclasses, we do.
