### PR TITLE
Allow implicit constructors for structs with array fields

### DIFF
--- a/engine/src/conversion/analysis/fun/implicit_constructors.rs
+++ b/engine/src/conversion/analysis/fun/implicit_constructors.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{hash_map, HashMap, HashSet};
 
-use syn::Type;
+use syn::{Type, TypeArray};
 
 use crate::{
     conversion::{
@@ -217,6 +217,12 @@ pub(super) fn find_constructors_present(
                 .filter_map(|field_info| match field_info.type_kind {
                     TypeKind::Regular | TypeKind::SubclassHolder(_) => match field_info.ty {
                         Type::Path(ref qn) => get_items_found(&QualifiedName::from_type_path(qn)),
+                        Type::Array(TypeArray { ref elem, .. }) => match elem.as_ref() {
+                            Type::Path(ref qn) => {
+                                get_items_found(&QualifiedName::from_type_path(qn))
+                            }
+                            _ => None,
+                        },
                         _ => None,
                     },
                     // TODO: https://github.com/google/autocxx/issues/865 Figure out how to

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -8469,12 +8469,11 @@ fn test_implicit_constructor_with_array_field() {
     "};
     let rs = quote! {
         moveit! {
-            let mut stack_obj = ffi::A::new();
+            let mut _stack_obj = ffi::A::new();
         }
     };
     run_test("", hdr, rs, &["A"], &[]);
 }
-
 
 #[test]
 fn test_implicit_constructor_moveit() {

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -8435,6 +8435,29 @@ fn test_move_out_of_uniqueptr() {
 }
 
 #[test]
+fn test_implicit_constructor_with_typedef_field() {
+    let hdr = indoc! {"
+    #include <stdint.h>
+    #include <string>
+    struct B {
+        uint32_t b;
+    };
+    typedef struct B C;
+    struct A {
+        B field;
+        uint32_t a;
+        std::string so_we_are_non_trivial;
+    };
+    "};
+    let rs = quote! {
+        moveit! {
+            let mut stack_obj = ffi::A::new();
+        }
+    };
+    run_test("", hdr, rs, &["A"], &[]);
+}
+
+#[test]
 fn test_implicit_constructor_moveit() {
     let hdr = indoc! {"
     #include <stdint.h>

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -8458,6 +8458,25 @@ fn test_implicit_constructor_with_typedef_field() {
 }
 
 #[test]
+fn test_implicit_constructor_with_array_field() {
+    let hdr = indoc! {"
+    #include <stdint.h>
+    #include <string>
+    struct A {
+        uint32_t a[3];
+        std::string so_we_are_non_trivial;
+    };
+    "};
+    let rs = quote! {
+        moveit! {
+            let mut stack_obj = ffi::A::new();
+        }
+    };
+    run_test("", hdr, rs, &["A"], &[]);
+}
+
+
+#[test]
 fn test_implicit_constructor_moveit() {
     let hdr = indoc! {"
     #include <stdint.h>


### PR DESCRIPTION
Fixes #1038.