### PR TITLE
Garbage collect methods properly.

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1973,6 +1973,12 @@ impl Api<FnPhase> {
                 }
             },
             Api::RustSubclassFn { subclass, .. } => subclass.0.name.clone(),
+            Api::IgnoredItem { name, ctx, .. } => match ctx {
+                ErrorContext::Method { self_ty, .. } => {
+                    QualifiedName::new(name.name.get_namespace(), self_ty.clone())
+                }
+                _ => name.name.clone(),
+            },
             _ => self.name().clone(),
         }
     }


### PR DESCRIPTION
Previously we may have discarded IgnoredItems related to methods
because we checked their function name against the allowlist, not their
type name.
