### PR TITLE
Add test for issue 1125.

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -11454,6 +11454,33 @@ fn test_issue_1081() {
     run_test("", hdr, rs, &["libtorrent::session"], &[]);
 }
 
+#[test]
+fn test_issue_1125() {
+    let hdr = indoc! {"
+        namespace {
+        namespace {
+        template <class a> class b {
+          typedef a c;
+          struct {
+            c : sizeof(c);
+          };
+        };
+        } // namespace
+        } // namespace
+    "};
+    run_test_ex(
+        "",
+        hdr,
+        quote! {},
+        quote! {
+            generate_all!()
+        },
+        make_cpp17_adder(),
+        None,
+        None,
+    );
+}
+
 // Yet to test:
 // - Ifdef
 // - Out param pointers

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -11455,6 +11455,17 @@ fn test_issue_1081() {
 }
 
 #[test]
+#[ignore] // This test passes under all normal builds. However
+          // it triggers a stack use-after-return in older versions of
+          // libclang which is only detected under ASAN (obviously it
+          // sometimes causes crashes the rest of the time).
+          // This UaR does not occur when the same code is processed
+          // with a HEAD version of clang itself as of June 2022. This
+          // may mean that the UaR has been fixed in later versions of
+          // the clang code, or that it only occurs when the code is used
+          // in a libclang context (not a plain clang compilation context).
+          // If the problem recurs, we should work out which of these is
+          // the case.
 fn test_issue_1125() {
     let hdr = indoc! {"
         namespace {


### PR DESCRIPTION
Fixes #1125.
By adding a test which passes with a working version of libclang.