### PR TITLE
Provide mode to output a single file (via source munging)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,10 +174,16 @@ dependencies = [
  "clap 2.33.4",
  "cxx",
  "env_logger 0.9.0",
+ "indexmap",
+ "itertools 0.10.3",
+ "log",
  "miette",
  "pathdiff",
  "proc-macro2",
  "quote",
+ "regex",
+ "serde",
+ "serde_json",
  "tempdir",
 ]
 
@@ -688,6 +694,7 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -169,13 +169,6 @@ impl<CTX: BuilderContext> Builder<'_, CTX> {
         self
     }
 
-    /// Whether to skip using [`cxx_gen`] to generate the C++ code,
-    /// so that some other process can handle that.
-    pub fn skip_cxx_gen(mut self, skip_cxx_gen: bool) -> Self {
-        self.cpp_codegen_options.skip_cxx_gen = skip_cxx_gen;
-        self
-    }
-
     /// Build autocxx C++ files and return a [`cc::Build`] you can use to build
     /// more from a build.rs file.
     ///

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -580,9 +580,7 @@ impl CppBuildable for IncludeCppEngine {
             State::NotGenerated => panic!("Call generate() first"),
             State::Generated(gen_results) => {
                 let rs = gen_results.item_mod.to_token_stream();
-                if !cpp_codegen_options.skip_cxx_gen {
-                    files.push(do_cxx_cpp_generation(rs, cpp_codegen_options)?);
-                }
+                files.push(do_cxx_cpp_generation(rs, cpp_codegen_options)?);
                 if let Some(cpp_file_pair) = &gen_results.cpp {
                     files.push(cpp_file_pair.clone());
                 }
@@ -676,9 +674,6 @@ pub struct CppCodegenOptions<'a> {
     /// An annotation optionally to include on each C++ function.
     /// For example to export the symbol from a library.
     pub cxx_impl_annotations: Option<String>,
-    /// Whether to skip using [`cxx_gen`] to generate the C++ code,
-    /// so that some other process can handle that.
-    pub skip_cxx_gen: bool,
 }
 
 fn proc_macro_span_to_miette_span(span: &proc_macro2::Span) -> SourceSpan {

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -29,6 +29,12 @@ proc-macro2 = "1.0"
 env_logger = "0.9.0"
 miette = { version="4.3", features=["fancy"]}
 pathdiff = "0.2.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+regex = "1.5"
+log = "0.4"
+itertools = "0.10.3"
+indexmap = { version = "1.8", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -140,12 +140,6 @@ fn main() -> miette::Result<()> {
             .arg("gen-rs-include")
         )
         .arg(
-            Arg::with_name("skip-cxx-gen")
-                .long("skip-cxx-gen")
-                .help("Skip performing C++ codegen for #[cxx::bridge] blocks. Only applies for --gen-cpp")
-                .requires("gen-cpp")
-        )
-        .arg(
             Arg::with_name("generate-exact")
                 .long("generate-exact")
                 .value_name("NUM")
@@ -237,7 +231,6 @@ fn main() -> miette::Result<()> {
         cxx_impl_annotations: get_option_string("cxx-impl-annotations", &matches),
         path_to_cxx_h: get_option_string("cxx-h-path", &matches),
         path_to_cxxgen_h: get_option_string("cxxgen-h-path", &matches),
-        skip_cxx_gen: matches.is_present("skip-cxx-gen"),
         header_namer,
     };
     let depfile = match matches.value_of("depfile") {

--- a/gen/cmd/src/output.rs
+++ b/gen/cmd/src/output.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    cell::RefCell,
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+    rc::Rc,
+};
+
+use crate::depfile::Depfile;
+
+pub(crate) trait Output {
+    fn write_cpp(&mut self, filename: String, content: &[u8]);
+
+    fn write_rs(&mut self, filename: String, content: &[u8]);
+
+    fn finalize(&mut self) {}
+}
+
+pub(crate) fn write_atomic(depfile: &Option<Rc<RefCell<Depfile>>>, path: &Path, content: &[u8]) {
+    let f = File::open(&path);
+    if let Some(depfile) = depfile {
+        depfile.borrow_mut().add_output(path);
+    }
+    if let Ok(mut f) = f {
+        let mut existing_content = Vec::new();
+        let r = f.read_to_end(&mut existing_content);
+        if r.is_ok() && existing_content == content {
+            return; // don't change timestamp on existing file unnecessarily
+        }
+    }
+    let mut f = File::create(&path).expect("Unable to create file");
+    f.write_all(content).expect("Unable to write file");
+}

--- a/gen/cmd/src/output_regular.rs
+++ b/gen/cmd/src/output_regular.rs
@@ -1,0 +1,47 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    cell::RefCell,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use crate::{
+    depfile::Depfile,
+    output::{write_atomic, Output},
+};
+
+pub(crate) struct RegularOutput {
+    depfile: Option<Rc<RefCell<Depfile>>>,
+    dir: PathBuf,
+}
+
+impl Output for RegularOutput {
+    fn write_cpp(&mut self, filename: String, content: &[u8]) {
+        self.write_to_file(filename, content)
+    }
+
+    fn write_rs(&mut self, filename: String, content: &[u8]) {
+        self.write_to_file(filename, content)
+    }
+}
+
+impl RegularOutput {
+    pub(crate) fn new(depfile: Option<Rc<RefCell<Depfile>>>, dir: &Path) -> Self {
+        Self {
+            depfile,
+            dir: dir.into(),
+        }
+    }
+
+    fn write_to_file(&self, filename: String, content: &[u8]) {
+        let path = self.dir.join(filename);
+        write_atomic(&self.depfile, &path, content);
+    }
+}

--- a/gen/cmd/src/output_single.rs
+++ b/gen/cmd/src/output_single.rs
@@ -1,0 +1,182 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    cell::RefCell,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
+
+use itertools::Itertools;
+use regex::Regex;
+use serde::Serialize;
+
+use crate::{
+    depfile::Depfile,
+    output::{write_atomic, Output},
+};
+
+pub(crate) struct SingleFileOutput {
+    depfile: Option<Rc<RefCell<Depfile>>>,
+    dir: PathBuf,
+    contents_rs: RustFiles,
+    contents_cpp: HashMap<String, String>,
+}
+
+#[derive(Serialize, Default)]
+struct RustFiles {
+    mapping: HashMap<String, String>,
+}
+
+impl Output for SingleFileOutput {
+    fn write_cpp(&mut self, filename: String, content: &[u8]) {
+        self.contents_cpp.insert(
+            filename,
+            String::from_utf8(content.to_vec()).expect("C++ code was not valid UTF8"),
+        );
+    }
+
+    fn write_rs(&mut self, filename: String, content: &[u8]) {
+        self.contents_rs.mapping.insert(
+            filename,
+            String::from_utf8(content.to_vec()).expect("Rust code was not valid UTF8"),
+        );
+    }
+
+    fn finalize(&mut self) {
+        // Write out the Rust as a big JSON blob.
+        let json_path = self.dir.join("autocxx_gen_combined.rs.json");
+        let json =
+            serde_json::to_string(&self.contents_rs).expect("Unable to serialize JSON for Rust");
+        write_atomic(&self.depfile, &json_path, json.as_bytes());
+
+        // For C++... we combine all headers into a single header, and all .cc files into a single .cc file.
+        let combined_h_content = create_combined_file(&mut self.contents_cpp, "h", None);
+        let combined_h_path = self.dir.join("autocxx_gen_combined.h");
+        write_atomic(
+            &self.depfile,
+            &combined_h_path,
+            combined_h_content.as_bytes(),
+        );
+
+        let combined_cc_content =
+            create_combined_file(&mut self.contents_cpp, "cc", Some("autocxx_gen_combined.h"));
+        let combined_cc_path = self.dir.join("autocxx_gen_combined.cc");
+        write_atomic(
+            &self.depfile,
+            &combined_cc_path,
+            combined_cc_content.as_bytes(),
+        );
+    }
+}
+
+impl SingleFileOutput {
+    pub(crate) fn new(depfile: Option<Rc<RefCell<Depfile>>>, dir: &Path) -> Self {
+        Self {
+            depfile,
+            dir: dir.into(),
+            contents_rs: Default::default(),
+            contents_cpp: HashMap::new(),
+        }
+    }
+}
+
+fn create_combined_file(
+    contents_cpp: &HashMap<String, String>,
+    filename_suffix: &str,
+    other_file_to_include: Option<&str>,
+) -> String {
+    let mut done = HashSet::new();
+    let all_filenames: HashSet<_> = contents_cpp.keys().cloned().collect();
+    let mut to_do: HashSet<String> = all_filenames
+        .iter()
+        .filter(|filename| filename.ends_with(filename_suffix))
+        .cloned()
+        .collect();
+    let mut output_lines = Vec::new();
+    loop {
+        if to_do.is_empty() {
+            break;
+        }
+        let mut this_filename = None;
+        for candidate in &to_do {
+            let candidate_deps =
+                find_dependencies(contents_cpp.get(&candidate.to_string()).unwrap());
+            let candidate_deps: HashSet<String> =
+                candidate_deps.into_iter().map(|s| s.to_string()).collect();
+            //println!("Deps from {} are {:?}", candidate, candidate_deps);
+            if candidate_deps.is_disjoint(&to_do) {
+                this_filename = Some(candidate.to_string());
+                break;
+            }
+        }
+        let this_filename = this_filename
+            .expect("All remaining files depend on other files we have yet to process");
+        to_do.remove(this_filename.as_str());
+        done.insert(this_filename.to_string());
+        let content = contents_cpp.get(this_filename.as_str()).unwrap();
+        for line in content.lines() {
+            let line_deps = find_dependencies(line);
+            let line_deps: HashSet<String> = line_deps.into_iter().map(|s| s.to_string()).collect();
+            if line_deps.is_disjoint(&all_filenames) {
+                output_lines.push(line.to_string());
+            }
+        }
+    }
+    let mut output_lines = other_file_to_include
+        .map(|s| format!("#include \"{}\"\n", s))
+        .into_iter()
+        .chain(output_lines.into_iter());
+    output_lines.join("\n")
+}
+
+#[test]
+fn test_create_combined_file() {
+    let mut contents: HashMap<String, String> = HashMap::new();
+    contents.insert("a.h".into(), "foo\n#include <b.h>\nbar\n".into());
+    contents.insert("b.h".into(), "foo2\n\nbar2\n".into());
+    contents.insert("a.cc".into(), "foo3\n#include <b.h>\nbar4\n".into());
+    contents.insert(
+        "b.cc".into(),
+        "foo5\n#include <a.h>\n#include <b.h>\n\nbar6\n".into(),
+    );
+    let combined = create_combined_file(&mut contents.clone(), "h", None);
+    assert_eq!(combined, "foo2\n\nbar2\nfoo\nbar");
+    let combined = create_combined_file(&mut contents.clone(), "cc", Some("combined.h"));
+    assert_eq!(
+        combined,
+        "#include \"combined.h\"\n\nfoo3\nbar4\nfoo5\n\nbar6"
+    );
+}
+
+fn find_dependencies(cpp_code: &str) -> HashSet<&str> {
+    let re = Regex::new("#include [<\"](.*)[>\"]").unwrap();
+    re.captures_iter(cpp_code)
+        .map(|captures| captures.get(1).unwrap().as_str())
+        .collect()
+}
+
+#[test]
+fn test_find_dependencies() {
+    assert_eq!(find_dependencies(""), HashSet::new());
+    assert_eq!(
+        find_dependencies("#include <a.h>"),
+        ["a.h"].into_iter().collect::<HashSet<_>>()
+    );
+    assert_eq!(
+        find_dependencies("#include \"a.h\""),
+        ["a.h"].into_iter().collect::<HashSet<_>>()
+    );
+    assert_eq!(
+        find_dependencies("#include \"a.h\"\nfoo\n#include <b.h>\n\nbar"),
+        ["a.h", "b.h"].into_iter().collect::<HashSet<_>>()
+    );
+}

--- a/gen/cmd/tests/cmd_test.rs
+++ b/gen/cmd/tests/cmd_test.rs
@@ -172,31 +172,6 @@ fn test_gen_repro() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[test]
-fn test_skip_cxx_gen() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
-    base_test_ex(
-        &tmp_dir,
-        |cmd| {
-            cmd.arg("--generate-exact")
-                .arg("3")
-                .arg("--fix-rs-include-name")
-                .arg("--skip-cxx-gen");
-        },
-        false,
-    )?;
-    assert_contentful(&tmp_dir, "gen0.h");
-    assert_not_contentful(&tmp_dir, "gen0.cc");
-    assert_exists(&tmp_dir, "gen1.cc");
-    assert_exists(&tmp_dir, "gen1.h");
-    assert_exists(&tmp_dir, "gen2.cc");
-    assert_exists(&tmp_dir, "gen2.h");
-    assert_contentful(&tmp_dir, "gen0.include.rs");
-    assert_exists(&tmp_dir, "gen1.include.rs");
-    assert_exists(&tmp_dir, "gen2.include.rs");
-    Ok(())
-}
-
 fn write_to_file(dir: &Path, filename: &str, content: &[u8]) {
     let path = dir.join(filename);
     let mut f = File::create(&path).expect("Unable to create file");
@@ -225,13 +200,6 @@ fn assert_not_contentful(outdir: &TempDir, fname: &str) {
         "File {} is not empty",
         fname
     );
-}
-
-fn assert_exists(outdir: &TempDir, fname: &str) {
-    let p = outdir.path().join(fname);
-    if !p.exists() {
-        panic!("File {} didn't exist", p.to_string_lossy());
-    }
 }
 
 fn assert_contains(outdir: &TempDir, fname: &str, pattern: &str) {

--- a/gen/cmd/tests/cmd_test.rs
+++ b/gen/cmd/tests/cmd_test.rs
@@ -32,16 +32,12 @@ fn base_test<F>(tmp_dir: &TempDir, arg_modifier: F) -> Result<(), Box<dyn std::e
 where
     F: FnOnce(&mut Command),
 {
-    let result = base_test_ex(tmp_dir, arg_modifier, false);
+    let result = base_test_ex(tmp_dir, arg_modifier);
     assert_contentful(tmp_dir, "gen0.cc");
     result
 }
 
-fn base_test_ex<F>(
-    tmp_dir: &TempDir,
-    arg_modifier: F,
-    use_complete_rs: bool,
-) -> Result<(), Box<dyn std::error::Error>>
+fn base_test_ex<F>(tmp_dir: &TempDir, arg_modifier: F) -> Result<(), Box<dyn std::error::Error>>
 where
     F: FnOnce(&mut Command),
 {
@@ -57,13 +53,12 @@ where
         .arg(demo_rs)
         .arg("--outdir")
         .arg(tmp_dir.path().to_str().unwrap())
-        .arg("--gen-cpp");
-    if use_complete_rs {
-        cmd.arg("--gen-rs-complete");
-    } else {
-        cmd.arg("--gen-rs-include");
-    }
+        .arg("--gen-cpp")
+        .arg("--gen-rs-include");
     cmd.assert().success();
+    if let Ok(output) = cmd.output() {
+        eprintln!("Cmd output={:?}", output);
+    }
     Ok(())
 }
 
@@ -94,48 +89,33 @@ fn test_include_prefixes() -> Result<(), Box<dyn std::error::Error>> {
         cmd.arg("--cxx-h-path")
             .arg("foo/")
             .arg("--cxxgen-h-path")
-            .arg("bar/")
-            .arg("--generate-exact")
-            .arg("3");
+            .arg("bar/");
     })?;
-    assert_contains(&tmp_dir, "gen0.h", "foo/cxx.h");
+    assert_contains(&tmp_dir, "autocxxgen_ffi.h", "foo/cxx.h");
     // Currently we don't test cxxgen-h-path because we build the demo code
     // which doesn't refer to generated cxx header code.
     Ok(())
 }
 
 #[test]
-fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
+fn test_gen_single() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = TempDir::new("example")?;
     let depfile = tmp_dir.path().join("test.d");
-    base_test_ex(
-        &tmp_dir,
-        |cmd| {
-            cmd.arg("--generate-exact")
-                .arg("3")
-                .arg("--depfile")
-                .arg(depfile);
-        },
-        true,
-    )?;
-    assert_contentful(&tmp_dir, "gen0.cc");
-    assert_contentful(&tmp_dir, "gen0.h");
-    // TODO: This file will actually try #including one of our .h files if there's anything to put
-    // in it. Figure out how to make that happen to test that it works.
-    assert_not_contentful(&tmp_dir, "gen1.cc");
-    assert_not_contentful(&tmp_dir, "gen1.h");
-    assert_not_contentful(&tmp_dir, "gen2.cc");
-    assert_not_contentful(&tmp_dir, "gen2.h");
-    assert_contentful(&tmp_dir, "cxxgen.h");
-    assert_contentful(&tmp_dir, "gen.complete.rs");
+    base_test_ex(&tmp_dir, |cmd| {
+        cmd.arg("--single").arg("--depfile").arg(depfile);
+    })?;
+    assert_contentful(&tmp_dir, "autocxx_gen_combined.cc");
+    assert_contentful(&tmp_dir, "autocxx_gen_combined.h");
+    assert_contentful(&tmp_dir, "autocxx_gen_combined.rs.json");
     assert_contentful(&tmp_dir, "test.d");
     File::create(tmp_dir.path().join("cxx.h"))
         .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
+    std::env::set_var("OUT_DIR", tmp_dir.path().to_str().unwrap());
     let r = build_from_folder(
         tmp_dir.path(),
-        &tmp_dir.path().join("gen.complete.rs"),
-        vec![],
-        &["gen0.cc"],
+        &tmp_dir.path().join("demo/main.rs"),
+        vec![tmp_dir.path().join("autocxx_gen_combined.rs.json")],
+        &["autocxx_gen_combined.cc"],
     );
     if KEEP_TEMPDIRS {
         println!("Tempdir: {:?}", tmp_dir.into_path().to_str());
@@ -186,18 +166,6 @@ fn assert_contentful(outdir: &TempDir, fname: &str) {
     assert!(
         p.metadata().unwrap().len() > BLANK.len().try_into().unwrap(),
         "File {} is empty",
-        fname
-    );
-}
-
-fn assert_not_contentful(outdir: &TempDir, fname: &str) {
-    let p = outdir.path().join(fname);
-    if !p.exists() {
-        panic!("File {} didn't exist", p.to_string_lossy());
-    }
-    assert!(
-        p.metadata().unwrap().len() <= BLANK.len().try_into().unwrap(),
-        "File {} is not empty",
         fname
     );
 }

--- a/integration-tests/tests/builder_modifiers.rs
+++ b/integration-tests/tests/builder_modifiers.rs
@@ -59,14 +59,3 @@ impl BuilderModifierFns for EnableAutodiscover {
         builder.auto_allowlist(true)
     }
 }
-
-pub(crate) struct SkipCxxGen;
-
-impl BuilderModifierFns for SkipCxxGen {
-    fn modify_autocxx_builder<'a>(
-        &self,
-        builder: Builder<'a, TestBuilderContext>,
-    ) -> Builder<'a, TestBuilderContext> {
-        builder.skip_cxx_gen(true)
-    }
-}

