### PR TITLE
Show `autocxx_build::Builder::new` in docs

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -85,7 +85,6 @@ pub struct Builder<'a, BuilderContext> {
 }
 
 impl<CTX: BuilderContext> Builder<'_, CTX> {
-    #[doc(hidden)]
     pub fn new(
         rs_file: impl AsRef<Path>,
         autocxx_incs: impl IntoIterator<Item = impl AsRef<OsStr>>,


### PR DESCRIPTION
Looking at the git blame, I can see that at one point this method was  called `new_internal`. It got switched over to `new`, but the `#[doc(hidden)]` wasn't removed which results in a usability wart. This method is used in the examples, so I'm pretty sure hiding it from the docs wasn't intentional.