### PR TITLE
Modularize directive handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,9 @@ dependencies = [
 name = "autocxx-parser"
 version = "0.21.0"
 dependencies = [
+ "itertools 0.10.3",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "serde",

--- a/engine/src/ast_discoverer.rs
+++ b/engine/src/ast_discoverer.rs
@@ -9,7 +9,7 @@
 use std::collections::HashSet;
 
 use autocxx_parser::{
-    directives::{EXTERN_RUST_FUN, EXTERN_RUST_TYPE},
+    directive_names::{EXTERN_RUST_FUN, EXTERN_RUST_TYPE},
     RustFun, RustPath,
 };
 use itertools::Itertools;

--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -12,7 +12,7 @@ use crate::{
     RebuildDependencyRecorder,
 };
 use crate::{CppCodegenOptions, LocatedSynError};
-use autocxx_parser::directives::SUBCLASS;
+use autocxx_parser::directive_names::SUBCLASS;
 use autocxx_parser::{AllowlistEntry, RustPath, Subclass, SubclassAttrs};
 use miette::Diagnostic;
 use proc_macro2::TokenStream;

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -24,6 +24,8 @@ quote = "1.0"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 thiserror = "1.0"
+once_cell = "1.10"
+itertools = "0.10.3"
 
 [dependencies.syn]
 version = "1.0.39"

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -11,8 +11,12 @@ use std::{
     collections::{HashMap, HashSet},
 };
 
+use itertools::Itertools;
 use proc_macro2::Span;
 use quote::ToTokens;
+
+#[cfg(feature = "reproduction_case")]
+use quote::format_ident;
 use syn::{
     parse::{Parse, ParseStream},
     Signature, Token, TypePath,
@@ -20,18 +24,20 @@ use syn::{
 use syn::{Ident, Result as ParseResult};
 use thiserror::Error;
 
-use crate::{
-    directives::{EXTERN_RUST_TYPE, SUBCLASS},
-    RustPath,
-};
+use crate::{directives::get_directives, RustPath};
 
-#[cfg(feature = "reproduction_case")]
 use quote::quote;
 
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub enum UnsafePolicy {
     AllFunctionsSafe,
     AllFunctionsUnsafe,
+}
+
+impl Default for UnsafePolicy {
+    fn default() -> Self {
+        Self::AllFunctionsUnsafe
+    }
 }
 
 impl Parse for UnsafePolicy {
@@ -59,7 +65,6 @@ impl Parse for UnsafePolicy {
     }
 }
 
-#[cfg(feature = "reproduction_case")]
 impl ToTokens for UnsafePolicy {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         if *self == UnsafePolicy::AllFunctionsSafe {
@@ -161,18 +166,18 @@ pub struct ExternCppType {
     pub opaque: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IncludeCppConfig {
     pub inclusions: Vec<String>,
     pub unsafe_policy: UnsafePolicy,
     pub parse_only: bool,
     pub exclude_impls: bool,
-    pod_requests: Vec<String>,
+    pub(crate) pod_requests: Vec<String>,
     pub allowlist: Allowlist,
-    blocklist: Vec<String>,
-    constructor_blocklist: Vec<String>,
-    exclude_utilities: bool,
-    mod_name: Option<Ident>,
+    pub(crate) blocklist: Vec<String>,
+    pub(crate) constructor_blocklist: Vec<String>,
+    pub(crate) exclude_utilities: bool,
+    pub(crate) mod_name: Option<Ident>,
     pub rust_types: Vec<RustPath>,
     pub subclasses: Vec<Subclass>,
     pub extern_rust_funs: Vec<RustFun>,
@@ -180,187 +185,43 @@ pub struct IncludeCppConfig {
     pub externs: HashMap<String, ExternCppType>,
 }
 
-fn allowlist_err_to_syn_err(err: AllowlistErr, span: Span) -> syn::Error {
-    syn::Error::new(span, format!("{}", err))
-}
-
 impl Parse for IncludeCppConfig {
     fn parse(input: ParseStream) -> ParseResult<Self> {
-        // Takes as inputs:
-        // 1. List of headers to include
-        // 2. List of #defines to include
-        // 3. Allowlist
-
-        let mut inclusions = Vec::new();
-        let mut parse_only = false;
-        let mut exclude_impls = false;
-        let mut unsafe_policy = UnsafePolicy::AllFunctionsUnsafe;
-        let mut allowlist = Allowlist::default();
-        let mut blocklist = Vec::new();
-        let mut constructor_blocklist = Vec::new();
-        let mut pod_requests = Vec::new();
-        let mut rust_types = Vec::new();
-        let mut exclude_utilities = false;
-        let mut mod_name = None;
-        let mut subclasses = Vec::new();
-        let mut extern_rust_funs = Vec::new();
-        let mut concretes = HashMap::new();
-        let mut externs = HashMap::new();
+        let mut config = IncludeCppConfig::default();
 
         while !input.is_empty() {
             let has_hexathorpe = input.parse::<Option<syn::token::Pound>>()?.is_some();
             let ident: syn::Ident = input.parse()?;
-            if has_hexathorpe {
-                if ident != "include" {
-                    return Err(syn::Error::new(ident.span(), "expected include"));
-                }
-                let hdr: syn::LitStr = input.parse()?;
-                inclusions.push(hdr.value());
+            let args;
+            let (possible_directives, to_parse, parse_completely) = if has_hexathorpe {
+                (&get_directives().need_hexathorpe, input, false)
             } else {
                 input.parse::<Option<syn::token::Bang>>()?;
-                if ident == "generate" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let generate: syn::LitStr = args.parse()?;
-                    allowlist
-                        .push(AllowlistEntry::Item(generate.value()))
-                        .map_err(|e| allowlist_err_to_syn_err(e, ident.span()))?;
-                } else if ident == "generate_ns" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let generate_ns: syn::LitStr = args.parse()?;
-                    allowlist
-                        .push(AllowlistEntry::Namespace(generate_ns.value()))
-                        .map_err(|e| allowlist_err_to_syn_err(e, ident.span()))?;
-                } else if ident == "generate_pod" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let generate_pod: syn::LitStr = args.parse()?;
-                    pod_requests.push(generate_pod.value());
-                    allowlist
-                        .push(AllowlistEntry::Item(generate_pod.value()))
-                        .map_err(|e| allowlist_err_to_syn_err(e, ident.span()))?;
-                } else if ident == "pod" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let pod: syn::LitStr = args.parse()?;
-                    pod_requests.push(pod.value());
-                } else if ident == "block" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let generate: syn::LitStr = args.parse()?;
-                    blocklist.push(generate.value());
-                } else if ident == "concrete" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let definition: syn::LitStr = args.parse()?;
-                    args.parse::<syn::token::Comma>()?;
-                    let rust_id: syn::Ident = args.parse()?;
-                    concretes.insert(definition.value(), rust_id);
-                } else if ident == "block_constructors" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let generate: syn::LitStr = args.parse()?;
-                    constructor_blocklist.push(generate.value());
-                } else if ident == "rust_type" || ident == EXTERN_RUST_TYPE {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let id: Ident = args.parse()?;
-                    rust_types.push(RustPath::new_from_ident(id));
-                } else if ident == SUBCLASS {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let superclass: syn::LitStr = args.parse()?;
-                    args.parse::<syn::token::Comma>()?;
-                    let subclass: syn::Ident = args.parse()?;
-                    subclasses.push(Subclass {
-                        superclass: superclass.value(),
-                        subclass,
-                    });
-                } else if ident == "parse_only" {
-                    parse_only = true;
-                    swallow_parentheses(&input, &ident)?;
-                } else if ident == "exclude_impls" {
-                    exclude_impls = true;
-                    swallow_parentheses(&input, &ident)?;
-                } else if ident == "generate_all" {
-                    allowlist
-                        .set_all()
-                        .map_err(|e| allowlist_err_to_syn_err(e, ident.span()))?;
-                    swallow_parentheses(&input, &ident)?;
-                } else if ident == "name" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let ident: syn::Ident = args.parse()?;
-                    mod_name = Some(ident);
-                } else if ident == "exclude_utilities" {
-                    exclude_utilities = true;
-                    swallow_parentheses(&input, &ident)?;
-                } else if ident == "safety" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    unsafe_policy = args.parse()?;
-                } else if ident == "extern_rust_fun" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let path: RustPath = args.parse()?;
-                    args.parse::<syn::token::Comma>()?;
-                    let sig: syn::Signature = args.parse()?;
-                    extern_rust_funs.push(RustFun {
-                        path,
-                        sig,
-                        receiver: None,
-                    });
-                } else if ident == "extern_cpp_type" || ident == "extern_cpp_opaque_type" {
-                    let args;
-                    syn::parenthesized!(args in input);
-                    let definition: syn::LitStr = args.parse()?;
-                    args.parse::<syn::token::Comma>()?;
-                    let rust_path: TypePath = args.parse()?;
-                    let opaque = ident == "extern_cpp_opaque_type";
-                    externs.insert(definition.value(), ExternCppType { rust_path, opaque });
-                } else {
+                syn::parenthesized!(args in input);
+                (&get_directives().need_exclamation, &args, true)
+            };
+            let all_possible = possible_directives.keys().join(", ");
+            let ident_str = ident.to_string();
+            match possible_directives.get(&ident_str) {
+                None => {
                     return Err(syn::Error::new(
                         ident.span(),
-                        "expected generate, generate_pod, nested_type, safety or one of the other autocxx directives",
+                        format!("expected {}", all_possible),
                     ));
                 }
+                Some(directive) => directive.parse(to_parse, &mut config, &ident.span())?,
+            }
+            if parse_completely && !to_parse.is_empty() {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    format!("found unexpected input within the directive {}", ident_str),
+                ));
             }
             if input.is_empty() {
                 break;
             }
         }
