### PR TITLE
Support extern_rust_function on methods.

### DIFF
--- a/engine/src/ast_discoverer.rs
+++ b/engine/src/ast_discoverer.rs
@@ -15,11 +15,11 @@ use autocxx_parser::{
 use itertools::Itertools;
 use proc_macro2::Ident;
 use syn::{
-    punctuated::Punctuated, Attribute, Binding, Expr, ExprAssign, ExprAssignOp, ExprAwait,
-    ExprBinary, ExprBox, ExprBreak, ExprCast, ExprField, ExprGroup, ExprLet, ExprParen,
+    parse_quote, punctuated::Punctuated, Attribute, Binding, Expr, ExprAssign, ExprAssignOp,
+    ExprAwait, ExprBinary, ExprBox, ExprBreak, ExprCast, ExprField, ExprGroup, ExprLet, ExprParen,
     ExprReference, ExprTry, ExprType, ExprUnary, ImplItem, Item, ItemEnum, ItemStruct, Pat, PatBox,
-    PatReference, PatSlice, PatTuple, Path, ReturnType, Stmt, TraitItem, Type, TypeArray,
-    TypeGroup, TypeParamBound, TypeParen, TypePtr, TypeReference, TypeSlice,
+    PatReference, PatSlice, PatTuple, Path, Receiver, ReturnType, Signature, Stmt, TraitItem, Type,
+    TypeArray, TypeGroup, TypeParamBound, TypeParen, TypePtr, TypeReference, TypeSlice,
 };
 
 #[derive(Default)]
@@ -29,13 +29,25 @@ pub(super) struct Discoveries {
     pub(super) extern_rust_types: Vec<RustPath>,
 }
 
+#[derive(Debug)]
+pub enum DiscoveryErr {
+    FoundExternRustFunOnTypeWithoutClearReceiver,
+    NonReferenceReceiver,
+    NoParameterOnMethod,
+    FoundExternRustFunWithinMod,
+}
+
 impl Discoveries {
-    pub(super) fn search_item(&mut self, item: &Item, mod_path: Option<RustPath>) {
+    pub(super) fn search_item(
+        &mut self,
+        item: &Item,
+        mod_path: Option<RustPath>,
+    ) -> Result<(), DiscoveryErr> {
         let mut this_mod = PerModDiscoveries {
             discoveries: self,
             mod_path,
         };
-        this_mod.search_item(item);
+        this_mod.search_item(item)
     }
 
     pub(crate) fn found_allowlist(&self) -> bool {
@@ -66,19 +78,19 @@ impl<'b> PerModDiscoveries<'b> {
         }
     }
 
-    fn search_item(&mut self, item: &Item) {
+    fn search_item(&mut self, item: &Item) -> Result<(), DiscoveryErr> {
         match item {
             Item::Fn(fun) => {
                 for stmt in &fun.block.stmts {
-                    self.search_stmt(stmt)
+                    self.search_stmt(stmt)?
                 }
-                self.search_return_type(&fun.sig.output);
+                self.search_return_type(&fun.sig.output)?;
                 for i in &fun.sig.inputs {
                     match i {
                         syn::FnArg::Receiver(_) => {}
                         syn::FnArg::Typed(pt) => {
-                            self.search_pat(&pt.pat);
-                            self.search_type(&pt.ty);
+                            self.search_pat(&pt.pat)?;
+                            self.search_type(&pt.ty)?;
                         }
                     }
                 }
@@ -86,12 +98,33 @@ impl<'b> PerModDiscoveries<'b> {
                     self.discoveries.extern_rust_funs.push(RustFun {
                         path: self.deeper_path(&fun.sig.ident),
                         sig: fun.sig.clone(),
+                        receiver: None,
                     });
                 }
             }
             Item::Impl(imp) => {
+                let receiver = match imp.trait_ {
+                    // We do not allow 'extern_rust_fun' on trait impls
+                    Some(_) => None,
+                    None => match &*imp.self_ty {
+                        Type::Path(typ) => {
+                            let mut segs = typ.path.segments.iter();
+                            let id = segs.next();
+                            if let Some(seg) = id {
+                                if segs.next().is_some() {
+                                    None
+                                } else {
+                                    Some(self.deeper_path(&seg.ident))
+                                }
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    },
+                };
                 for item in &imp.items {
-                    self.search_impl_item(item)
+                    self.search_impl_item(item, receiver.as_ref())?
                 }
             }
             Item::Mod(md) => {
@@ -102,13 +135,13 @@ impl<'b> PerModDiscoveries<'b> {
                         mod_path,
                     };
                     for item in items {
-                        new_mod.search_item(item)
+                        new_mod.search_item(item)?
                     }
                 }
             }
             Item::Trait(tr) => {
                 for item in &tr.items {
-                    self.search_trait_item(item)
+                    self.search_trait_item(item)?
                 }
             }
             Item::Struct(ItemStruct { ident, attrs, .. })
@@ -121,9 +154,10 @@ impl<'b> PerModDiscoveries<'b> {
             }
             _ => {}
         }
+        Ok(())
     }
 
-    fn search_path(&mut self, path: &Path) {
+    fn search_path(&mut self, path: &Path) -> Result<(), DiscoveryErr> {
         let mut seg_iter = path.segments.iter();
         if let Some(first_seg) = seg_iter.next() {
             if first_seg.ident == "ffi" {
@@ -133,55 +167,61 @@ impl<'b> PerModDiscoveries<'b> {
             }
         }
         for seg in path.segments.iter() {
-            self.search_path_arguments(&seg.arguments);
+            self.search_path_arguments(&seg.arguments)?;
         }
+        Ok(())
     }
 
-    fn search_trait_item(&mut self, itm: &TraitItem) {
+    fn search_trait_item(&mut self, itm: &TraitItem) -> Result<(), DiscoveryErr> {
         if let TraitItem::Method(itm) = itm {
             if let Some(block) = &itm.default {
-                self.search_stmts(block.stmts.iter())
+                self.search_stmts(block.stmts.iter())?
             }
         }
+        Ok(())
     }
 
-    fn search_stmts<'a>(&mut self, stmts: impl Iterator<Item = &'a Stmt>) {
+    fn search_stmts<'a>(
+        &mut self,
+        stmts: impl Iterator<Item = &'a Stmt>,
+    ) -> Result<(), DiscoveryErr> {
         for stmt in stmts {
-            self.search_stmt(stmt)
+            self.search_stmt(stmt)?
         }
+        Ok(())
     }
 
-    fn search_stmt(&mut self, stmt: &Stmt) {
+    fn search_stmt(&mut self, stmt: &Stmt) -> Result<(), DiscoveryErr> {
         match stmt {
             Stmt::Local(lcl) => {
                 if let Some((_, expr)) = &lcl.init {
-                    self.search_expr(expr)
+                    self.search_expr(expr)?
                 }
-                self.search_pat(&lcl.pat);
+                self.search_pat(&lcl.pat)
             }
             Stmt::Item(itm) => self.search_item(itm),
             Stmt::Expr(exp) | Stmt::Semi(exp, _) => self.search_expr(exp),
         }
     }
 
-    fn search_expr(&mut self, expr: &Expr) {
+    fn search_expr(&mut self, expr: &Expr) -> Result<(), DiscoveryErr> {
         match expr {
             Expr::Path(exp) => {
-                self.search_path(&exp.path);
+                self.search_path(&exp.path)?;
             }
             Expr::Macro(_) => {}
-            Expr::Array(array) => self.search_exprs(array.elems.iter()),
+            Expr::Array(array) => self.search_exprs(array.elems.iter())?,
             Expr::Assign(ExprAssign { left, right, .. })
             | Expr::AssignOp(ExprAssignOp { left, right, .. })
             | Expr::Binary(ExprBinary { left, right, .. }) => {
-                self.search_expr(left);
-                self.search_expr(right);
+                self.search_expr(left)?;
+                self.search_expr(right)?;
             }
-            Expr::Async(ass) => self.search_stmts(ass.block.stmts.iter()),
+            Expr::Async(ass) => self.search_stmts(ass.block.stmts.iter())?,
             Expr::Await(ExprAwait { base, .. }) | Expr::Field(ExprField { base, .. }) => {
-                self.search_expr(base)
+                self.search_expr(base)?
             }
-            Expr::Block(blck) => self.search_stmts(blck.block.stmts.iter()),
+            Expr::Block(blck) => self.search_stmts(blck.block.stmts.iter())?,
             Expr::Box(ExprBox { expr, .. })
             | Expr::Break(ExprBreak {
                 expr: Some(expr), ..
@@ -192,185 +232,229 @@ impl<'b> PerModDiscoveries<'b> {
             | Expr::Reference(ExprReference { expr, .. })
             | Expr::Try(ExprTry { expr, .. })
             | Expr::Type(ExprType { expr, .. })
-            | Expr::Unary(ExprUnary { expr, .. }) => self.search_expr(expr),
+            | Expr::Unary(ExprUnary { expr, .. }) => self.search_expr(expr)?,
             Expr::Call(exc) => {
-                self.search_expr(&exc.func);
-                self.search_exprs(exc.args.iter());
+                self.search_expr(&exc.func)?;
+                self.search_exprs(exc.args.iter())?;
             }
-            Expr::Closure(cls) => self.search_expr(&cls.body),
+            Expr::Closure(cls) => self.search_expr(&cls.body)?,
             Expr::Continue(_)
             | Expr::Lit(_)
             | Expr::Break(ExprBreak { expr: None, .. })
             | Expr::Verbatim(_) => {}
             Expr::ForLoop(fl) => {
-                self.search_expr(&fl.expr);
-                self.search_stmts(fl.body.stmts.iter());
+                self.search_expr(&fl.expr)?;
+                self.search_stmts(fl.body.stmts.iter())?;
             }
             Expr::If(exif) => {
-                self.search_expr(&exif.cond);
-                self.search_stmts(exif.then_branch.stmts.iter());
+                self.search_expr(&exif.cond)?;
+                self.search_stmts(exif.then_branch.stmts.iter())?;
                 if let Some((_, else_branch)) = &exif.else_branch {
-                    self.search_expr(else_branch);
+                    self.search_expr(else_branch)?;
                 }
             }
             Expr::Index(exidx) => {
-                self.search_expr(&exidx.expr);
-                self.search_expr(&exidx.index);
+                self.search_expr(&exidx.expr)?;
+                self.search_expr(&exidx.index)?;
             }
             Expr::Let(ExprLet { expr, pat, .. }) => {
-                self.search_expr(expr);
-                self.search_pat(pat);
+                self.search_expr(expr)?;
+                self.search_pat(pat)?;
             }
-            Expr::Loop(exloo) => self.search_stmts(exloo.body.stmts.iter()),
+            Expr::Loop(exloo) => self.search_stmts(exloo.body.stmts.iter())?,
             Expr::Match(exm) => {
-                self.search_expr(&exm.expr);
+                self.search_expr(&exm.expr)?;
                 for a in &exm.arms {
-                    self.search_expr(&a.body);
+                    self.search_expr(&a.body)?;
                     if let Some((_, guard)) = &a.guard {
-                        self.search_expr(guard);
+                        self.search_expr(guard)?;
                     }
                 }
             }
             Expr::MethodCall(mtc) => {
-                self.search_expr(&mtc.receiver);
-                self.search_exprs(mtc.args.iter());
+                self.search_expr(&mtc.receiver)?;
+                self.search_exprs(mtc.args.iter())?;
             }
             Expr::Range(exr) => {
-                self.search_option_expr(&exr.from);
-                self.search_option_expr(&exr.to);
+                self.search_option_expr(&exr.from)?;
+                self.search_option_expr(&exr.to)?;
             }
             Expr::Repeat(exr) => {
-                self.search_expr(&exr.expr);
-                self.search_expr(&exr.len);
+                self.search_expr(&exr.expr)?;
+                self.search_expr(&exr.len)?;
             }
             Expr::Return(exret) => {
                 if let Some(expr) = &exret.expr {
-                    self.search_expr(expr);
+                    self.search_expr(expr)?;
                 }
             }
             Expr::Struct(exst) => {
                 for f in &exst.fields {
-                    self.search_expr(&f.expr);
+                    self.search_expr(&f.expr)?;
                 }
-                self.search_option_expr(&exst.rest);
+                self.search_option_expr(&exst.rest)?;
             }
-            Expr::TryBlock(extb) => self.search_stmts(extb.block.stmts.iter()),
-            Expr::Tuple(ext) => self.search_exprs(ext.elems.iter()),
-            Expr::Unsafe(exs) => self.search_stmts(exs.block.stmts.iter()),
+            Expr::TryBlock(extb) => self.search_stmts(extb.block.stmts.iter())?,
+            Expr::Tuple(ext) => self.search_exprs(ext.elems.iter())?,
+            Expr::Unsafe(exs) => self.search_stmts(exs.block.stmts.iter())?,
             Expr::While(exw) => {
-                self.search_expr(&exw.cond);
-                self.search_stmts(exw.body.stmts.iter());
+                self.search_expr(&exw.cond)?;
+                self.search_stmts(exw.body.stmts.iter())?;
             }
-            Expr::Yield(exy) => self.search_option_expr(&exy.expr),
+            Expr::Yield(exy) => self.search_option_expr(&exy.expr)?,
             Expr::__TestExhaustive(_) => {}
         }
+        Ok(())
     }
 
-    fn search_option_expr(&mut self, expr: &Option<Box<Expr>>) {
+    fn search_option_expr(&mut self, expr: &Option<Box<Expr>>) -> Result<(), DiscoveryErr> {
         if let Some(expr) = &expr {
-            self.search_expr(expr);
+            self.search_expr(expr)?;
         }
+        Ok(())
     }
 
-    fn search_exprs<'a>(&mut self, exprs: impl Iterator<Item = &'a Expr>) {
+    fn search_exprs<'a>(
+        &mut self,
+        exprs: impl Iterator<Item = &'a Expr>,
+    ) -> Result<(), DiscoveryErr> {
         for e in exprs {
-            self.search_expr(e);
+            self.search_expr(e)?;
         }
+        Ok(())
     }
 
-    fn search_impl_item(&mut self, impl_item: &ImplItem) {
+    fn search_impl_item(
+        &mut self,
+        impl_item: &ImplItem,
+        receiver: Option<&RustPath>,
+    ) -> Result<(), DiscoveryErr> {
         if let ImplItem::Method(itm) = impl_item {
+            if Self::has_attr(&itm.attrs, EXTERN_RUST_FUN) {
+                if self.mod_path.is_some() {
+                    return Err(DiscoveryErr::FoundExternRustFunWithinMod);
+                }
+                if let Some(receiver) = receiver {
+                    // We have a method which we want to put into the cxx::bridge's
+                    // "extern Rust" block.
+                    let sig = add_receiver(&itm.sig, receiver.get_final_ident())?;
+                    assert!(receiver.len() == 1);
+                    self.discoveries.extern_rust_funs.push(RustFun {
+                        path: self.deeper_path(&itm.sig.ident),
+                        sig,
+                        receiver: Some(receiver.get_final_ident().clone()),
+                    });
+                    self.discoveries.extern_rust_types.push(receiver.clone())
+                } else {
+                    return Err(DiscoveryErr::FoundExternRustFunOnTypeWithoutClearReceiver);
+                }
+            }
             for stmt in &itm.block.stmts {
-                self.search_stmt(stmt)
+                self.search_stmt(stmt)?
             }
         }
+        Ok(())
     }
 
-    fn search_pat(&mut self, pat: &Pat) {
+    fn search_pat(&mut self, pat: &Pat) -> Result<(), DiscoveryErr> {
         match pat {
             Pat::Box(PatBox { pat, .. }) | Pat::Reference(PatReference { pat, .. }) => {
                 self.search_pat(pat)
             }
-            Pat::Ident(_) | Pat::Lit(_) | Pat::Macro(_) | Pat::Range(_) | Pat::Rest(_) => {}
+            Pat::Ident(_) | Pat::Lit(_) | Pat::Macro(_) | Pat::Range(_) | Pat::Rest(_) => Ok(()),
             Pat::Or(pator) => {
                 for case in &pator.cases {
-                    self.search_pat(case);
+                    self.search_pat(case)?;
                 }
+                Ok(())
             }
             Pat::Path(pp) => self.search_path(&pp.path),
             Pat::Slice(PatSlice { elems, .. }) | Pat::Tuple(PatTuple { elems, .. }) => {
                 for case in elems {
-                    self.search_pat(case);
+                    self.search_pat(case)?;
                 }
+                Ok(())
             }
             Pat::Struct(ps) => {
-                self.search_path(&ps.path);
+                self.search_path(&ps.path)?;
                 for f in &ps.fields {
-                    self.search_pat(&f.pat);
+                    self.search_pat(&f.pat)?;
                 }
+                Ok(())
             }
             Pat::TupleStruct(tps) => {
-                self.search_path(&tps.path);
+                self.search_path(&tps.path)?;
                 for f in &tps.pat.elems {
-                    self.search_pat(f);
+                    self.search_pat(f)?;
                 }
+                Ok(())
             }
             Pat::Type(pt) => {
-                self.search_pat(&pt.pat);
-                self.search_type(&pt.ty);
+                self.search_pat(&pt.pat)?;
+                self.search_type(&pt.ty)
             }
-            _ => {}
+            _ => Ok(()),
         }
     }
 
-    fn search_type(&mut self, ty: &Type) {
+    fn search_type(&mut self, ty: &Type) -> Result<(), DiscoveryErr> {
         match ty {
             Type::Array(TypeArray { elem, .. })
             | Type::Group(TypeGroup { elem, .. })
             | Type::Paren(TypeParen { elem, .. })
             | Type::Ptr(TypePtr { elem, .. })
             | Type::Reference(TypeReference { elem, .. })
-            | Type::Slice(TypeSlice { elem, .. }) => self.search_type(elem),
+            | Type::Slice(TypeSlice { elem, .. }) => self.search_type(elem)?,
             Type::BareFn(tf) => {
                 for input in &tf.inputs {
-                    self.search_type(&input.ty);
+                    self.search_type(&input.ty)?;
                 }
-                self.search_return_type(&tf.output);
+                self.search_return_type(&tf.output)?;
             }
             Type::ImplTrait(tyit) => {
                 for b in &tyit.bounds {
                     if let syn::TypeParamBound::Trait(tyt) = b {
-                        self.search_path(&tyt.path)
+                        self.search_path(&tyt.path)?
                     }
                 }
             }
             Type::Infer(_) | Type::Macro(_) | Type::Never(_) => {}
-            Type::Path(typ) => self.search_path(&typ.path),
-            Type::TraitObject(tto) => self.search_type_param_bounds(&tto.bounds),
+            Type::Path(typ) => self.search_path(&typ.path)?,
+            Type::TraitObject(tto) => self.search_type_param_bounds(&tto.bounds)?,
             Type::Tuple(tt) => {
                 for e in &tt.elems {
-                    self.search_type(e)
+                    self.search_type(e)?
                 }
             }
             _ => {}
         }
+        Ok(())
     }
 
-    fn search_type_param_bounds(&mut self, bounds: &Punctuated<TypeParamBound, syn::token::Add>) {
+    fn search_type_param_bounds(
+        &mut self,
+        bounds: &Punctuated<TypeParamBound, syn::token::Add>,
+    ) -> Result<(), DiscoveryErr> {
         for b in bounds {
             if let syn::TypeParamBound::Trait(tpbt) = b {
-                self.search_path(&tpbt.path)
+                self.search_path(&tpbt.path)?
             }
         }
+        Ok(())
     }
 
-    fn search_return_type(&mut self, output: &ReturnType) {
+    fn search_return_type(&mut self, output: &ReturnType) -> Result<(), DiscoveryErr> {
         if let ReturnType::Type(_, ty) = &output {
             self.search_type(ty)
+        } else {
+            Ok(())
         }
     }
 
-    fn search_path_arguments(&mut self, arguments: &syn::PathArguments) {
+    fn search_path_arguments(
+        &mut self,
+        arguments: &syn::PathArguments,
+    ) -> Result<(), DiscoveryErr> {
         match arguments {
             syn::PathArguments::None => {}
             syn::PathArguments::AngleBracketed(paab) => {
@@ -378,21 +462,24 @@ impl<'b> PerModDiscoveries<'b> {
                     match arg {
                         syn::GenericArgument::Lifetime(_) => {}
                         syn::GenericArgument::Type(ty)
-                        | syn::GenericArgument::Binding(Binding { ty, .. }) => self.search_type(ty),
-                        syn::GenericArgument::Constraint(c) => {
-                            self.search_type_param_bounds(&c.bounds)
+                        | syn::GenericArgument::Binding(Binding { ty, .. }) => {
+                            self.search_type(ty)?
                         }
-                        syn::GenericArgument::Const(c) => self.search_expr(c),
+                        syn::GenericArgument::Constraint(c) => {
+                            self.search_type_param_bounds(&c.bounds)?
+                        }
+                        syn::GenericArgument::Const(c) => self.search_expr(c)?,
                     }
                 }
             }
             syn::PathArguments::Parenthesized(pas) => {
-                self.search_return_type(&pas.output);
+                self.search_return_type(&pas.output)?;
                 for t in &pas.inputs {
-                    self.search_type(t);
+                    self.search_type(t)?;
                 }
             }
         }
+        Ok(())
     }
 
     fn has_attr(attrs: &[Attribute], attr_name: &str) -> bool {
@@ -406,9 +493,45 @@ impl<'b> PerModDiscoveries<'b> {
     }
 }
 
+/// Take a method signature that may be `fn a(&self)`
+/// and turn it into `fn a(self: &A)` which is what we will
+/// need to specify to cxx.
+fn add_receiver(sig: &Signature, receiver: &Ident) -> Result<Signature, DiscoveryErr> {
+    let mut sig = sig.clone();
+    match sig.inputs.iter_mut().next() {
+        Some(first_arg) => match first_arg {
+            syn::FnArg::Receiver(Receiver {
+                reference: Some(_),
+                mutability: Some(_),
+                ..
+            }) => {
+                *first_arg = parse_quote! {
+                    self: &mut #receiver
+                }
+            }
+            syn::FnArg::Receiver(Receiver {
+                reference: Some(_),
+                mutability: None,
+                ..
+            }) => {
+                *first_arg = parse_quote! {
+                    self: &#receiver
+                }
+            }
+            syn::FnArg::Receiver(..) => return Err(DiscoveryErr::NonReferenceReceiver),
+            syn::FnArg::Typed(_) => {}
+        },
+        None => return Err(DiscoveryErr::NoParameterOnMethod),
+    }
+    Ok(sig)
+}
+
 #[cfg(test)]
 mod tests {
-    use syn::parse_quote;
+    use quote::{quote, ToTokens};
+    use syn::{parse_quote, ImplItemMethod};
+
+    use crate::{ast_discoverer::add_receiver, types::make_ident};
 
     use super::Discoveries;
 
@@ -427,7 +550,7 @@ mod tests {
                 }
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -439,7 +562,7 @@ mod tests {
                 ffi::xxx()
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -451,7 +574,7 @@ mod tests {
                 ffi::xxx();
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -463,7 +586,7 @@ mod tests {
                 ffi::a::b::xxx();
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert!(!discoveries.cpp_list.is_empty());
         assert!(discoveries.cpp_list.iter().next().unwrap() == "a::b::xxx");
     }
@@ -476,7 +599,7 @@ mod tests {
                 a + 3 * foo(ffi::xxx());
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -488,7 +611,7 @@ mod tests {
                 let foo: ffi::xxx = bar();
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -499,7 +622,7 @@ mod tests {
             fn bar(a: &mut ffi::xxx) {
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -510,7 +633,7 @@ mod tests {
             fn bar(a: cxx::UniquePtr<ffi::xxx>) {
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert_cpp_found(&discoveries);
     }
 
@@ -522,7 +645,21 @@ mod tests {
             fn bar(a: cxx::UniquePtr<ffi::xxx>) {
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
+        assert!(discoveries.extern_rust_funs.get(0).unwrap().sig.ident == "bar");
+    }
+
+    #[test]
+    fn test_extern_rust_method() {
+        let mut discoveries = Discoveries::default();
+        let itm = parse_quote! {
+            impl A {
+                #[autocxx::extern_rust::extern_rust_function]
+                fn bar(&self) {
+                }
+            }
+        };
+        discoveries.search_item(&itm, None).unwrap();
         assert!(discoveries.extern_rust_funs.get(0).unwrap().sig.ident == "bar");
     }
 
@@ -535,7 +672,7 @@ mod tests {
 
             }
         };
-        discoveries.search_item(&itm, None);
+        discoveries.search_item(&itm, None).unwrap();
         assert!(
             discoveries
                 .extern_rust_types
@@ -544,5 +681,41 @@ mod tests {
                 .get_final_ident()
                 == "Bar"
         );
+    }
+
+    #[test]
+    fn test_add_receiver() {
+        let meth: ImplItemMethod = parse_quote! {
+            fn a(&self) {}
+        };
+        let a = make_ident("A");
+        assert_eq!(
+            add_receiver(&meth.sig, &a)
+                .unwrap()
+                .to_token_stream()
+                .to_string(),
+            quote! { fn a(self: &A) }.to_string()
+        );
+
+        let meth: ImplItemMethod = parse_quote! {
+            fn a(&mut self, b: u32) -> Foo {}
+        };
+        assert_eq!(
+            add_receiver(&meth.sig, &a)
+                .unwrap()
+                .to_token_stream()
+                .to_string(),
+            quote! { fn a(self: &mut A, b: u32) -> Foo }.to_string()
+        );
+
+        let meth: ImplItemMethod = parse_quote! {
+            fn a(self) {}
+        };
+        assert!(add_receiver(&meth.sig, &a).is_err());
+
+        let meth: ImplItemMethod = parse_quote! {
+            fn a() {}
+        };
+        assert!(add_receiver(&meth.sig, &a).is_err());
     }
 }

--- a/engine/src/conversion/analysis/deps.rs
+++ b/engine/src/conversion/analysis/deps.rs
@@ -52,6 +52,7 @@ impl HasDependencies for Api<FnPrePhase1> {
                 superclass,
             } => Box::new(std::iter::once(superclass)),
             Api::RustSubclassFn { details, .. } => Box::new(details.dependencies.iter()),
+            Api::RustFn { receiver, .. } => Box::new(receiver.iter()),
             _ => Box::new(std::iter::empty()),
         }
     }
@@ -104,6 +105,7 @@ impl HasDependencies for Api<FnPhase> {
                 superclass,
             } => Box::new(std::iter::once(superclass)),
             Api::RustSubclassFn { details, .. } => Box::new(details.dependencies.iter()),
+            Api::RustFn { receiver, .. } => Box::new(receiver.iter()),
             _ => Box::new(std::iter::empty()),
         }
     }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -9,7 +9,7 @@
 use std::{collections::HashSet, fmt::Display};
 
 use crate::types::{make_ident, Namespace, QualifiedName};
-use autocxx_parser::RustPath;
+use autocxx_parser::{RustFun, RustPath};
 use itertools::Itertools;
 use quote::ToTokens;
 use syn::{
@@ -17,7 +17,7 @@ use syn::{
     punctuated::Punctuated,
     token::{Comma, Unsafe},
     Attribute, FnArg, Ident, ItemConst, ItemEnum, ItemStruct, ItemType, ItemUse, LitBool, LitInt,
-    Pat, ReturnType, Signature, Type, Visibility,
+    Pat, ReturnType, Type, Visibility,
 };
 
 use super::{
@@ -490,8 +490,8 @@ pub(crate) enum Api<T: AnalysisPhase> {
     /// A function for the 'extern Rust' block which is not a C++ type.
     RustFn {
         name: ApiName,
-        sig: Signature,
-        path: RustPath,
+        details: RustFun,
+        receiver: Option<QualifiedName>,
     },
     /// Some function for the extern "Rust" block.
     RustSubclassFn {

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod unqualify;
 
 use std::collections::{HashMap, HashSet};
 
-use autocxx_parser::IncludeCppConfig;
+use autocxx_parser::{IncludeCppConfig, RustFun};
 
 use itertools::Itertools;
 use proc_macro2::{Span, TokenStream};
@@ -554,10 +554,33 @@ impl<'a> RsCodeGenerator<'a> {
                 }],
                 ..Default::default()
             },
-            Api::RustFn { sig, path, .. } => RsCodegenResult {
+            Api::RustFn {
+                details:
+                    RustFun {
+                        path,
+                        sig,
+                        receiver: None,
+                        ..
+                    },
+                ..
+            } => RsCodegenResult {
                 global_items: vec![parse_quote! {
                     use super::#path;
                 }],
+                extern_rust_mod_items: vec![parse_quote! {
+                    #sig;
+                }],
+                ..Default::default()
+            },
+            Api::RustFn {
+                details:
+                    RustFun {
+                        sig,
+                        receiver: Some(_),
+                        ..
+                    },
+                ..
+            } => RsCodegenResult {
                 extern_rust_mod_items: vec![parse_quote! {
                     #sig;
                 }],

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -115,9 +115,15 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
             Api::RustType { name, path } => {
                 Ok(Box::new(std::iter::once(Api::RustType { name, path })))
             }
-            Api::RustFn { name, sig, path } => {
-                Ok(Box::new(std::iter::once(Api::RustFn { name, sig, path })))
-            }
+            Api::RustFn {
+                name,
+                details,
+                receiver,
+            } => Ok(Box::new(std::iter::once(Api::RustFn {
+                name,
+                details,
+                receiver,
+            }))),
             Api::RustSubclassFn {
                 name,
                 subclass,

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -6408,37 +6408,32 @@ fn test_pass_thru_rust_reference() {
 }
 
 #[test]
-#[ignore]
-fn test_rust_reference_method() {
+fn test_extern_rust_method() {
     let hdr = indoc! {"
-    #include <cstdint>
-
-    struct RustType;
-    uint32_t take_rust_reference(const RustType& foo);
+        #include <cstdint>
+        struct RustType;
+        uint32_t examine(const RustType& foo);
     "};
     let cxx = indoc! {"
-    #include \"cxxgen.h\"
-    uint32_t take_rust_reference(const RustType& foo) {
-        return foo.get();
-    }"};
+        uint32_t examine(const RustType& foo) {
+            return foo.get();
+        }"};
     let rs = quote! {
-        let foo = RustType(3);
-        assert_eq!(ffi::take_rust_reference(&foo), 3);
+        let a = RustType(74);
+        assert_eq!(ffi::examine(&a), 74);
     };
     run_test_ex(
         cxx,
         hdr,
         rs,
-        quote! {
-            generate!("take_rust_reference")
-        },
+        directives_from_lists(&["examine"], &[], None),
         Some(Box::new(EnableAutodiscover)),
         None,
         Some(quote! {
-            #[autocxx::extern_rust_type]
+            #[autocxx::extern_rust::extern_rust_type]
             pub struct RustType(i32);
             impl RustType {
-                #[autocxx::extern_rust_function]
+                #[autocxx::extern_rust::extern_rust_function]
                 pub fn get(&self) -> i32 {
                     return self.0
                 }
@@ -6596,7 +6591,9 @@ fn test_extern_rust_fn_simple() {
     run_test_ex(
         cpp,
         hdr,
-        quote! {},
+        quote! {
+            ffi::do_thing();
+        },
         quote! {
             generate!("do_thing")
         },
@@ -6605,7 +6602,6 @@ fn test_extern_rust_fn_simple() {
         Some(quote! {
             #[autocxx::extern_rust::extern_rust_function]
             fn my_rust_fun() {
-
             }
         }),
     );

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -137,9 +137,11 @@ pub struct Subclass {
     pub subclass: Ident,
 }
 
+#[derive(Clone)]
 pub struct RustFun {
     pub path: RustPath,
     pub sig: Signature,
+    pub receiver: Option<Ident>,
 }
 
 impl std::fmt::Debug for RustFun {
@@ -288,7 +290,11 @@ impl Parse for IncludeCppConfig {
                     let path: RustPath = args.parse()?;
                     args.parse::<syn::token::Comma>()?;
                     let sig: syn::Signature = args.parse()?;
-                    extern_rust_funs.push(RustFun { path, sig });
+                    extern_rust_funs.push(RustFun {
+                        path,
+                        sig,
+                        receiver: None,
+                    });
                 } else {
                     return Err(syn::Error::new(
                         ident.span(),

--- a/parser/src/path.rs
+++ b/parser/src/path.rs
@@ -13,7 +13,7 @@ use syn::parse::{Parse, ParseStream};
 
 /// A little like [`syn::Path`] but simpler - contains only identifiers,
 /// no path arguments. Guaranteed to always have at least one identifier.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct RustPath(Vec<Ident>);
 
 impl RustPath {
@@ -28,6 +28,14 @@ impl RustPath {
 
     pub fn get_final_ident(&self) -> &Ident {
         self.0.last().unwrap()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 


### PR DESCRIPTION
This allows the #[extern_rust_function] attribute to be used to make Rust methods
available to call from C++, as well as free functions.

Fixes #947.