### PR TITLE
Avoid duplicate stddef introduction in reduction.

### DIFF
--- a/engine/src/conversion/analysis/abstract_types.rs
+++ b/engine/src/conversion/analysis/abstract_types.rs
@@ -19,7 +19,7 @@ use crate::conversion::{
     error_reporter::{convert_apis, convert_item_apis},
     ConvertError,
 };
-use std::collections::HashSet;
+use indexmap::set::IndexSet as HashSet;
 
 /// Spot types with pure virtual functions and mark them abstract.
 pub(crate) fn mark_types_abstract(mut apis: ApiVec<FnPrePhase2>) -> ApiVec<FnPrePhase2> {

--- a/engine/src/conversion/analysis/depth_first.rs
+++ b/engine/src/conversion/analysis/depth_first.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{HashSet, VecDeque};
+use indexmap::set::IndexSet as HashSet;
+use std::collections::VecDeque;
 use std::fmt::Debug;
 
 use itertools::Itertools;

--- a/engine/src/conversion/analysis/fun/implicit_constructors.rs
+++ b/engine/src/conversion/analysis/fun/implicit_constructors.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{hash_map, HashMap, HashSet};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::{map::Entry, set::IndexSet as HashSet};
 
 use syn::{Type, TypeArray};
 
@@ -549,14 +550,14 @@ fn find_explicit_items(
     let mut merge_fun = |ty: QualifiedName, kind: ExplicitKind, fun: &FuncToConvert| match result
         .entry(ExplicitType { ty, kind })
     {
-        hash_map::Entry::Vacant(entry) => {
+        Entry::Vacant(entry) => {
             entry.insert(if fun.is_deleted {
                 ExplicitFound::Deleted
             } else {
                 ExplicitFound::UserDefined(fun.cpp_vis)
             });
         }
-        hash_map::Entry::Occupied(mut entry) => {
+        Entry::Occupied(mut entry) => {
             entry.insert(ExplicitFound::Multiple);
         }
     };

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -8,7 +8,8 @@
 
 mod byvalue_checker;
 
-use std::collections::{HashMap, HashSet};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::IncludeCppConfig;
 use byvalue_checker::ByValueChecker;

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -605,6 +605,7 @@ impl<'a> CppCodeGenerator<'a> {
         };
         let mut headers = vec![Header::System("memory")];
         if need_allocators {
+            headers.push(Header::System("cstddef"));
             headers.push(Header::NewDeletePrelude);
         }
         Ok(ExtraCpp {

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -605,7 +605,7 @@ impl<'a> CppCodeGenerator<'a> {
         };
         let mut headers = vec![Header::System("memory")];
         if need_allocators {
-            headers.push(Header::System("cstddef"));
+            headers.push(Header::System("stddef.h"));
             headers.push(Header::NewDeletePrelude);
         }
         Ok(ExtraCpp {

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -16,11 +16,10 @@ use crate::{
     CppCodegenOptions, CppFilePair,
 };
 use autocxx_parser::IncludeCppConfig;
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 use itertools::Itertools;
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::borrow::Cow;
 use type_to_cpp::{original_name_map_from_apis, type_to_cpp, CppNameMap};
 
 use self::type_to_cpp::{

--- a/engine/src/conversion/codegen_cpp/new_and_delete_prelude.rs
+++ b/engine/src/conversion/codegen_cpp/new_and_delete_prelude.rs
@@ -14,7 +14,6 @@ use indoc::indoc;
 /// and so the versions which match class-specific operator new/delete
 /// will be used in preference to the general global ::operator new/delete.
 pub(super) static NEW_AND_DELETE_PRELUDE: &str = indoc! {"
-    #include <stddef.h>
     #ifndef AUTOCXX_NEW_AND_DELETE_PRELUDE
     #define AUTOCXX_NEW_AND_DELETE_PRELUDE
     // Mechanics to call custom operator new and delete

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::{HashMap, HashSet};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
 
 use crate::{
     conversion::{

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -6,10 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use indexmap::map::IndexMap as HashMap;
+use indexmap::set::IndexSet as HashSet;
+use std::borrow::Cow;
 
 use itertools::Itertools;
 use proc_macro2::Span;


### PR DESCRIPTION
In the reduction pipeline we studiously try to keep things hermetic thus
avoiding system headers. This one crept in.
