### PR TITLE
Fix inconsistent name of `extern_rust_function`

### DIFF
--- a/engine/src/ast_discoverer.rs
+++ b/engine/src/ast_discoverer.rs
@@ -516,7 +516,7 @@ mod tests {
     fn test_extern_rust_fun() {
         let mut discoveries = Discoveries::default();
         let itm = parse_quote! {
-            #[autocxx::extern_rust::extern_rust_fun]
+            #[autocxx::extern_rust::extern_rust_function]
             fn bar(a: cxx::UniquePtr<ffi::xxx>) {
             }
         };

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -6521,13 +6521,18 @@ fn test_box_via_extern_rust_in_mod() {
 }
 
 #[test]
-fn test_extern_rust_fn() {
+fn test_extern_rust_fn_simple() {
+    let cpp = indoc! {"
+        void foo() {
+            my_rust_fun();
+        }
+    "};
     let hdr = indoc! {"
         #include <cxx.h>
         inline void do_thing() {}
     "};
     run_test_ex(
-        "",
+        cpp,
         hdr,
         quote! {},
         quote! {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -452,7 +452,7 @@ impl IncludeCppConfig {
     fn is_concrete_type(&self, cpp_name: &str) -> bool {
         self.concretes
             .values()
-            .any(|val| &val.to_string() == cpp_name)
+            .any(|val| val.to_string() == cpp_name)
     }
 
     /// In case there are multiple sets of ffi mods in a single binary,

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -450,9 +450,7 @@ impl IncludeCppConfig {
     }
 
     fn is_concrete_type(&self, cpp_name: &str) -> bool {
-        self.concretes
-            .values()
-            .any(|val| val.to_string() == cpp_name)
+        self.concretes.values().any(|val| *val == cpp_name)
     }
 
     /// In case there are multiple sets of ffi mods in a single binary,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -29,7 +29,7 @@ use syn::{
 /// and the standalone macro discoverer
 pub mod directives {
     pub static EXTERN_RUST_TYPE: &str = "extern_rust_type";
-    pub static EXTERN_RUST_FUN: &str = "extern_rust_fun";
+    pub static EXTERN_RUST_FUN: &str = "extern_rust_function";
     pub static SUBCLASS: &str = "subclass";
 }
 


### PR DESCRIPTION
And enhance the test to ensure we can actually reach such a function from C++.