-
-        Ok(IncludeCppConfig {
-            inclusions,
-            unsafe_policy,
-            parse_only,
-            exclude_impls,
-            pod_requests,
-            rust_types,
-            allowlist,
-            blocklist,
-            constructor_blocklist,
-            exclude_utilities,
-            mod_name,
-            subclasses,
-            extern_rust_funs,
-            concretes,
-            externs,
-        })
-    }
-}
-
-fn swallow_parentheses(input: &ParseStream, latest_ident: &Ident) -> ParseResult<()> {
-    let args;
-    syn::parenthesized!(args in input);
-    if args.is_empty() {
-        Ok(())
-    } else {
-        Err(syn::Error::new(
-            latest_ident.span(),
-            "expected no arguments to directive",
-        ))
+        Ok(config)
     }
 }
 
@@ -558,63 +419,23 @@ impl IncludeCppConfig {
 #[cfg(feature = "reproduction_case")]
 impl ToTokens for IncludeCppConfig {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        for inc in &self.inclusions {
-            let hexathorpe = syn::token::Pound(Span::call_site());
-            tokens.extend(quote! {
-                #hexathorpe include #inc
-            })
-        }
-        let unsafety = &self.unsafe_policy;
-        tokens.extend(quote! {
-            safety!(#unsafety)
-        });
-        if self.exclude_impls {
-            tokens.extend(quote! { exclude_impls!() });
-        }
-        if self.parse_only {
-            tokens.extend(quote! { parse_only!() });
-        }
-        if self.exclude_utilities {
-            tokens.extend(quote! { exclude_utilities!() });
-        }
-        for i in &self.pod_requests {
-            tokens.extend(quote! { pod!(#i) });
-        }
-        for i in &self.blocklist {
-            tokens.extend(quote! { block!(#i) });
-        }
-        for i in &self.constructor_blocklist {
-            tokens.extend(quote! { block_constructors!(#i) });
-        }
-        for path in &self.rust_types {
-            tokens.extend(quote! { rust_type!(#path) });
-        }
-        match &self.allowlist {
-            Allowlist::All => tokens.extend(quote! { generate_all!() }),
-            Allowlist::Specific(items) => {
-                for i in items {
-                    match i {
-                        AllowlistEntry::Item(i) => tokens.extend(quote! { generate!(#i) }),
-                        AllowlistEntry::Namespace(ns) => {
-                            tokens.extend(quote! { generate_ns!(#ns) })
-                        }
-                    }
-                }
+        let directives = get_directives();
+        let hexathorpe = syn::token::Pound(Span::call_site());
+        for (id, directive) in &directives.need_hexathorpe {
+            let id = format_ident!("{}", id);
+            for output in directive.output(self) {
+                tokens.extend(quote! {
+                    #hexathorpe #id #output
+                })
             }
-            Allowlist::Unspecified(_) => panic!("Allowlist mode not yet determined"),
         }
-        if let Some(mod_name) = &self.mod_name {
-            tokens.extend(quote! { mod_name!(#mod_name) });
-        }
-        for i in &self.extern_rust_funs {
-            let p = &i.path;
-            let s = &i.sig;
-            tokens.extend(quote! { extern_rust_fun!(#p,#s) });
-        }
-        for i in &self.subclasses {
-            let superclass = &i.superclass;
-            let subclass = &i.subclass;
-            tokens.extend(quote! { subclass!(#superclass,#subclass) });
+        for (id, directive) in &directives.need_exclamation {
+            let id = format_ident!("{}", id);
+            for output in directive.output(self) {
+                tokens.extend(quote! {
+                    #id ! (#output)
+                })
+            }
         }
     }
 }

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -1,0 +1,531 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::collections::HashMap;
+
+use once_cell::sync::OnceCell;
+use proc_macro2::Span;
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
+use syn::parse::ParseStream;
+
+use crate::config::{Allowlist, AllowlistErr};
+use crate::directive_names::{EXTERN_RUST_FUN, EXTERN_RUST_TYPE, SUBCLASS};
+use crate::{AllowlistEntry, IncludeCppConfig};
+use crate::{ParseResult, RustFun, RustPath};
+
+pub(crate) struct DirectivesMap {
+    pub(crate) need_hexathorpe: HashMap<String, Box<dyn Directive>>,
+    pub(crate) need_exclamation: HashMap<String, Box<dyn Directive>>,
+}
+
+static DIRECTIVES: OnceCell<DirectivesMap> = OnceCell::new();
+
+pub(crate) fn get_directives() -> &'static DirectivesMap {
+    DIRECTIVES.get_or_init(|| {
+        let mut need_hexathorpe: HashMap<String, Box<dyn Directive>> = HashMap::new();
+        need_hexathorpe.insert("include".into(), Box::new(Inclusion));
+        let mut need_exclamation: HashMap<String, Box<dyn Directive>> = HashMap::new();
+        need_exclamation.insert("generate".into(), Box::new(Generate(false)));
+        need_exclamation.insert("generate_pod".into(), Box::new(Generate(true)));
+        need_exclamation.insert("generate_ns".into(), Box::new(GenerateNs));
+        need_exclamation.insert("generate_all".into(), Box::new(GenerateAll));
+        need_exclamation.insert("safety".into(), Box::new(Safety));
+        need_exclamation.insert(
+            "pod".into(),
+            Box::new(StringList(
+                |config| &mut config.pod_requests,
+                |config| &config.pod_requests,
+            )),
+        );
+        need_exclamation.insert(
+            "block".into(),
+            Box::new(StringList(
+                |config| &mut config.blocklist,
+                |config| &config.blocklist,
+            )),
+        );
+        need_exclamation.insert(
+            "block_constructors".into(),
+            Box::new(StringList(
+                |config| &mut config.constructor_blocklist,
+                |config| &config.constructor_blocklist,
+            )),
+        );
+        need_exclamation.insert(
+            "parse_only".into(),
+            Box::new(BoolFlag(
+                |config| &mut config.parse_only,
+                |config| &config.parse_only,
+            )),
+        );
+        need_exclamation.insert(
+            "exclude_impls".into(),
+            Box::new(BoolFlag(
+                |config| &mut config.exclude_impls,
+                |config| &config.exclude_impls,
+            )),
+        );
+        need_exclamation.insert(
+            "exclude_utilities".into(),
+            Box::new(BoolFlag(
+                |config| &mut config.exclude_utilities,
+                |config| &config.exclude_utilities,
+            )),
+        );
+        need_exclamation.insert("name".into(), Box::new(ModName));
+        need_exclamation.insert("concrete".into(), Box::new(Concrete));
+        need_exclamation.insert("rust_type".into(), Box::new(RustType { output: false }));
+        need_exclamation.insert(EXTERN_RUST_TYPE.into(), Box::new(RustType { output: true }));
+        need_exclamation.insert(SUBCLASS.into(), Box::new(Subclass));
+        need_exclamation.insert(EXTERN_RUST_FUN.into(), Box::new(ExternRustFun));
+        need_exclamation.insert(
+            "extern_cpp_type".into(),
+            Box::new(ExternCppType { opaque: false }),
+        );
+        need_exclamation.insert(
+            "extern_cpp_opaque_type".into(),
+            Box::new(ExternCppType { opaque: true }),
+        );
+
+        DirectivesMap {
+            need_hexathorpe,
+            need_exclamation,
+        }
+    })
+}
+
+/// Trait for handling an `include_cpp!` configuration directive.
+pub(crate) trait Directive: Send + Sync {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        span: &Span,
+    ) -> ParseResult<()>;
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a>;
+}
+
+struct Inclusion;
+
+impl Directive for Inclusion {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _span: &Span,
+    ) -> ParseResult<()> {
+        let hdr: syn::LitStr = args.parse()?;
+        config.inclusions.push(hdr.value());
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        Box::new(config.inclusions.iter().map(|val| quote! { #val }))
+    }
+}
+
+struct Generate(bool);
+
+impl Directive for Generate {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        span: &Span,
+    ) -> ParseResult<()> {
+        let generate: syn::LitStr = args.parse()?;
+        config
+            .allowlist
+            .push(AllowlistEntry::Item(generate.value()))
+            .map_err(|e| allowlist_err_to_syn_err(e, span))?;
+        if self.0 {
+            config.pod_requests.push(generate.value());
+        }
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        match &config.allowlist {
+            Allowlist::Specific(items) => Box::new(
+                items
+                    .iter()
+                    .flat_map(|i| match i {
+                        AllowlistEntry::Item(s) => Some(s),
+                        _ => None,
+                    })
+                    .map(|s| quote! { #s }),
+            ),
+            Allowlist::Unspecified(_) => panic!("Allowlist mode not yet determined"),
+            _ => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+struct GenerateNs;
+
+impl Directive for GenerateNs {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        span: &Span,
+    ) -> ParseResult<()> {
+        let generate: syn::LitStr = args.parse()?;
+        config
+            .allowlist
+            .push(AllowlistEntry::Namespace(generate.value()))
+            .map_err(|e| allowlist_err_to_syn_err(e, span))?;
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        match &config.allowlist {
+            Allowlist::Specific(items) => Box::new(
+                items
+                    .iter()
+                    .flat_map(|i| match i {
+                        AllowlistEntry::Namespace(s) => Some(s),
+                        _ => None,
+                    })
+                    .map(|s| quote! { #s }),
+            ),
+            Allowlist::Unspecified(_) => panic!("Allowlist mode not yet determined"),
+            _ => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+struct GenerateAll;
+
+impl Directive for GenerateAll {
+    fn parse(
+        &self,
+        _args: ParseStream,
+        config: &mut IncludeCppConfig,
+        span: &Span,
+    ) -> ParseResult<()> {
+        config
+            .allowlist
+            .set_all()
+            .map_err(|e| allowlist_err_to_syn_err(e, span))?;
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        match &config.allowlist {
+            Allowlist::All => Box::new(std::iter::once(TokenStream::new())),
+            Allowlist::Unspecified(_) => panic!("Allowlist mode not yet determined"),
+            _ => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+struct Safety;
+
+impl Directive for Safety {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        config.unsafe_policy = args.parse()?;
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        let policy = &config.unsafe_policy;
+        match config.unsafe_policy {
+            crate::UnsafePolicy::AllFunctionsSafe => {
+                Box::new(std::iter::once(policy.to_token_stream()))
+            }
+            crate::UnsafePolicy::AllFunctionsUnsafe => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+fn allowlist_err_to_syn_err(err: AllowlistErr, span: &Span) -> syn::Error {
+    syn::Error::new(span.clone(), format!("{}", err))
+}
+
+struct StringList<SET, GET>(SET, GET)
+where
+    SET: Fn(&mut IncludeCppConfig) -> &mut Vec<String>,
+    GET: Fn(&IncludeCppConfig) -> &Vec<String>;
+
+impl<SET, GET> Directive for StringList<SET, GET>
+where
+    SET: Fn(&mut IncludeCppConfig) -> &mut Vec<String> + Sync + Send,
+    GET: Fn(&IncludeCppConfig) -> &Vec<String> + Sync + Send,
+{
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let val: syn::LitStr = args.parse()?;
+        self.0(config).push(val.value());
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        Box::new(self.1(config).iter().map(|val| {
+            quote! {
+                #val
+            }
+        }))
+    }
+}
+
+struct BoolFlag<SET, GET>(SET, GET)
+where
+    SET: Fn(&mut IncludeCppConfig) -> &mut bool,
+    GET: Fn(&IncludeCppConfig) -> &bool;
+
+impl<SET, GET> Directive for BoolFlag<SET, GET>
+where
+    SET: Fn(&mut IncludeCppConfig) -> &mut bool + Sync + Send,
+    GET: Fn(&IncludeCppConfig) -> &bool + Sync + Send,
+{
+    fn parse(
+        &self,
+        _args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        *self.0(config) = true;
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        if *self.1(config) {
+            Box::new(std::iter::once(quote! {}))
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+}
+
+struct ModName;
+
+impl Directive for ModName {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let id: Ident = args.parse()?;
+        config.mod_name = Some(id);
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        match &config.mod_name {
+            None => Box::new(std::iter::empty()),
+            Some(id) => Box::new(std::iter::once(quote! { #id })),
+        }
+    }
+}
+
+struct Concrete;
+
+impl Directive for Concrete {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let definition: syn::LitStr = args.parse()?;
+        args.parse::<syn::token::Comma>()?;
+        let rust_id: syn::Ident = args.parse()?;
+        config.concretes.insert(definition.value(), rust_id);
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        Box::new(config.concretes.iter().map(|(k, v)| {
+            quote! {
+                #k,#v
+            }
+        }))
+    }
+}
+
+struct RustType {
+    output: bool,
+}
+
+impl Directive for RustType {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let id: Ident = args.parse()?;
+        config.rust_types.push(RustPath::new_from_ident(id));
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        if self.output {
+            Box::new(config.rust_types.iter().map(|rp| rp.to_token_stream()))
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+}
+
+struct Subclass;
+
+impl Directive for Subclass {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let superclass: syn::LitStr = args.parse()?;
+        args.parse::<syn::token::Comma>()?;
+        let subclass: syn::Ident = args.parse()?;
+        config.subclasses.push(crate::config::Subclass {
+            superclass: superclass.value(),
+            subclass,
+        });
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        Box::new(config.subclasses.iter().map(|sc| {
+            let superclass = &sc.superclass;
+            let subclass = &sc.subclass;
+            quote! {
+                #superclass,#subclass
+            }
+        }))
+    }
+}
+
+struct ExternRustFun;
+
+impl Directive for ExternRustFun {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let path: RustPath = args.parse()?;
+        args.parse::<syn::token::Comma>()?;
+        let sig: syn::Signature = args.parse()?;
+        config.extern_rust_funs.push(RustFun {
+            path,
+            sig,
+            receiver: None,
+        });
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        Box::new(config.extern_rust_funs.iter().map(|erf| {
+            let p = &erf.path;
+            let s = &erf.sig;
+            quote! { #p,#s }
+        }))
+    }
+}
+
+struct ExternCppType {
+    opaque: bool,
+}
+
+impl Directive for ExternCppType {
+    fn parse(
+        &self,
+        args: ParseStream,
+        config: &mut IncludeCppConfig,
+        _ident_span: &Span,
+    ) -> ParseResult<()> {
+        let definition: syn::LitStr = args.parse()?;
+        args.parse::<syn::token::Comma>()?;
+        let rust_path: syn::TypePath = args.parse()?;
+        config.externs.insert(
+            definition.value(),
+            crate::config::ExternCppType {
+                rust_path,
+                opaque: self.opaque,
+            },
+        );
+        Ok(())
+    }
+
+    fn output<'a>(
+        &self,
+        config: &'a IncludeCppConfig,
+    ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
+        let opaque_needed = self.opaque;
+        Box::new(
+            config
+                .externs
+                .iter()
+                .filter_map(move |(definition, details)| {
+                    if details.opaque == opaque_needed {
+                        let rust_path = &details.rust_path;
+                        Some(quote! {
+                            #definition, #rust_path
+                        })
+                    } else {
+                        None
+                    }
+                }),
+        )
+    }
+}

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -269,7 +269,7 @@ impl Directive for Safety {
 }
 
 fn allowlist_err_to_syn_err(err: AllowlistErr, span: &Span) -> syn::Error {
-    syn::Error::new(span.clone(), format!("{}", err))
+    syn::Error::new(*span, format!("{}", err))
 }
 
 struct StringList<SET, GET>(SET, GET)

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -9,6 +9,7 @@
 #![forbid(unsafe_code)]
 
 mod config;
+mod directives;
 pub mod file_locations;
 mod path;
 mod subclass_attrs;
@@ -29,7 +30,7 @@ use syn::{
 #[doc(hidden)]
 /// Ensure consistency between the `include_cpp!` parser
 /// and the standalone macro discoverer
-pub mod directives {
+pub mod directive_names {
     pub static EXTERN_RUST_TYPE: &str = "extern_rust_type";
     pub static EXTERN_RUST_FUN: &str = "extern_rust_function";
     pub static SUBCLASS: &str = "subclass";


### PR DESCRIPTION
No intentional functional changes.

This fixes two immediate bugs:
* The list of possible directives listed within error messages was incorrect
  ("expected generate, generate_pod," etc.)
* We were failing to output all directives within reproduction cases.

This forces symmetrical handling for all directives so prevents these sorts of
bugs being introduced in future.
