### PR TITLE
Disable windows GNU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,10 @@ jobs:
           - name: macOS
             rust: nightly
             os: macos
-          - name: Windows (gnu)
-            rust: nightly-x86_64-pc-windows-gnu
-            os: windows
+          # Windows GNU disabled due to https://github.com/google/autocxx/issues/1134
+          # - name: Windows (gnu)
+          #    rust: nightly-x86_64-pc-windows-gnu
+          #    os: windows
           - name: Windows (msvc)
             rust: nightly-x86_64-pc-windows-msvc
             os: windows

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -143,8 +143,7 @@ impl<'a> BridgeConverter<'a> {
                 // Specifically, let's confirm that the items requested by the user to be
                 // POD really are POD, and duly mark any dependent types.
                 // This returns a new list of `Api`s, which will be parameterized with
-                // the analysis results. It also returns an object which can be used
-                // by subsequent phases to work out which objects are POD.
+                // the analysis results.
                 let analyzed_apis = analyze_pod_apis(apis, self.config)?;
                 Self::dump_apis("pod analysis", &analyzed_apis);
                 let analyzed_apis = replace_hopeless_typedef_targets(self.config, analyzed_apis);


### PR DESCRIPTION
These are failing for unknown reasons; however, the failure began on main and
is therefore some external environmental change (likely a change to rustc)
rather than a change to autocxx.

Fixes #1134