### PR TITLE
Much more conservatism on opaque types.

### DIFF
--- a/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
+++ b/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
@@ -28,13 +28,6 @@ pub(crate) fn replace_hopeless_typedef_targets(apis: ApiVec<PodPhase>) -> ApiVec
         .iter()
         .filter_map(|api| match api {
             Api::IgnoredItem { .. } => Some(api.name()),
-            _ => None,
-        })
-        .cloned()
-        .collect();
-    let ignored_forward_declarations: HashSet<QualifiedName> = apis
-        .iter()
-        .filter_map(|api| match api {
             Api::ForwardDeclaration { err: Some(_), .. } => Some(api.name()),
             _ => None,
         })
@@ -73,17 +66,9 @@ pub(crate) fn replace_hopeless_typedef_targets(apis: ApiVec<PodPhase>) -> ApiVec
                 } else {
                     Api::OpaqueTypedef {
                         name: api.name_info().clone(),
-                        forward_declaration: false,
                     }
                 }
             }
-            Api::Typedef {
-                analysis: TypedefAnalysis { ref deps, .. },
-                ..
-            } if !ignored_forward_declarations.is_disjoint(deps) => Api::OpaqueTypedef {
-                name: api.name_info().clone(),
-                forward_declaration: true,
-            },
             Api::ForwardDeclaration {
                 name,
                 err: Some(ConvertErrorWithContext(err, ctx)),

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -466,13 +466,7 @@ pub(crate) enum Api<T: AnalysisPhase> {
     },
     /// We found a typedef to something that we didn't fully understand.
     /// We'll treat it as an opaque unsized type.
-    OpaqueTypedef {
-        name: ApiName,
-        /// Further store whether this was a typedef to a forward declaration.
-        /// If so we can't allow it to live in a UniquePtr, just like a regular
-        /// Api::ForwardDeclaration.
-        forward_declaration: bool,
-    },
+    OpaqueTypedef { name: ApiName },
     /// A synthetic type we've manufactured in order to
     /// concretize some templated C++ type.
     ConcreteType {

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -57,7 +57,7 @@ pub enum ConvertError {
     InvalidPointee,
     #[error("The 'generate' or 'generate_pod' directive for '{0}' did not result in any code being generated. Perhaps this was mis-spelled or you didn't qualify the name with any namespaces? Otherwise please report a bug.")]
     DidNotGenerateAnything(String),
-    #[error("Found an attempt at using a forward declaration ({}) inside a templated cxx type such as UniquePtr or CxxVector", .0.to_cpp_name())]
+    #[error("Found an attempt at using a forward declaration ({}) inside a templated cxx type such as UniquePtr or CxxVector. (Alternatively, the type may be some type which autocxx couldn't fully understand).", .0.to_cpp_name())]
     TypeContainingForwardDeclaration(QualifiedName),
     #[error("Found an attempt at using a type marked as blocked! ({})", .0.to_cpp_name())]
     Blocked(QualifiedName),

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -105,13 +105,9 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                     err,
                 })))
             }
-            Api::OpaqueTypedef {
-                name,
-                forward_declaration,
-            } => Ok(Box::new(std::iter::once(Api::OpaqueTypedef {
-                name,
-                forward_declaration,
-            }))),
+            Api::OpaqueTypedef { name } => {
+                Ok(Box::new(std::iter::once(Api::OpaqueTypedef { name })))
+            }
             Api::StringConstructor { name } => {
                 Ok(Box::new(std::iter::once(Api::StringConstructor { name })))
             }

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -11014,7 +11014,6 @@ fn test_pass_rust_str_and_return_struct() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/1065
 fn test_issue_1065a() {
     let hdr = indoc! {"
         #include <memory>
@@ -11028,6 +11027,7 @@ fn test_issue_1065a() {
         class RenderFrameHost {
         public:
         virtual std::vector<bc> &bd() = 0;
+        virtual std::unique_ptr<bc> &be() = 0;
         virtual ~RenderFrameHost() {}
         };
     "};


### PR DESCRIPTION
This change increases paranoia and decreases flexibility in two circumstances:

* When there's a &UniquePtr<T> or &CxxVector<T>, we no longer allow T to be a
  forward declaration. Previously this was permitted but it seems that in some
  circumstances this still causes allocation/freeing code to be made for T,
  which is not allowed if it's a forward declaration.
* Treat all opaque typedefs as forward declarations. Previously, we assumed
  that opaque typedefs could be instantiated, so allowed them to exist in
  UniquePtr or CxxVector. That turned out to be incorrect in cases such as
  where an opaque typedef contained a UniquePtr<T> where T was a forward
  declaration or otherwise incomplete type. We will therefore err on the side
  of caution and assume that no such opaque typedef can be instantiated at all.
  This will sadly make them less useful.

Fixes #1065.
