### PR TITLE
Optional mode to be paranoid about whether C++ references cause aliasing problems in Rust

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -9,7 +9,7 @@
 use autocxx::prelude::*;
 include_cpp! {
     #include "input.h"
-    safety!(unsafe_ffi)
+    safety!(unsafe_references_wrapped)
     generate!("DoMath")
     generate!("Goat")
 }

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -53,6 +53,7 @@ pub(crate) enum RustConversionType {
     FromPlacementParamToNewReturn,
     FromRValueParamToPtr,
     FromReferenceWrapperToPointer,
+    FromPointerToReferenceWrapper,
 }
 
 impl RustConversionType {
@@ -88,6 +89,14 @@ impl TypeConversionPolicy {
             unwrapped_type: ty,
             cpp_conversion: CppConversionType::None,
             rust_conversion: RustConversionType::None,
+        }
+    }
+
+    pub(crate) fn return_reference_into_wrapper(ty: Type) -> Self {
+        TypeConversionPolicy {
+            unwrapped_type: ty,
+            cpp_conversion: CppConversionType::None,
+            rust_conversion: RustConversionType::FromPointerToReferenceWrapper,
         }
     }
 

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -52,6 +52,7 @@ pub(crate) enum RustConversionType {
     FromValueParamToPtr,
     FromPlacementParamToNewReturn,
     FromRValueParamToPtr,
+    FromReferenceWrapperToPointer,
 }
 
 impl RustConversionType {

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1745,6 +1745,12 @@ impl<'a> FnAnalyzer<'a> {
                         cpp_conversion: CppConversionType::FromPtrToValue,
                         rust_conversion: RustConversionType::FromRValueParamToPtr,
                     }
+                } else if matches!(self.config.unsafe_policy, UnsafePolicy::ReferencesWrappedAllFunctionsSafe) {
+                    TypeConversionPolicy {
+                        unwrapped_type: ty.clone(),
+                        cpp_conversion: CppConversionType::None,
+                        rust_conversion: RustConversionType::FromReferenceWrapperToPointer,
+                    }
                 } else {
                     TypeConversionPolicy {
                         unwrapped_type: ty.clone(),

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1594,7 +1594,10 @@ impl<'a> FnAnalyzer<'a> {
                         is_placement_return_destination = construct_into_self;
                         if treat_this_as_reference {
                             pp.ident = Ident::new("self", pp.ident.span());
-                            if !matches!(self.config.unsafe_policy, UnsafePolicy::ReferencesWrappedAllFunctionsSafe) {
+                            if !matches!(
+                                self.config.unsafe_policy,
+                                UnsafePolicy::ReferencesWrappedAllFunctionsSafe
+                            ) {
                                 pointer_treatment = PointerTreatment::Reference;
                             }
                         }
@@ -1745,7 +1748,10 @@ impl<'a> FnAnalyzer<'a> {
                         cpp_conversion: CppConversionType::FromPtrToValue,
                         rust_conversion: RustConversionType::FromRValueParamToPtr,
                     }
-                } else if matches!(self.config.unsafe_policy, UnsafePolicy::ReferencesWrappedAllFunctionsSafe) {
+                } else if matches!(
+                    self.config.unsafe_policy,
+                    UnsafePolicy::ReferencesWrappedAllFunctionsSafe
+                ) {
                     TypeConversionPolicy {
                         unwrapped_type: ty.clone(),
                         cpp_conversion: CppConversionType::None,
@@ -1841,8 +1847,19 @@ impl<'a> FnAnalyzer<'a> {
                         }
                     }
                     _ => {
-                        let was_reference = matches!(boxed_type.as_ref(), Type::Reference(_));
-                        let conversion = Some(TypeConversionPolicy::new_unconverted(ty.clone()));
+                        let was_reference = references.ref_return;
+                        let conversion = Some(
+                            if was_reference
+                                && matches!(
+                                    self.config.unsafe_policy,
+                                    UnsafePolicy::ReferencesWrappedAllFunctionsSafe
+                                )
+                            {
+                                TypeConversionPolicy::return_reference_into_wrapper(ty.clone())
+                            } else {
+                                TypeConversionPolicy::new_unconverted(ty.clone())
+                            },
+                        );
                         ReturnTypeAnalysis {
                             rt: ReturnType::Type(*rarrow, boxed_type),
                             conversion,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1594,7 +1594,9 @@ impl<'a> FnAnalyzer<'a> {
                         is_placement_return_destination = construct_into_self;
                         if treat_this_as_reference {
                             pp.ident = Ident::new("self", pp.ident.span());
-                            pointer_treatment = PointerTreatment::Reference;
+                            if !matches!(self.config.unsafe_policy, UnsafePolicy::ReferencesWrappedAllFunctionsSafe) {
+                                pointer_treatment = PointerTreatment::Reference;
+                            }
                         }
                         syn::Pat::Ident(pp)
                     }

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -413,16 +413,7 @@ impl<'a> TypeConverter<'a> {
                 // a wobbler if not. rust::Str should only be seen _by value_ in C++
                 // headers; it manifests as &str in Rust but on the C++ side it must
                 // be a plain value. We should detect and abort.
-                let mut outer = if matches!(self.config.unsafe_policy, UnsafePolicy::ReferencesWrappedAllFunctionsSafe) {
-                    elem.map(|elem| match mutability {
-                        Some(_) => Type::Path(parse_quote! {
-                            ::autocxx::CppRef < #elem, ::autocxx::Mut >
-                        }),
-                        None => Type::Reference(parse_quote! {
-                            ::autocxx::CppRef < #elem, ::autocxx::Const >
-                        }),
-                    })
-                } else {
+                let mut outer = 
                     elem.map(|elem| match mutability {
                         Some(_) => Type::Path(parse_quote! {
                             ::std::pin::Pin < & #mutability #elem >
@@ -431,7 +422,7 @@ impl<'a> TypeConverter<'a> {
                             & #elem
                         }),
                     })
-                };
+                ;
                 outer.kind = if mutability.is_some() {
                     TypeKind::MutableReference
                 } else {

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -16,7 +16,7 @@ use crate::{
     known_types::{known_types, CxxGenericType},
     types::{make_ident, Namespace, QualifiedName},
 };
-use autocxx_parser::{IncludeCppConfig};
+use autocxx_parser::IncludeCppConfig;
 use indexmap::map::IndexMap as HashMap;
 use indexmap::set::IndexSet as HashSet;
 use itertools::Itertools;
@@ -413,16 +413,14 @@ impl<'a> TypeConverter<'a> {
                 // a wobbler if not. rust::Str should only be seen _by value_ in C++
                 // headers; it manifests as &str in Rust but on the C++ side it must
                 // be a plain value. We should detect and abort.
-                let mut outer = 
-                    elem.map(|elem| match mutability {
-                        Some(_) => Type::Path(parse_quote! {
-                            ::std::pin::Pin < & #mutability #elem >
-                        }),
-                        None => Type::Reference(parse_quote! {
-                            & #elem
-                        }),
-                    })
-                ;
+                let mut outer = elem.map(|elem| match mutability {
+                    Some(_) => Type::Path(parse_quote! {
+                        ::std::pin::Pin < & #mutability #elem >
+                    }),
+                    None => Type::Reference(parse_quote! {
+                        & #elem
+                    }),
+                });
                 outer.kind = if mutability.is_some() {
                     TypeKind::MutableReference
                 } else {

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -16,7 +16,7 @@ use crate::{
     known_types::{known_types, CxxGenericType},
     types::{make_ident, Namespace, QualifiedName},
 };
-use autocxx_parser::{IncludeCppConfig, UnsafePolicy};
+use autocxx_parser::{IncludeCppConfig};
 use indexmap::map::IndexMap as HashMap;
 use indexmap::set::IndexSet as HashSet;
 use itertools::Itertools;

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -166,6 +166,21 @@ impl TypeConversionPolicy {
                     _ => panic!("Not a ptr"),
                 };
                 RustParamConversion::ReturnValue { ty }
+            },
+            RustConversionType::FromReferenceWrapperToPointer => {
+                let ty = match &self.unwrapped_type {
+                    Type::Ptr(TypePtr { elem, .. }) => &*elem,
+                    _ => panic!("Not a ptr"),
+                };
+                let ty = parse_quote! { ::autocxx::CppRef<#ty, ::autocxx::Mut> };
+                RustParamConversion::Param {
+                    ty,
+                    local_variables: Vec::new(),
+                    conversion: quote! {
+                        #var
+                    },
+                    conversion_requires_unsafe: false,
+                }
             }
         }
     }

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -54,7 +54,10 @@ impl Parse for UnsafePolicy {
                 } else if id == "unsafe_references_wrapped" {
                     Ok(UnsafePolicy::ReferencesWrappedAllFunctionsSafe)
                 } else {
-                    Err(syn::Error::new(id.span(), "expected unsafe_ffi"))
+                    Err(syn::Error::new(
+                        id.span(),
+                        "expected unsafe_ffi or unsafe_references_wrapped",
+                    ))
                 }
             }
             None => Ok(UnsafePolicy::AllFunctionsUnsafe),

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -33,6 +33,7 @@ use quote::quote;
 pub enum UnsafePolicy {
     AllFunctionsSafe,
     AllFunctionsUnsafe,
+    ReferencesWrappedAllFunctionsSafe,
 }
 
 impl Default for UnsafePolicy {
@@ -50,6 +51,8 @@ impl Parse for UnsafePolicy {
             Some(id) => {
                 if id == "unsafe_ffi" {
                     Ok(UnsafePolicy::AllFunctionsSafe)
+                } else if id == "unsafe_references_wrapped" {
+                    Ok(UnsafePolicy::ReferencesWrappedAllFunctionsSafe)
                 } else {
                     Err(syn::Error::new(id.span(), "expected unsafe_ffi"))
                 }
@@ -70,6 +73,8 @@ impl ToTokens for UnsafePolicy {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         if *self == UnsafePolicy::AllFunctionsSafe {
             tokens.extend(quote! { unsafe })
+        } else if *self == UnsafePolicy::ReferencesWrappedAllFunctionsSafe {
+            tokens.extend(quote! { unsafe_references_wrapped })
         }
     }
 }

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -261,10 +261,10 @@ impl Directive for Safety {
     ) -> Box<dyn Iterator<Item = TokenStream> + 'a> {
         let policy = &config.unsafe_policy;
         match config.unsafe_policy {
-            crate::UnsafePolicy::AllFunctionsSafe => {
+            crate::UnsafePolicy::AllFunctionsUnsafe => Box::new(std::iter::empty()),
+            _ => {
                 Box::new(std::iter::once(policy.to_token_stream()))
             }
-            crate::UnsafePolicy::AllFunctionsUnsafe => Box::new(std::iter::empty()),
         }
     }
 }

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -262,9 +262,7 @@ impl Directive for Safety {
         let policy = &config.unsafe_policy;
         match config.unsafe_policy {
             crate::UnsafePolicy::AllFunctionsUnsafe => Box::new(std::iter::empty()),
-            _ => {
-                Box::new(std::iter::once(policy.to_token_stream()))
-            }
+            _ => Box::new(std::iter::once(policy.to_token_stream())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,12 @@
 // do anything - all the magic is handled entirely by
 // autocxx_macro::include_cpp_impl.
 
+mod reference_wrapper;
 mod rvalue_param;
 pub mod subclass;
 mod value_param;
+
+pub use reference_wrapper::{CppRef, Const, Mut, CppRefMutability};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Include some C++ headers in your Rust project.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod rvalue_param;
 pub mod subclass;
 mod value_param;
 
-pub use reference_wrapper::{CppRef, Const, Mut, CppRefMutability};
+pub use reference_wrapper::{Const, CppRef, CppRefMutability, Mut};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Include some C++ headers in your Rust project.

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::marker::PhantomData;
+
+pub trait CppRefMutability {}
+
+pub struct Const;
+
+impl CppRefMutability for Const {}
+
+pub struct Mut;
+
+impl CppRefMutability for Mut {}
+
+/// A C++ non-const reference. These are different from Rust's `&mut T` in that
+/// several C++ references can exist to the same underlying data ("aliasing")
+/// and that's not permitted in Rust.
+///
+/// This type
+#[repr(transparent)]
+pub struct CppRef<'a, M: CppRefMutability, T>(*mut T, PhantomData<&'a T>, PhantomData<M>);
+
+// Implement manually so that there's no need for the inner type to implement Clone
+impl<'a, M: CppRefMutability, T> Clone for CppRef<'a, M, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData, PhantomData)
+    }
+}
+
+impl<'a, M: CppRefMutability, T> Copy for CppRef<'a, M, T> {}
+
+impl<'a, M: CppRefMutability, T> CppRef<'a, M, T> {
+    #[doc(hidden)]
+    pub fn new(ptr: *mut T) -> Self {
+        Self(ptr, PhantomData, PhantomData)
+    }
+
+    pub unsafe fn as_ref(&self) -> &T {
+        &*self.0
+    }
+}
+
+impl<'a, T> CppRef<'a, Mut, T> {
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        &mut *self.0
+    }
+}


### PR DESCRIPTION
Fixes #1006.