### PR TITLE
Remove gen-rs-complete.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,6 @@ dependencies = [
  "miette",
  "pathdiff",
  "proc-macro2",
- "quote",
  "tempdir",
 ]
 

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -24,7 +24,6 @@ static = [ "autocxx-engine/static" ]
 [dependencies]
 autocxx-engine = { version="=0.21.2", path="../../engine" }
 clap = "~2.33"
-quote = "1.0.7"
 proc-macro2 = "1.0"
 env_logger = "0.9.0"
 miette = { version="4.3", features=["fancy"]}

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -48,20 +48,16 @@ b) build all *.cc files produced by this tool.
 
 If your build system requires each build rule to make precise filenames
 known in advance, then you will need to:
-a) Use `--generate-exact <N> --gen-rs-complete`
+a) Use `--generate-exact <N>`
 b) Teach your build system that the C++ files to compile are named `gen0.h`,
    `gen0.cc`, `gen1.h`, `gen1.cc`, etc (through `N`), corresponding
-   to each `include_cpp!` section, plus 'cxxgen.h`. `gen.complete.rs` will also
-   be generated and should be compiled _instead of_ the original Rust file.
+   to each `include_cpp!` section, plus 'cxxgen.h`.
 c) If `N` is bigger than the number of files needed, extra no-op files will
    be emitted. These may still be compiled normally, but won't do anything. If
    `N` is smaller than the number of files needed, generation will fail.
 
-Note that there is currently no way to teach each `include_cpp!` section
-which `.include.rs` file to use, so the only way to get fixed output paths is
-with `--gen-rs-complete`. There are always multiple `.cc` files (even with just
-a single `include_cpp!` section), and we always generate the same number of each
-type of file.
+At present, N must be 2, which means each invocation must be processing
+exactly one include_cpp! macro. This will improve in future.
 ";
 
 fn main() -> miette::Result<()> {

--- a/gen/cmd/tests/cmd_test.rs
+++ b/gen/cmd/tests/cmd_test.rs
@@ -32,16 +32,12 @@ fn base_test<F>(tmp_dir: &TempDir, arg_modifier: F) -> Result<(), Box<dyn std::e
 where
     F: FnOnce(&mut Command),
 {
-    let result = base_test_ex(tmp_dir, arg_modifier, false);
+    let result = base_test_ex(tmp_dir, arg_modifier);
     assert_contentful(tmp_dir, "gen0.cc");
     result
 }
 
-fn base_test_ex<F>(
-    tmp_dir: &TempDir,
-    arg_modifier: F,
-    use_complete_rs: bool,
-) -> Result<(), Box<dyn std::error::Error>>
+fn base_test_ex<F>(tmp_dir: &TempDir, arg_modifier: F) -> Result<(), Box<dyn std::error::Error>>
 where
     F: FnOnce(&mut Command),
 {
@@ -57,12 +53,8 @@ where
         .arg(demo_rs)
         .arg("--outdir")
         .arg(tmp_dir.path().to_str().unwrap())
-        .arg("--gen-cpp");
-    if use_complete_rs {
-        cmd.arg("--gen-rs-complete");
-    } else {
-        cmd.arg("--gen-rs-include");
-    }
+        .arg("--gen-cpp")
+        .arg("--gen-rs-include");
     cmd.assert().success();
     Ok(())
 }
@@ -108,16 +100,12 @@ fn test_include_prefixes() -> Result<(), Box<dyn std::error::Error>> {
 fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = TempDir::new("example")?;
     let depfile = tmp_dir.path().join("test.d");
-    base_test_ex(
-        &tmp_dir,
-        |cmd| {
-            cmd.arg("--generate-exact")
-                .arg("3")
-                .arg("--depfile")
-                .arg(depfile);
-        },
-        true,
-    )?;
+    base_test_ex(&tmp_dir, |cmd| {
+        cmd.arg("--generate-exact")
+            .arg("3")
+            .arg("--depfile")
+            .arg(depfile);
+    })?;
     assert_contentful(&tmp_dir, "gen0.cc");
     assert_contentful(&tmp_dir, "gen0.h");
     // TODO: This file will actually try #including one of our .h files if there's anything to put

--- a/tools/reduce/src/main.rs
+++ b/tools/reduce/src/main.rs
@@ -372,7 +372,7 @@ fn format_gen_cmd<'a>(
         "-I".to_string(),
         dir.to_string(),
         rs_file.to_str().unwrap().to_string(),
-        "--gen-rs-complete".to_string(),
+        "--gen-rs-include".to_string(),
         "--gen-cpp".to_string(),
         "--suppress-system-headers".to_string(),
         "--".to_string(),


### PR DESCRIPTION
Removing another `autocxx_gen` option which, to my knowledge, is unused and will soon become difficult to maintain.