### PR TITLE
Instantiable opaques

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -410,7 +410,7 @@ impl<'a> FnAnalyzer<'a> {
         ns: &Namespace,
         pointer_treatment: PointerTreatment,
     ) -> Result<Annotated<Box<Type>>, ConvertError> {
-        let ctx = TypeConversionContext::CxxOuterType { pointer_treatment };
+        let ctx = TypeConversionContext::OuterType { pointer_treatment };
         let mut annotated = self.type_converter.convert_boxed_type(ty, ns, &ctx)?;
         self.extra_apis.append(&mut annotated.extra_apis);
         Ok(annotated)

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -203,11 +203,8 @@ fn get_struct_field_types(
 ) -> Vec<ConvertError> {
     let mut convert_errors = Vec::new();
     for f in &s.fields {
-        let annotated = type_converter.convert_type(
-            f.ty.clone(),
-            ns,
-            &TypeConversionContext::CxxWithinReference,
-        );
+        let annotated =
+            type_converter.convert_type(f.ty.clone(), ns, &TypeConversionContext::WithinReference);
         match annotated {
             Ok(mut r) => {
                 extra_apis.append(&mut r.extra_apis);

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -203,8 +203,11 @@ fn get_struct_field_types(
 ) -> Vec<ConvertError> {
     let mut convert_errors = Vec::new();
     for f in &s.fields {
-        let annotated =
-            type_converter.convert_type(f.ty.clone(), ns, &TypeConversionContext::CxxInnerType);
+        let annotated = type_converter.convert_type(
+            f.ty.clone(),
+            ns,
+            &TypeConversionContext::CxxWithinReference,
+        );
         match annotated {
             Ok(mut r) => {
                 extra_apis.append(&mut r.extra_apis);

--- a/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
+++ b/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use autocxx_parser::IncludeCppConfig;
 use indexmap::set::IndexSet as HashSet;
 
 use crate::{
@@ -23,7 +24,10 @@ use super::pod::PodPhase;
 /// Where we find a typedef pointing at something we can't represent,
 /// e.g. because it uses too many template parameters, break the link.
 /// Use the typedef as a first-class type.
-pub(crate) fn replace_hopeless_typedef_targets(apis: ApiVec<PodPhase>) -> ApiVec<PodPhase> {
+pub(crate) fn replace_hopeless_typedef_targets(
+    config: &IncludeCppConfig,
+    apis: ApiVec<PodPhase>,
+) -> ApiVec<PodPhase> {
     let ignored_types: HashSet<QualifiedName> = apis
         .iter()
         .filter_map(|api| match api {
@@ -73,7 +77,9 @@ pub(crate) fn replace_hopeless_typedef_targets(apis: ApiVec<PodPhase>) -> ApiVec
                 } else {
                     Api::OpaqueTypedef {
                         name: api.name_info().clone(),
-                        forward_declaration: false,
+                        forward_declaration: !config
+                            .instantiable
+                            .contains(&name.name.to_cpp_name()),
                     }
                 }
             }

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -91,7 +91,7 @@ fn get_replacement_typedef(
     let type_conversion_results = type_converter.convert_type(
         (*ity.ty).clone(),
         name.name.get_namespace(),
-        &TypeConversionContext::CxxInnerType,
+        &TypeConversionContext::CxxWithinReference,
     );
     match type_conversion_results {
         Err(err) => Err(ConvertErrorWithContext(

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -91,7 +91,7 @@ fn get_replacement_typedef(
     let type_conversion_results = type_converter.convert_type(
         (*ity.ty).clone(),
         name.name.get_namespace(),
-        &TypeConversionContext::CxxWithinReference,
+        &TypeConversionContext::WithinReference,
     );
     match type_conversion_results {
         Err(err) => Err(ConvertErrorWithContext(

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -57,7 +57,7 @@ pub enum ConvertError {
     InvalidPointee,
     #[error("The 'generate' or 'generate_pod' directive for '{0}' did not result in any code being generated. Perhaps this was mis-spelled or you didn't qualify the name with any namespaces? Otherwise please report a bug.")]
     DidNotGenerateAnything(String),
-    #[error("Found an attempt at using a forward declaration ({}) inside a templated cxx type such as UniquePtr or CxxVector", .0.to_cpp_name())]
+    #[error("Found an attempt at using a forward declaration ({}) inside a templated cxx type such as UniquePtr or CxxVector. If the forward declaration is a typedef, perhaps autocxx wasn't sure whether or not it involved a forward declaration. If you're sure it didn't, then you may be able to solve this by using instantiable!.", .0.to_cpp_name())]
     TypeContainingForwardDeclaration(QualifiedName),
     #[error("Found an attempt at using a type marked as blocked! ({})", .0.to_cpp_name())]
     Blocked(QualifiedName),

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -147,7 +147,7 @@ impl<'a> BridgeConverter<'a> {
                 // by subsequent phases to work out which objects are POD.
                 let analyzed_apis = analyze_pod_apis(apis, self.config)?;
                 Self::dump_apis("pod analysis", &analyzed_apis);
-                let analyzed_apis = replace_hopeless_typedef_targets(analyzed_apis);
+                let analyzed_apis = replace_hopeless_typedef_targets(self.config, analyzed_apis);
                 let analyzed_apis = add_casts(analyzed_apis);
                 let analyzed_apis = create_alloc_and_frees(analyzed_apis);
                 // Next, figure out how we materialize different functions.

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -4010,6 +4010,7 @@ fn test_forward_declaration() {
             static B daft3(const A&) { B b; return b; }
             A daft4();
             std::unique_ptr<A> daft5();
+            const std::unique_ptr<A>& daft6();
         };
         A* get_a();
         void delete_a(A*);
@@ -4031,6 +4032,10 @@ fn test_forward_declaration() {
         }
         std::unique_ptr<A> B::daft5() {
             return std::make_unique<A>();
+        }
+        std::unique_ptr<A> fixed;
+        const std::unique_ptr<A>& B::daft6() {
+            return fixed;
         }
     "};
     let rs = quote! {

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -3412,12 +3412,18 @@ fn test_associated_type_templated_typedef_by_value_regular() {
         let sp = ffi::give_string_piece();
         ffi::take_string_piece(sp);
     };
-    run_test(
+    run_test_ex(
         "",
         hdr,
         rs,
-        &["take_string_piece", "give_string_piece"],
-        &[],
+        quote! {
+            generate!("take_string_piece")
+            generate!("give_string_piece")
+            instantiable!("StringPiece")
+        },
+        None,
+        None,
+        None,
     );
 }
 
@@ -11019,7 +11025,6 @@ fn test_pass_rust_str_and_return_struct() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/1065
 fn test_issue_1065a() {
     let hdr = indoc! {"
         #include <memory>

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -203,6 +203,7 @@ pub struct IncludeCppConfig {
     pub allowlist: Allowlist,
     pub(crate) blocklist: Vec<String>,
     pub(crate) constructor_blocklist: Vec<String>,
+    pub instantiable: Vec<String>,
     pub(crate) exclude_utilities: bool,
     pub(crate) mod_name: Option<Ident>,
     pub rust_types: Vec<RustPath>,

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -58,6 +58,13 @@ pub(crate) fn get_directives() -> &'static DirectivesMap {
             )),
         );
         need_exclamation.insert(
+            "instantiable".into(),
+            Box::new(StringList(
+                |config| &mut config.instantiable,
+                |config| &config.instantiable,
+            )),
+        );
+        need_exclamation.insert(
             "parse_only".into(),
             Box::new(BoolFlag(
                 |config| &mut config.parse_only,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,29 @@ macro_rules! subclass {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
+/// Indicates that a C++ type can definitely be instantiated. This has effect
+/// only in a very specific case:
+/// * the type is a typedef to something else
+/// * the 'something else' can't be fully inspected by autocxx, possibly
+///   becaue it relies on dependent qualified types or some other template
+///   arrangement that bindgen cannot fully understand.
+/// In such circumstances, autocxx normally has to err on the side of caution
+/// and assume that some type within the 'something else' is itself a forward
+/// declaration. That means, the opaque typedef won't be storable within
+/// a [`cxx::UniquePtr`]. If you know that no forward declarations are involved,
+/// you can declare the typedef type is instantiable and then you'll be able to
+/// own it within Rust.
+///
+/// The syntax is:
+/// `instantiable!("CppNameGoesHere")`
+///
+/// A directive to be included inside
+/// [include_cpp] - see [include_cpp] for general information.
+#[macro_export]
+macro_rules! instantiable {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! usage {


### PR DESCRIPTION
When autocxx encountered a typedef to something that it couldn't comprehend, it
treated that as an 'opaque typedef' such that people could still use it in
limited contexts. One of those contexts was inside a UniquePtr or CxxVector;
unfortunately that proved to be too lenient. Sometimes the referents of such
typedefs would themselves include forward declarations, which were of course
invisible to autocxx since the whole point is that we couldn't see inside the
definition of these typedefs.

So, we now treat such typedefs as non-instantiable by default. This renders
them significantly less useful, so there's now an "instantiable!" directive
that can be used to revert to the prior behavior.

Fixes https://github.com/google/autocxx/issues/1065.