### PR TITLE
Fix and test subclass without `safety!(unsafe)`

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -640,7 +640,7 @@ impl<'a> FnAnalyzer<'a> {
                     receiver_mutability,
                     sup,
                     subclass_fn_deps,
-                    &self.unsafe_policy,
+                    self.unsafe_policy,
                 ));
 
                 // Create the trait item for the <superclass>_methods and <superclass>_supers
@@ -658,7 +658,7 @@ impl<'a> FnAnalyzer<'a> {
                         receiver_mutability,
                         sup.clone(),
                         is_pure_virtual,
-                        &self.unsafe_policy,
+                        self.unsafe_policy,
                     ));
                 }
             }

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod unqualify;
 use indexmap::map::IndexMap as HashMap;
 use indexmap::set::IndexSet as HashSet;
 
-use autocxx_parser::{ExternCppType, IncludeCppConfig, RustFun};
+use autocxx_parser::{ExternCppType, IncludeCppConfig, RustFun, UnsafePolicy};
 
 use itertools::Itertools;
 use proc_macro2::{Span, TokenStream};
@@ -134,6 +134,7 @@ fn get_string_items() -> Vec<Item> {
 /// In practice, much of the "generation" involves connecting together
 /// existing lumps of code within the Api structures.
 pub(crate) struct RsCodeGenerator<'a> {
+    unsafe_policy: &'a UnsafePolicy,
     include_list: &'a [String],
     bindgen_mod: ItemMod,
     original_name_map: CppNameMap,
@@ -145,12 +146,14 @@ impl<'a> RsCodeGenerator<'a> {
     /// Generate code for a set of APIs that was discovered during parsing.
     pub(crate) fn generate_rs_code(
         all_apis: ApiVec<FnPhase>,
+        unsafe_policy: &'a UnsafePolicy,
         include_list: &'a [String],
         bindgen_mod: ItemMod,
         config: &'a IncludeCppConfig,
         header_name: Option<String>,
     ) -> Vec<Item> {
         let c = Self {
+            unsafe_policy,
             include_list,
             bindgen_mod,
             original_name_map: original_name_map_from_apis(&all_apis),
@@ -609,8 +612,11 @@ impl<'a> RsCodeGenerator<'a> {
                 name, superclass, ..
             } => {
                 let methods = associated_methods.get(&superclass);
-                let generate_peer_constructor =
-                    subclasses_with_a_single_trivial_constructor.contains(&name.0.name);
+                let generate_peer_constructor = subclasses_with_a_single_trivial_constructor.contains(&name.0.name) &&
+                    // TODO: Create an UnsafeCppPeerConstructor trait for calling an unsafe
+                    // constructor instead? Need to create unsafe versions of everything that uses
+                    // it too.
+                    matches!(self.unsafe_policy, UnsafePolicy::AllFunctionsSafe);
                 self.generate_subclass(name, &superclass, methods, generate_peer_constructor)
             }
             Api::ExternCppType {

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -157,7 +157,7 @@ impl<'a> BridgeConverter<'a> {
                 // parameterized by a richer set of metadata.
                 Self::dump_apis("adding casts", &analyzed_apis);
                 let analyzed_apis =
-                    FnAnalyzer::analyze_functions(analyzed_apis, unsafe_policy, self.config);
+                    FnAnalyzer::analyze_functions(analyzed_apis, &unsafe_policy, self.config);
                 // If any of those functions turned out to be pure virtual, don't attempt
                 // to generate UniquePtr implementations for the type, since it can't
                 // be instantiated.
@@ -197,6 +197,7 @@ impl<'a> BridgeConverter<'a> {
                 )?;
                 let rs = RsCodeGenerator::generate_rs_code(
                     analyzed_apis,
+                    &unsafe_policy,
                     self.include_list,
                     bindgen_mod,
                     self.config,

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -207,8 +207,9 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 /// * You _may_ need to implement [`CppPeerConstructor`] for your subclass,
 ///   but only if autocxx determines that there are multiple possible superclass
 ///   constructors so you need to call one explicitly (or if there's a single
-///   non-trivial superclass constructor.) autocxx will implemente this trait
-///   for you if there's no ambiguity.
+///   non-trivial superclass constructor.) autocxx will implement this trait
+///   for you if there's no ambiguity and FFI functions are safe to call due to
+///   [`autocxx::safety!`] being used.
 ///
 /// # How to access your Rust structure from outside
 ///

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -209,7 +209,7 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 ///   constructors so you need to call one explicitly (or if there's a single
 ///   non-trivial superclass constructor.) autocxx will implement this trait
 ///   for you if there's no ambiguity and FFI functions are safe to call due to
-///   [`autocxx::safety!`] being used.
+///   `autocxx::safety!` being used.
 ///
 /// # How to access your Rust structure from outside
 ///


### PR DESCRIPTION
It never automatically generates peer constructor functions, which makes
it a bit annoying to use, but at least it's usable. I think creating a
parallel set of "unsafe to construct" traits (which doesn't implement
Default) could avoid this, but that's a larger change.