### PR TITLE
Replace lingering tempdir usages with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
  "miette",
  "pathdiff",
  "proc-macro2",
- "tempdir",
+ "tempfile",
 ]
 
 [[package]]
@@ -271,7 +271,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "syn",
- "tempdir",
  "tempfile",
 ]
 
@@ -608,12 +607,6 @@ dependencies = [
  "thiserror",
  "winapi",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "gag"
@@ -1135,34 +1128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rayon"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,15 +1149,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1389,16 +1345,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = "1.8"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"
-tempdir = "0.3.7"
+tempfile = "3.1"
 autocxx-integration-tests = { path = "../../integration-tests", version="=0.22.1" }
 # This is necessary for building the projects created
 # by the trybuild test system...

--- a/gen/cmd/src/depfile.rs
+++ b/gen/cmd/src/depfile.rs
@@ -63,13 +63,13 @@ impl Depfile {
 mod tests {
     use std::{fs::File, io::Read};
 
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     use super::Depfile;
 
     #[test]
     fn test_simple_depfile() {
-        let tmp_dir = TempDir::new("depfile-test").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let f = tmp_dir.path().join("depfile.d");
         let mut df = Depfile::new(&f).unwrap();
         df.add_output(&tmp_dir.path().join("a/b"));
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_multiple_outputs() {
-        let tmp_dir = TempDir::new("depfile-test").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let f = tmp_dir.path().join("depfile.d");
         let mut df = Depfile::new(&f).unwrap();
         df.add_output(&tmp_dir.path().join("a/b"));

--- a/gen/cmd/tests/cmd_test.rs
+++ b/gen/cmd/tests/cmd_test.rs
@@ -13,7 +13,7 @@ use indexmap::map::IndexMap as HashMap;
 use assert_cmd::Command;
 use autocxx_integration_tests::{build_from_folder, RsFindMode};
 use itertools::Itertools;
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 static MAIN_RS: &str = concat!(
     include_str!("../../../demo/src/main.rs"),
@@ -107,7 +107,7 @@ where
 
 #[test]
 fn test_gen() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Single, |_| {})?;
     File::create(tmp_dir.path().join("cxx.h"))
         .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
@@ -128,7 +128,7 @@ fn test_gen() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_gen_archive() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Archive, |_| {})?;
     File::create(tmp_dir.path().join("cxx.h"))
         .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
@@ -148,7 +148,7 @@ fn test_gen_archive() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_gen_multiple_in_archive() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
 
     let mut files = HashMap::new();
     files.insert("input2.h", INPUT2_H.as_bytes());
@@ -186,7 +186,7 @@ fn test_gen_multiple_in_archive() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_include_prefixes() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Single, |cmd| {
         cmd.arg("--cxx-h-path")
             .arg("foo/")
@@ -204,7 +204,7 @@ fn test_include_prefixes() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     let depfile = tmp_dir.path().join("test.d");
     base_test(&tmp_dir, RsGenMode::Single, |cmd| {
         cmd.arg("--generate-exact")
@@ -239,7 +239,7 @@ fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_gen_preprocess() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     let prepro_path = tmp_dir.path().join("preprocessed.h");
     base_test(&tmp_dir, RsGenMode::Single, |cmd| {
         cmd.env("AUTOCXX_PREPROCESS", prepro_path.to_str().unwrap());
@@ -253,7 +253,7 @@ fn test_gen_preprocess() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_gen_repro() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     let repro_path = tmp_dir.path().join("repro.json");
     base_test(&tmp_dir, RsGenMode::Single, |cmd| {
         cmd.env("AUTOCXX_REPRO_CASE", repro_path.to_str().unwrap());

--- a/tools/reduce/Cargo.toml
+++ b/tools/reduce/Cargo.toml
@@ -32,6 +32,6 @@ indexmap = "1.8"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"
-tempdir = "0.3.7"
+tempfile = "3.1"
 indoc = "1.0"
 proc-macro2 = "1.0"

--- a/tools/reduce/tests/reduce_test.rs
+++ b/tools/reduce/tests/reduce_test.rs
@@ -16,7 +16,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use syn::Token;
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 static INPUT_H: &str = indoc::indoc! {"
     inline int DoMath(int a) {
@@ -169,7 +169,7 @@ where
     if creduce_is_broken() {
         return Ok(());
     }
-    let tmp_dir = TempDir::new("example")?;
+    let tmp_dir = tempdir()?;
     let demo_code_dir = tmp_dir.path().join("demo");
     std::fs::create_dir(&demo_code_dir).unwrap();
     let input_header = if include_cxx_h {


### PR DESCRIPTION
A few tests used the old tempdir crate which has been replaced by
tempfile.

- [:heavy_check_mark:] Tests pass
- [N/A] Appropriate changes to README are included in PR