### PR TITLE
Achieve predictable iteraction order.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ version = "0.21.0"
 dependencies = [
  "autocxx-engine",
  "env_logger 0.9.0",
+ "indexmap",
  "syn",
 ]
 
@@ -147,6 +148,7 @@ dependencies = [
  "autocxx-parser",
  "cc",
  "cxx-gen",
+ "indexmap",
  "indoc",
  "itertools 0.10.3",
  "log",
@@ -237,6 +239,7 @@ dependencies = [
 name = "autocxx-parser"
 version = "0.21.0"
 dependencies = [
+ "indexmap",
  "itertools 0.10.3",
  "log",
  "once_cell",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -48,6 +48,7 @@ serde_json = { version = "1.0", optional = true }
 miette = "4.3"
 thiserror = "1"
 regex = "1.5"
+indexmap = "1.8"
 
 [dependencies.syn]
 version = "1.0.39"

--- a/engine/src/ast_discoverer.rs
+++ b/engine/src/ast_discoverer.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashSet;
+use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::{
     directive_names::{EXTERN_RUST_FUN, EXTERN_RUST_TYPE},

--- a/engine/src/conversion/analysis/constructor_deps.rs
+++ b/engine/src/conversion/analysis/constructor_deps.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+use indexmap::map::IndexMap as HashMap;
 
 use crate::{
     conversion::{

--- a/engine/src/conversion/analysis/ctypes.rs
+++ b/engine/src/conversion/analysis/ctypes.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+use indexmap::map::IndexMap as HashMap;
 
 use syn::Ident;
 

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -31,7 +31,8 @@ use crate::{
     known_types::known_types,
     types::validate_ident_ok_for_rust,
 };
-use std::collections::{HashMap, HashSet};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::{ExternCppType, IncludeCppConfig, UnsafePolicy};
 use function_wrapper::{CppFunction, CppFunctionBody, TypeConversionPolicy};
@@ -1222,7 +1223,7 @@ impl<'a> FnAnalyzer<'a> {
                 })
         };
         let mut deps = params_deps;
-        deps.extend(return_analysis.deps.drain());
+        deps.extend(return_analysis.deps.drain(..));
 
         // Sometimes, the return type will actually be a value type
         // for which we instead want to _pass_ a pointer into which the value

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+use indexmap::map::IndexMap as HashMap;
 
 use syn::{parse_quote, FnArg, PatType, Type, TypePtr};
 

--- a/engine/src/conversion/analysis/gc.rs
+++ b/engine/src/conversion/analysis/gc.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{HashMap, HashSet};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::IncludeCppConfig;
 

--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+use indexmap::map::IndexMap as HashMap;
 
 use syn::Ident;
 

--- a/engine/src/conversion/analysis/remove_ignored.rs
+++ b/engine/src/conversion/analysis/remove_ignored.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashSet;
+use indexmap::set::IndexSet as HashSet;
 
 use super::deps::HasDependencies;
 use super::fun::{FnAnalysis, FnKind, FnPhase};
@@ -38,7 +38,7 @@ pub(crate) fn filter_apis_by_ignored_dependents(mut apis: ApiVec<FnPhase>) -> Ap
             .map(|api| {
                 let ignored_dependents: HashSet<_> = api
                     .deps()
-                    .filter(|dep| ignored_items.contains(dep))
+                    .filter(|dep| ignored_items.contains(*dep))
                     .cloned()
                     .collect();
                 if !ignored_dependents.is_empty() {
@@ -47,7 +47,7 @@ pub(crate) fn filter_apis_by_ignored_dependents(mut apis: ApiVec<FnPhase>) -> Ap
                     create_ignore_item(api, ConvertError::IgnoredDependent(ignored_dependents))
                 } else {
                     let mut missing_deps = api.deps().filter(|dep| {
-                        !valid_types.contains(dep) && !known_types().is_known_type(dep)
+                        !valid_types.contains(*dep) && !known_types().is_known_type(dep)
                     });
                     let first = missing_deps.next();
                     std::mem::drop(missing_deps);

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashSet;
+use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::IncludeCppConfig;
 use syn::ItemType;

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -17,10 +17,11 @@ use crate::{
     types::{make_ident, Namespace, QualifiedName},
 };
 use autocxx_parser::IncludeCppConfig;
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 use itertools::Itertools;
 use proc_macro2::Ident;
 use quote::ToTokens;
-use std::collections::{HashMap, HashSet};
 use syn::{
     parse_quote, punctuated::Punctuated, GenericArgument, PathArguments, PathSegment, Type,
     TypePath, TypePtr,
@@ -309,7 +310,7 @@ impl<'a> TypeConverter<'a> {
                 if let PathArguments::AngleBracketed(ref mut ab) = last_seg.arguments {
                     let mut innerty = self.convert_punctuated(ab.args.clone(), ns)?;
                     ab.args = innerty.ty;
-                    deps.extend(innerty.types_encountered.drain());
+                    deps.extend(innerty.types_encountered.drain(..));
                 }
             } else {
                 // Oh poop. It's a generic type which cxx won't be able to handle.
@@ -348,7 +349,7 @@ impl<'a> TypeConverter<'a> {
                 GenericArgument::Type(t) => {
                     let mut innerty =
                         self.convert_type(t, ns, &TypeConversionContext::CxxInnerType)?;
-                    types_encountered.extend(innerty.types_encountered.drain());
+                    types_encountered.extend(innerty.types_encountered.drain(..));
                     extra_apis.append(&mut innerty.extra_apis);
                     GenericArgument::Type(innerty.ty)
                 }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{collections::HashSet, fmt::Display};
+use indexmap::set::IndexSet as HashSet;
+use std::fmt::Display;
 
 use crate::types::{make_ident, Namespace, QualifiedName};
 use autocxx_parser::{ExternCppType, RustFun, RustPath};

--- a/engine/src/conversion/apivec.rs
+++ b/engine/src/conversion/apivec.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use indexmap::set::IndexSet as HashSet;
 
 use crate::{
     conversion::{api::ApiName, convert_error::ErrorContext, ConvertError},

--- a/engine/src/conversion/codegen_cpp/type_to_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/type_to_cpp.rs
@@ -10,9 +10,9 @@ use crate::{
     conversion::{apivec::ApiVec, AnalysisPhase, ConvertError},
     types::QualifiedName,
 };
+use indexmap::map::IndexMap as HashMap;
 use itertools::Itertools;
 use quote::ToTokens;
-use std::collections::HashMap;
 use std::iter::once;
 use syn::{Token, Type};
 

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{borrow::Cow, collections::HashSet};
+use indexmap::set::IndexSet as HashSet;
+use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};

--- a/engine/src/conversion/codegen_rs/lifetime.rs
+++ b/engine/src/conversion/codegen_rs/lifetime.rs
@@ -11,9 +11,10 @@ use crate::{
     },
     types::QualifiedName,
 };
+use indexmap::set::IndexSet as HashSet;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use std::{borrow::Cow, collections::HashSet};
+use std::borrow::Cow;
 use syn::{
     parse_quote, punctuated::Punctuated, token::Comma, FnArg, GenericArgument, PatType, Path,
     PathSegment, ReturnType, Type, TypePath, TypeReference,

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -14,7 +14,8 @@ mod namespace_organizer;
 mod non_pod_struct;
 pub(crate) mod unqualify;
 
-use std::collections::{HashMap, HashSet};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::{ExternCppType, IncludeCppConfig, RustFun};
 

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashSet;
+use indexmap::set::IndexSet as HashSet;
 
 use itertools::Itertools;
 use syn::Ident;

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -10,9 +10,9 @@ use crate::{
     conversion::ConvertError,
     types::{make_ident, QualifiedName},
 };
+use indexmap::map::IndexMap as HashMap;
 use indoc::indoc;
 use once_cell::sync::OnceCell;
-use std::collections::HashMap;
 use syn::{parse_quote, Type, TypePath, TypePtr};
 
 //// The behavior of the type.

--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -14,10 +14,11 @@ use crate::{
 use crate::{CppCodegenOptions, LocatedSynError};
 use autocxx_parser::directive_names::SUBCLASS;
 use autocxx_parser::{AllowlistEntry, RustPath, Subclass, SubclassAttrs};
+use indexmap::set::IndexSet as HashSet;
 use miette::Diagnostic;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use std::{collections::HashSet, io::Read, path::PathBuf};
+use std::{io::Read, path::PathBuf};
 use std::{panic::UnwindSafe, path::Path, rc::Rc};
 use syn::{token::Brace, Item, ItemMod};
 use thiserror::Error;

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -24,6 +24,7 @@ static = [ "autocxx-engine/static" ]
 [dependencies]
 autocxx-engine = { version="=0.21.0", path="../../engine", features = ["build"] }
 env_logger = "0.9.0"
+indexmap = "1.8"
 
 [dependencies.syn]
 version = "1.0"

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -9,7 +9,8 @@
 #![forbid(unsafe_code)]
 
 use autocxx_engine::{BuilderContext, RebuildDependencyRecorder};
-use std::{collections::HashSet, io::Write, sync::Mutex};
+use indexmap::set::IndexSet as HashSet;
+use std::{io::Write, sync::Mutex};
 
 pub type Builder = autocxx_engine::Builder<'static, CargoBuilderContext>;
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -26,6 +26,7 @@ serde_derive = { version = "1.0", optional = true }
 thiserror = "1.0"
 once_cell = "1.10"
 itertools = "0.10.3"
+indexmap = "1.8"
 
 [dependencies.syn]
 version = "1.0.39"

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+use indexmap::map::IndexMap as HashMap;
 
 use once_cell::sync::OnceCell;
 use proc_macro2::Span;


### PR DESCRIPTION
Previously some parts of autocxx would run in a random order, which resulted in
(at least) different logging, and possibly differing output.
