### PR TITLE
Fix allocation sizes.

### DIFF
--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -517,7 +517,7 @@ impl<'a> CppCodeGenerator<'a> {
             CppFunctionBody::AllocUninitialized(ty) => {
                 let namespaced_ty = self.namespaced_name(ty);
                 (
-                    format!("new_appropriately<{}>(1);", namespaced_ty,),
+                    format!("new_appropriately<{}>();", namespaced_ty,),
                     "".to_string(),
                     true,
                 )

--- a/engine/src/conversion/codegen_cpp/new_and_delete_prelude.rs
+++ b/engine/src/conversion/codegen_cpp/new_and_delete_prelude.rs
@@ -35,10 +35,10 @@ pub(super) static NEW_AND_DELETE_PRELUDE: &str = indoc! {"
     template <typename T> void *new_imp(size_t count, long) {
       return ::operator new(count);
     }
-    template <typename T> T *new_appropriately(size_t count) {
+    template <typename T> T *new_appropriately() {
       // 0 is a better match for the first 'delete_imp' so will match
       // preferentially.
-      return static_cast<T *>(new_imp<T>(count, 0));
+      return static_cast<T *>(new_imp<T>(sizeof(T), 0));
     }
     #endif // AUTOCXX_NEW_AND_DELETE_PRELUDE
 "};


### PR DESCRIPTION
The 'moveit' code paths had a buffer overflow.

Fixes #990.
