### PR TITLE
Where possible, treat incomprehensible typedefs as opaque types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "autocxx-bindgen"
-version = "0.59.15"
+version = "0.59.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c489e3a7c88e42bd4c9a7c7298853084840bf56de5ea1fff355db14208d6175"
+checksum = "435723e14bf88f198322f8555a4fdb108363021d97a47bb6492891ca86055e79"
 dependencies = [
  "bitflags",
  "cexpr",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -30,8 +30,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.59.15"
-#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "denote-deleted-move-constructors" }
+autocxx-bindgen = "=0.59.16"
+#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "pollute-fewer-typedefs" }
 itertools = "0.10.3"
 cc = { version = "1.0", optional = true }
 # Note: Keep the patch-level version of cxx-gen and cxx in sync.

--- a/engine/src/conversion/analysis/mod.rs
+++ b/engine/src/conversion/analysis/mod.rs
@@ -19,8 +19,10 @@ pub(crate) mod gc;
 mod name_check;
 pub(crate) mod pod; // hey, that rhymes
 pub(crate) mod remove_ignored;
+mod replace_hopeless_typedef_targets;
 pub(crate) mod tdef;
 mod type_converter;
 
 pub(crate) use name_check::check_names;
+pub(crate) use replace_hopeless_typedef_targets::replace_hopeless_typedef_targets;
 pub(crate) use type_converter::PointerTreatment;

--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -35,6 +35,7 @@ pub(crate) fn check_names(apis: ApiVec<FnPhase>) -> ApiVec<FnPhase> {
     convert_item_apis(apis, &mut intermediate, |api| match api {
         Api::Typedef { ref name, .. }
         | Api::ForwardDeclaration { ref name, .. }
+        | Api::OpaqueTypedef { ref name, .. }
         | Api::Const { ref name, .. }
         | Api::Enum { ref name, .. }
         | Api::Struct { ref name, .. } => {

--- a/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
+++ b/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
@@ -1,0 +1,67 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::collections::HashSet;
+
+use crate::{
+    conversion::{
+        analysis::tdef::TypedefAnalysis, api::Api, apivec::ApiVec,
+        convert_error::ConvertErrorWithContext,
+    },
+    types::QualifiedName,
+};
+
+use super::pod::PodPhase;
+/// Where we find a typedef pointing at something we can't represent,
+/// e.g. because it uses too many template parameters, break the link.
+/// Use the typedef as a first-class type.
+pub(crate) fn replace_hopeless_typedef_targets(apis: ApiVec<PodPhase>) -> ApiVec<PodPhase> {
+    let ignored_types: HashSet<QualifiedName> = apis
+        .iter()
+        .filter_map(|api| match api {
+            Api::IgnoredItem { .. } => Some(api.name()),
+            _ => None,
+        })
+        .cloned()
+        .collect();
+    let ignored_forward_declarations: HashSet<QualifiedName> = apis
+        .iter()
+        .filter_map(|api| match api {
+            Api::ForwardDeclaration { err: Some(_), .. } => Some(api.name()),
+            _ => None,
+        })
+        .cloned()
+        .collect();
+    // Convert any Typedefs which depend on these things into OpaqueTypedefs
+    // instead.
+    // And, after this point we no longer need special knowledge of forward
+    // declarations with errors, so just convert them into regular IgnoredItems too.
+    apis.into_iter()
+        .map(|api| match api {
+            Api::Typedef {
+                analysis: TypedefAnalysis { ref deps, .. },
+                ..
+            } if !ignored_types.is_disjoint(deps) => Api::OpaqueTypedef {
+                name: api.name_info().clone(),
+                forward_declaration: false,
+            },
+            Api::Typedef {
+                analysis: TypedefAnalysis { ref deps, .. },
+                ..
+            } if !ignored_forward_declarations.is_disjoint(deps) => Api::OpaqueTypedef {
+                name: api.name_info().clone(),
+                forward_declaration: true,
+            },
+            Api::ForwardDeclaration {
+                name,
+                err: Some(ConvertErrorWithContext(err, ctx)),
+            } => Api::IgnoredItem { name, err, ctx },
+            _ => api,
+        })
+        .collect()
+}

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -584,7 +584,11 @@ impl<'a> TypeConverter<'a> {
     fn find_incomplete_types<A: AnalysisPhase>(apis: &ApiVec<A>) -> HashSet<QualifiedName> {
         apis.iter()
             .filter_map(|api| match api {
-                Api::ForwardDeclaration { .. } => Some(api.name()),
+                Api::ForwardDeclaration { .. }
+                | Api::OpaqueTypedef {
+                    forward_declaration: true,
+                    ..
+                } => Some(api.name()),
                 _ => None,
             })
             .cloned()
@@ -635,6 +639,7 @@ pub(crate) fn find_types<A: AnalysisPhase>(apis: &ApiVec<A>) -> HashSet<Qualifie
     apis.iter()
         .filter_map(|api| match api {
             Api::ForwardDeclaration { .. }
+            | Api::OpaqueTypedef { .. }
             | Api::ConcreteType { .. }
             | Api::Typedef { .. }
             | Api::Enum { .. }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -451,8 +451,27 @@ impl SubclassName {
 /// (Specifically, allowing `syn` Types to be `Debug` requires
 /// enabling syn's `extra-traits` feature which increases compile time.)
 pub(crate) enum Api<T: AnalysisPhase> {
-    /// A forward declared type for which no definition is available.
-    ForwardDeclaration { name: ApiName },
+    /// A forward declaration, which we mustn't store in a UniquePtr.
+    ForwardDeclaration {
+        name: ApiName,
+        /// If we found a problem parsing this forward declaration, we'll
+        /// ephemerally store the error here, as opposed to immediately
+        /// converting it to an `IgnoredItem`. That's because the
+        /// 'replace_hopeless_typedef_targets' analysis phase needs to spot
+        /// cases where there was an error which was _also_ a forward declaration.
+        /// That phase will then discard such Api::ForwardDeclarations
+        /// and replace them with normal Api::IgnoredItems.
+        err: Option<ConvertErrorWithContext>,
+    },
+    /// We found a typedef to something that we didn't fully understand.
+    /// We'll treat it as an opaque unsized type.
+    OpaqueTypedef {
+        name: ApiName,
+        /// Further store whether this was a typedef to a forward declaration.
+        /// If so we can't allow it to live in a UniquePtr, just like a regular
+        /// Api::ForwardDeclaration.
+        forward_declaration: bool,
+    },
     /// A synthetic type we've manufactured in order to
     /// concretize some templated C++ type.
     ConcreteType {
@@ -562,7 +581,8 @@ pub(crate) enum UnsafetyNeeded {
 impl<T: AnalysisPhase> Api<T> {
     pub(crate) fn name_info(&self) -> &ApiName {
         match self {
-            Api::ForwardDeclaration { name } => name,
+            Api::ForwardDeclaration { name, .. } => name,
+            Api::OpaqueTypedef { name, .. } => name,
             Api::ConcreteType { name, .. } => name,
             Api::StringConstructor { name } => name,
             Api::Function { name, .. } => name,

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -529,7 +529,9 @@ impl<'a> RsCodeGenerator<'a> {
                     None,
                 )
             }
-            Api::ForwardDeclaration { .. } | Api::ConcreteType { .. } => self.generate_type(
+            Api::ForwardDeclaration { .. }
+            | Api::ConcreteType { .. }
+            | Api::OpaqueTypedef { .. } => self.generate_type(
                 &name,
                 id,
                 TypeKind::Abstract,

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -99,9 +99,19 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                 rs_definition,
                 cpp_definition,
             }))),
-            Api::ForwardDeclaration { name } => {
-                Ok(Box::new(std::iter::once(Api::ForwardDeclaration { name })))
+            Api::ForwardDeclaration { name, err } => {
+                Ok(Box::new(std::iter::once(Api::ForwardDeclaration {
+                    name,
+                    err,
+                })))
             }
+            Api::OpaqueTypedef {
+                name,
+                forward_declaration,
+            } => Ok(Box::new(std::iter::once(Api::OpaqueTypedef {
+                name,
+                forward_declaration,
+            }))),
             Api::StringConstructor { name } => {
                 Ok(Box::new(std::iter::once(Api::StringConstructor { name })))
             }

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -41,6 +41,7 @@ use self::{
         gc::filter_apis_by_following_edges_from_allowlist,
         pod::analyze_pod_apis,
         remove_ignored::filter_apis_by_ignored_dependents,
+        replace_hopeless_typedef_targets,
         tdef::convert_typedef_targets,
     },
     api::AnalysisPhase,
@@ -145,6 +146,7 @@ impl<'a> BridgeConverter<'a> {
                 // by subsequent phases to work out which objects are POD.
                 let analyzed_apis = analyze_pod_apis(apis, self.config)?;
                 Self::dump_apis("pod analysis", &analyzed_apis);
+                let analyzed_apis = replace_hopeless_typedef_targets(analyzed_apis);
                 let analyzed_apis = add_casts(analyzed_apis);
                 let analyzed_apis = create_alloc_and_frees(analyzed_apis);
                 // Next, figure out how we materialize different functions.


### PR DESCRIPTION
Supposing (as is commonly the case) we have

```cpp
  typedef SomethingComplex SomethingSimple;
```

Previously if bindgen couldn't represent `SomethingComplex`, we gave up on `SomethingSimple` too.
Now we generate an opaque type for `SomethingSimple`.