### PR TITLE
Constructors taking non-reference parameters give a `NotAPin` error

### DIFF
--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -29,7 +29,7 @@ use crate::{
             TraitMethodDetails,
         },
         api::UnsafetyNeeded,
-        codegen_rs::lifetime::add_lifetime_to_all_params,
+        codegen_rs::lifetime::add_lifetime_to_all_reference_params,
     },
     types::{Namespace, QualifiedName},
 };
@@ -355,7 +355,7 @@ impl<'a> FnGenerator<'a> {
         let rust_name = make_ident(&self.rust_name);
         let any_references = self.param_details.iter().any(|pd| pd.was_reference);
         let (lifetime_param, lifetime_addition) = if any_references {
-            add_lifetime_to_all_params(&mut wrapper_params);
+            add_lifetime_to_all_reference_params(&mut wrapper_params);
             (quote! { <'a> }, quote! { + 'a })
         } else {
             (quote! {}, quote! {})

--- a/engine/src/conversion/codegen_rs/lifetime.rs
+++ b/engine/src/conversion/codegen_rs/lifetime.rs
@@ -164,14 +164,19 @@ fn add_lifetime_to_reference(tyr: &mut syn::TypeReference) {
     tyr.lifetime = Some(parse_quote! { 'a })
 }
 
-pub(crate) fn add_lifetime_to_all_params(params: &mut Punctuated<FnArg, Comma>) {
+pub(crate) fn add_lifetime_to_all_reference_params(params: &mut Punctuated<FnArg, Comma>) {
     for mut param in params.iter_mut() {
         match &mut param {
             FnArg::Typed(PatType { ty, .. }) => match ty.as_mut() {
                 Type::Path(TypePath {
                     path: Path { segments, .. },
                     ..
-                }) => add_lifetime_to_pinned_reference(segments).unwrap(),
+                }) => {
+                    // This function will check whether this path is a pinned reference and if
+                    // so, add a lifetime to it. Otherwise, it will return an error - which
+                    // we ignore.
+                    add_lifetime_to_pinned_reference(segments).unwrap_or_default()
+                }
                 Type::Reference(tyr) => add_lifetime_to_reference(tyr),
                 _ => {}
             },

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -1593,16 +1593,14 @@ fn test_issue_931() {
 fn test_issue_936() {
     let cxx = "";
     let hdr = indoc! {"
-    namespace a {
-    struct b;
-    }
-    class GURL {
+    struct a;
+    class B {
     public:
-        GURL(a::b &, bool);
+        B(a &, bool);
     };
     "};
     let rs = quote! {};
-    run_test(cxx, hdr, rs, &["GURL"], &[]);
+    run_test(cxx, hdr, rs, &["B"], &[]);
 }
 
 #[test]

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -1590,6 +1590,22 @@ fn test_issue_931() {
 }
 
 #[test]
+fn test_issue_936() {
+    let cxx = "";
+    let hdr = indoc! {"
+    namespace a {
+    struct b;
+    }
+    class GURL {
+    public:
+        GURL(a::b &, bool);
+    };
+    "};
+    let rs = quote! {};
+    run_test(cxx, hdr, rs, &["GURL"], &[]);
+}
+
+#[test]
 fn test_method_pass_nonpod_by_value_with_up() {
     // Checks that existing UniquePtr params are not wrecked
     // by the conversion we do here.


### PR DESCRIPTION
Fixes #936.