--- a/integration-tests/tests/code_checkers.rs
+++ b/integration-tests/tests/code_checkers.rs
@@ -124,31 +124,6 @@ pub(crate) fn make_rust_code_finder(code: Vec<TokenStream>) -> CodeChecker {
     Box::new(RustCodeFinder(code))
 }
 
-/// Counts the number of generated C++ files.
-pub(crate) struct CppCounter {
-    cpp_count: usize,
-}
-
-impl CppCounter {
-    pub(crate) fn new(cpp_count: usize) -> Self {
-        Self { cpp_count }
-    }
-}
-
-impl CodeCheckerFns for CppCounter {
-    fn check_cpp(&self, cpp: &[PathBuf]) -> Result<(), TestError> {
-        if cpp.len() == self.cpp_count {
-            Ok(())
-        } else {
-            Err(TestError::CppCodeExaminationFail)
-        }
-    }
-
-    fn skip_build(&self) -> bool {
-        true
-    }
-}
-
 /// Searches generated C++ for strings we want to find, or want _not_ to find,
 /// or both.
 pub(crate) struct CppMatcher<'a> {

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -9,10 +9,9 @@
 use crate::{
     builder_modifiers::{
         make_clang_arg_adder, make_cpp17_adder, EnableAutodiscover, SetSuppressSystemHeaders,
-        SkipCxxGen,
     },
     code_checkers::{
-        make_error_finder, make_rust_code_finder, make_string_finder, CppCounter, CppMatcher,
+        make_error_finder, make_rust_code_finder, make_string_finder, CppMatcher,
         NoSystemHeadersChecker,
     },
 };
@@ -9518,27 +9517,6 @@ fn test_issue486_multi_types() {
         rs,
         &["spanner::Key", "a::spanner::Key", "b::spanner::Key"],
         &[],
-    );
-}
-
-#[test]
-fn test_skip_cxx_gen() {
-    let cxx = indoc! {"
-        void do_nothing() {
-        }
-    "};
-    let hdr = indoc! {"
-        void do_nothing();
-    "};
-    let rs = quote! {};
-    run_test_ex(
-        cxx,
-        hdr,
-        rs,
-        directives_from_lists(&["do_nothing"], &[], None),
-        Some(Box::new(SkipCxxGen)),
-        Some(Box::new(CppCounter::new(1))),
-        None,
     );
 }
 


### PR DESCRIPTION
This seems unlikely to work due to a load-bearing #pragma once in the cxx
output. Instead, we will try to merge multiple cxx::bridges before a single
invocation of cxx_gen. Other parts of this will work OK so saving.