### PR TITLE
Pretty print using prettyplease instead of rustfmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "log",
  "miette",
  "once_cell",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1060,6 +1061,16 @@ checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1516508b396cefe095485fdce673007422f5e48e82934b7b423dc26aa5e6a4"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -49,6 +49,7 @@ miette = "4.3"
 thiserror = "1"
 regex = "1.5"
 indexmap = "1.8"
+prettyplease = { version = "0.1.15", features = ["verbatim"] }
 
 [dependencies.syn]
 version = "1.0.39"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -433,7 +433,7 @@ impl IncludeCppEngine {
         new_bindings.content.as_mut().unwrap().1.append(&mut items);
         info!(
             "New bindings:\n{}",
-            rust_pretty_printer::pretty_print(&new_bindings.to_token_stream())
+            rust_pretty_printer::pretty_print(&new_bindings)
         );
         self.state = State::Generated(Box::new(GenerationResults {
             item_mod: new_bindings,

--- a/engine/src/rust_pretty_printer.rs
+++ b/engine/src/rust_pretty_printer.rs
@@ -6,35 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use proc_macro2::TokenStream;
-use std::io::Write;
-use std::process::{Command, Stdio};
+use syn::{Item, ItemMod};
 
-enum Error {
-    Run(std::io::Error),
-    Write(std::io::Error),
-    Utf8(std::string::FromUtf8Error),
-    Wait(std::io::Error),
-}
-
-pub(crate) fn pretty_print(ts: &TokenStream) -> String {
-    reformat_or_else(ts.to_string())
-}
-
-fn reformat_or_else(text: impl std::fmt::Display) -> String {
-    match reformat(&text) {
-        Ok(s) => s,
-        Err(_) => text.to_string(),
-    }
-}
-
-fn reformat(text: impl std::fmt::Display) -> Result<String, Error> {
-    let mut rustfmt = Command::new("rustfmt")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(Error::Run)?;
-    write!(rustfmt.stdin.take().unwrap(), "{}", text).map_err(Error::Write)?;
-    let output = rustfmt.wait_with_output().map_err(Error::Wait)?;
-    String::from_utf8(output.stdout).map_err(Error::Utf8)
+pub(crate) fn pretty_print(itm: &ItemMod) -> String {
+    prettyplease::unparse(&syn::File {
+        shebang: None,
+        attrs: Vec::new(),
+        items: vec![Item::Mod(itm.clone())],
+    })
 }


### PR DESCRIPTION
This was attempted a while ago in #763 but did not work at the time.

<details>
<summary>An output diff</summary>

```diff
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 mod ffi {
     pub trait ToCppString {
         fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxString>;
     }
     impl ToCppString for &str {
         fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxString> {
             make_string(self)
         }
     }
     impl ToCppString for String {
         fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxString> {
             make_string(&self)
         }
     }
     impl ToCppString for &String {
         fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxString> {
             make_string(self)
         }
     }
     impl ToCppString for cxx::UniquePtr<cxx::CxxString> {
         fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxString> {
             self
         }
     }
     unsafe impl cxx::ExternType for bindgen::root::Anna {
         type Id = cxx::type_id!("Anna");
         type Kind = cxx::kind::Opaque;
     }
     unsafe impl cxx::ExternType for bindgen::root::Bob {
         type Id = cxx::type_id!("Bob");
         type Kind = cxx::kind::Trivial;
     }
     mod bindgen {
         pub(super) mod root {
             #[repr(C, align(8))]
             pub struct Anna {
                 _pinned: core::marker::PhantomData<core::marker::PhantomPinned>,
                 _non_send_sync: core::marker::PhantomData<[*const u8; 0]>,
                 _data: [u8; 40],
             }
             #[repr(C)]
             pub struct Bob {
                 pub a: u32,
                 pub b: u32,
             }
             pub fn give_anna() -> impl autocxx::moveit::new::New<Output = root::Anna> {
                 unsafe {
                     autocxx::moveit::new::by_raw(move |placement_return_type| {
-                        let placement_return_type =
-                            placement_return_type.get_unchecked_mut().as_mut_ptr();
+                        let placement_return_type = placement_return_type
+                            .get_unchecked_mut()
+                            .as_mut_ptr();
                         cxxbridge::give_anna_autocxx_wrapper(placement_return_type)
                     })
                 }
             }
             impl Bob {
                 pub fn get_bob(
                     self: &root::Bob,
                     a: impl autocxx::ValueParam<root::Anna>,
                     arg1: cxx::UniquePtr<root::Anna>,
                 ) -> u32 {
                     let mut a_space = autocxx::ValueParamHandler::default();
-                    let mut a_space = unsafe { ::std::pin::Pin::new_unchecked(&mut a_space) };
+                    let mut a_space = unsafe {
+                        ::std::pin::Pin::new_unchecked(&mut a_space)
+                    };
                     unsafe {
                         a_space.as_mut().populate(a);
                         cxxbridge::get_bob_autocxx_wrapper(self, a_space.get_ptr(), arg1)
                     }
                 }
-                #[doc = "Synthesized default constructor."]
+                ///Synthesized default constructor.
                 pub fn new() -> impl autocxx::moveit::new::New<Output = Self> {
                     unsafe {
                         autocxx::moveit::new::by_raw(move |this| {
                             let this = this.get_unchecked_mut().as_mut_ptr();
                             cxxbridge::Bob_new_autocxx_autocxx_wrapper(this)
                         })
                     }
                 }
             }
             impl Anna {
-                #[doc = "Synthesized default constructor."]
+                ///Synthesized default constructor.
                 pub fn new() -> impl autocxx::moveit::new::New<Output = Self> {
                     unsafe {
                         autocxx::moveit::new::by_raw(move |this| {
                             let this = this.get_unchecked_mut().as_mut_ptr();
                             cxxbridge::new_autocxx_autocxx_wrapper(this)
                         })
                     }
                 }
             }
             unsafe impl autocxx::moveit::MakeCppStorage for root::Anna {
                 unsafe fn allocate_uninitialized_cpp_storage() -> *mut root::Anna {
                     cxxbridge::Anna_alloc_autocxx_wrapper()
                 }
                 unsafe fn free_uninitialized_cpp_storage(arg0: *mut root::Anna) {
                     cxxbridge::Anna_free_autocxx_wrapper(arg0)
                 }
             }
             unsafe impl autocxx::moveit::MakeCppStorage for root::Bob {
                 unsafe fn allocate_uninitialized_cpp_storage() -> *mut root::Bob {
                     cxxbridge::Bob_alloc_autocxx_wrapper()
                 }
                 unsafe fn free_uninitialized_cpp_storage(arg0: *mut root::Bob) {
                     cxxbridge::Bob_free_autocxx_wrapper(arg0)
                 }
             }
             unsafe impl autocxx::moveit::new::MoveNew for root::Anna {
-                #[doc = "Synthesized move constructor."]
+                ///Synthesized move constructor.
                 unsafe fn move_new(
                     mut other: ::std::pin::Pin<autocxx::moveit::MoveRef<'_, root::Anna>>,
                     this: ::std::pin::Pin<&mut ::std::mem::MaybeUninit<root::Anna>>,
                 ) {
                     cxxbridge::new_synthetic_move_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                         this.get_unchecked_mut().as_mut_ptr(),
                         {
-                            let r: &mut _ = ::std::pin::Pin::into_inner_unchecked(other.as_mut());
+                            let r: &mut _ = ::std::pin::Pin::into_inner_unchecked(
+                                other.as_mut(),
+                            );
                             r
                         },
                     )
                 }
             }
             unsafe impl autocxx::moveit::new::CopyNew for root::Anna {
-                #[doc = "Synthesized copy constructor."]
+                ///Synthesized copy constructor.
                 unsafe fn copy_new(
                     other: &root::Anna,
                     this: ::std::pin::Pin<&mut ::std::mem::MaybeUninit<root::Anna>>,
                 ) {
                     cxxbridge::new_synthetic_const_copy_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                         this.get_unchecked_mut().as_mut_ptr(),
                         other,
                     )
                 }
             }
             impl Drop for root::Anna {
-                #[doc = "Synthesized destructor."]
+                ///Synthesized destructor.
                 fn drop(self: &mut root::Anna) {
                     unsafe {
                         cxxbridge::Anna_synthetic_destructor_0xad4378f8634e85a3_autocxx_wrapper(
                             self,
                         )
                     }
                 }
             }
             unsafe impl autocxx::moveit::new::MoveNew for root::Bob {
-                #[doc = "Synthesized move constructor."]
+                ///Synthesized move constructor.
                 unsafe fn move_new(
                     mut other: ::std::pin::Pin<autocxx::moveit::MoveRef<'_, root::Bob>>,
                     this: ::std::pin::Pin<&mut ::std::mem::MaybeUninit<root::Bob>>,
                 ) {
                     cxxbridge::Bob_new_synthetic_move_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                         this.get_unchecked_mut().as_mut_ptr(),
                         {
-                            let r: &mut _ = ::std::pin::Pin::into_inner_unchecked(other.as_mut());
+                            let r: &mut _ = ::std::pin::Pin::into_inner_unchecked(
+                                other.as_mut(),
+                            );
                             r
                         },
                     )
                 }
             }
             unsafe impl autocxx::moveit::new::CopyNew for root::Bob {
-                #[doc = "Synthesized copy constructor."]
+                ///Synthesized copy constructor.
                 unsafe fn copy_new(
                     other: &root::Bob,
                     this: ::std::pin::Pin<&mut ::std::mem::MaybeUninit<root::Bob>>,
                 ) {
                     cxxbridge::Bob_new_synthetic_const_copy_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                         this.get_unchecked_mut().as_mut_ptr(),
                         other,
                     )
                 }
             }
             impl Drop for root::Bob {
-                #[doc = "Synthesized destructor."]
+                ///Synthesized destructor.
                 fn drop(self: &mut root::Bob) {
                     unsafe {
-                        cxxbridge::Bob_synthetic_destructor_0xad4378f8634e85a3_autocxx_wrapper(self)
+                        cxxbridge::Bob_synthetic_destructor_0xad4378f8634e85a3_autocxx_wrapper(
+                            self,
+                        )
                     }
                 }
             }
             #[allow(unused_imports)]
             use self::super::super::cxxbridge;
             #[allow(unused_imports)]
             use self::super::super::ToCppString;
             #[allow(unused_imports)]
             use self::super::root;
         }
     }
     #[cxx::bridge]
     mod cxxbridge {
         impl UniquePtr<Anna> {}
         impl SharedPtr<Anna> {}
         impl WeakPtr<Anna> {}
         impl CxxVector<Anna> {}
         impl UniquePtr<Bob> {}
         impl SharedPtr<Bob> {}
         impl WeakPtr<Bob> {}
         impl CxxVector<Bob> {}
         unsafe extern "C++" {
-            fn autocxx_make_string_0xad4378f8634e85a3(str_: &str) -> UniquePtr<CxxString>;
+            fn autocxx_make_string_0xad4378f8634e85a3(
+                str_: &str,
+            ) -> UniquePtr<CxxString>;
             pub unsafe fn Anna_alloc_autocxx_wrapper() -> *mut Anna;
             pub unsafe fn Anna_free_autocxx_wrapper(arg0: *mut Anna);
             type Anna = super::bindgen::root::Anna;
             pub unsafe fn Bob_alloc_autocxx_wrapper() -> *mut Bob;
             pub unsafe fn Bob_free_autocxx_wrapper(arg0: *mut Bob);
             type Bob = super::bindgen::root::Bob;
             pub unsafe fn give_anna_autocxx_wrapper(placement_return_type: *mut Anna);
             pub unsafe fn get_bob_autocxx_wrapper(
                 autocxx_gen_this: &Bob,
                 a: *mut Anna,
                 arg1: UniquePtr<Anna>,
             ) -> u32;
-            #[doc = "Synthesized default constructor."]
+            ///Synthesized default constructor.
             pub unsafe fn new_autocxx_autocxx_wrapper(autocxx_gen_this: *mut Anna);
-            #[doc = "Synthesized move constructor."]
+            ///Synthesized move constructor.
             pub unsafe fn new_synthetic_move_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                 autocxx_gen_this: *mut Anna,
                 other: *mut Anna,
             );
-            #[doc = "Synthesized copy constructor."]
+            ///Synthesized copy constructor.
             pub unsafe fn new_synthetic_const_copy_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                 autocxx_gen_this: *mut Anna,
                 other: &Anna,
             );
-            #[doc = "Synthesized destructor."]
+            ///Synthesized destructor.
             pub unsafe fn Anna_synthetic_destructor_0xad4378f8634e85a3_autocxx_wrapper(
                 autocxx_gen_this: *mut Anna,
             );
-            #[doc = "Synthesized default constructor."]
+            ///Synthesized default constructor.
             pub unsafe fn Bob_new_autocxx_autocxx_wrapper(autocxx_gen_this: *mut Bob);
-            #[doc = "Synthesized move constructor."]
+            ///Synthesized move constructor.
             pub unsafe fn Bob_new_synthetic_move_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                 autocxx_gen_this: *mut Bob,
                 other: *mut Bob,
             );
-            #[doc = "Synthesized copy constructor."]
+            ///Synthesized copy constructor.
             pub unsafe fn Bob_new_synthetic_const_copy_ctor_0xad4378f8634e85a3_autocxx_wrapper(
                 autocxx_gen_this: *mut Bob,
                 other: &Bob,
             );
-            #[doc = "Synthesized destructor."]
+            ///Synthesized destructor.
             pub unsafe fn Bob_synthetic_destructor_0xad4378f8634e85a3_autocxx_wrapper(
                 autocxx_gen_this: *mut Bob,
             );
             include!("input.h");
             include!("autocxxgen_ffi.h");
         }
         extern "Rust" {}
     }
     #[allow(unused_imports)]
     use bindgen::root;
-    pub use bindgen::root::give_anna;
+    pub use cxxbridge::autocxx_make_string_0xad4378f8634e85a3 as make_string;
     pub use bindgen::root::Anna;
     pub use bindgen::root::Bob;
-    pub use cxxbridge::autocxx_make_string_0xad4378f8634e85a3 as make_string;
+    pub use bindgen::root::give_anna;
 }
```
</details>