### PR TITLE
Fix use of `&str` in generated C++ code

### DIFF
--- a/engine/src/conversion/codegen_cpp/type_to_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/type_to_cpp.rs
@@ -101,11 +101,14 @@ pub(crate) fn type_to_cpp(ty: &Type, cpp_name_map: &CppNameMap) -> Result<String
                 Some(suffix) => Ok(format!("{}<{}>", root, suffix)),
             }
         }
-        Type::Reference(typr) => Ok(format!(
-            "{}{}&",
-            get_mut_string(&typr.mutability),
-            type_to_cpp(typr.elem.as_ref(), cpp_name_map)?
-        )),
+        Type::Reference(typr) => match &*typr.elem {
+            Type::Path(typ) if typ.path.is_ident("str") => Ok("rust::Str".into()),
+            _ => Ok(format!(
+                "{}{}&",
+                get_mut_string(&typr.mutability),
+                type_to_cpp(typr.elem.as_ref(), cpp_name_map)?
+            )),
+        },
         Type::Ptr(typp) => Ok(format!(
             "{}{}*",
             get_mut_string(&typp.mutability),

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -10263,6 +10263,55 @@ fn test_doc_comments_survive() {
     );
 }
 
+#[test]
+fn test_pass_rust_str_and_return_struct() {
+    // we can take a str
+    let cxx = indoc! {"
+        A return_struct() {
+            A a;
+            return a;
+        }
+    "};
+    let hdr = indoc! {"
+        struct A {};
+        A return_struct();
+    "};
+    let rs = quote! {
+        ffi::return_struct();
+    };
+    run_test(cxx, hdr, rs, &["return_struct"], &[]);
+
+    // we can return a struct
+    let cxx = indoc! {"
+        void take_str(rust::Str) {}
+    "};
+    let hdr = indoc! {"
+        #include <cxx.h>
+        void take_str(rust::Str);
+    "};
+    let rs = quote! {
+        ffi::take_str("hi");
+    };
+    run_test(cxx, hdr, rs, &["take_str"], &[]);
+
+    // but we cant do both at the same time
+    let cxx = indoc! {"
+        A take_str_return_struct(rust::Str) {
+            A a;
+            return a;
+        }
+    "};
+    let hdr = indoc! {"
+        #include <cxx.h>
+        struct A {};
+        A take_str_return_struct(rust::Str);
+    "};
+    let rs = quote! {
+        ffi::take_str_return_struct("hi");
+    };
+    run_test(cxx, hdr, rs, &["take_str_return_struct"], &[]);
+}
+
 // Yet to test:
 // - Ifdef
 // - Out param pointers

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -10265,36 +10265,6 @@ fn test_doc_comments_survive() {
 
 #[test]
 fn test_pass_rust_str_and_return_struct() {
-    // we can take a str
-    let cxx = indoc! {"
-        A return_struct() {
-            A a;
-            return a;
-        }
-    "};
-    let hdr = indoc! {"
-        struct A {};
-        A return_struct();
-    "};
-    let rs = quote! {
-        ffi::return_struct();
-    };
-    run_test(cxx, hdr, rs, &["return_struct"], &[]);
-
-    // we can return a struct
-    let cxx = indoc! {"
-        void take_str(rust::Str) {}
-    "};
-    let hdr = indoc! {"
-        #include <cxx.h>
-        void take_str(rust::Str);
-    "};
-    let rs = quote! {
-        ffi::take_str("hi");
-    };
-    run_test(cxx, hdr, rs, &["take_str"], &[]);
-
-    // but we cant do both at the same time
     let cxx = indoc! {"
         A take_str_return_struct(rust::Str) {
             A a;


### PR DESCRIPTION
Fixes #982. Thanks to @bddap.