### PR TITLE
Tell bindgen to skip rustfmt

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -304,7 +304,7 @@ impl IncludeCppEngine {
             .default_enum_style(bindgen::EnumVariation::Rust {
                 non_exhaustive: false,
             })
-            .rustfmt_bindings(false)
+            .rustfmt_bindings(log::log_enabled!(log::Level::Info))
             .size_t_is_usize(true)
             .enable_cxx_namespaces()
             .generate_inline_functions(true)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -304,6 +304,7 @@ impl IncludeCppEngine {
             .default_enum_style(bindgen::EnumVariation::Rust {
                 non_exhaustive: false,
             })
+            .rustfmt_bindings(false)
             .size_t_is_usize(true)
             .enable_cxx_namespaces()
             .generate_inline_functions(true)


### PR DESCRIPTION
The intermediate code is only for code to parse, so formatting is a
waste of time. Also it prints an annoying message when it can't find
rustfmt otherwise.