### PR TITLE
extern_rust_{type|fun} work without autodiscover.

### DIFF
--- a/engine/src/ast_discoverer.rs
+++ b/engine/src/ast_discoverer.rs
@@ -38,10 +38,12 @@ impl Discoveries {
         this_mod.search_item(item);
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.cpp_list.is_empty()
-            && self.extern_rust_funs.is_empty()
-            && self.extern_rust_types.is_empty()
+    pub(crate) fn found_allowlist(&self) -> bool {
+        !self.cpp_list.is_empty()
+    }
+
+    pub(crate) fn found_rust(&self) -> bool {
+        !self.extern_rust_funs.is_empty() || !self.extern_rust_types.is_empty()
     }
 
     pub(crate) fn extend(&mut self, other: Self) {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -510,19 +510,9 @@ impl IncludeCppConfig {
         )
     }
 
-    pub fn confirm_complete(&mut self, auto_allowlist: bool) -> ParseResult<()> {
+    pub fn confirm_complete(&mut self) {
         if matches!(self.allowlist, Allowlist::Unspecified(_)) {
-            if auto_allowlist {
-                self.allowlist = Allowlist::Specific(Vec::new());
-                Ok(())
-            } else {
-                Err(syn::Error::new(
-                    Span::call_site(),
-                    "expected either generate!/generate_ns! or generate_all!",
-                ))
-            }
-        } else {
-            Ok(())
+            self.allowlist = Allowlist::Specific(Vec::new());
         }
     }
 


### PR DESCRIPTION
These directives were previously only found when autodiscover mode was enabled,
but are safer and more useful than autodiscover mode, so are now enabled
irrespective.

Fixes #946.
