### PR TITLE
Generate `impl UniquePtr` for abstract types too

### DIFF
--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -644,14 +644,23 @@ impl<'a> RsCodeGenerator<'a> {
                     false,
                 )
             }
-            Api::ForwardDeclaration { .. }
-            | Api::ConcreteType { .. }
-            | Api::OpaqueTypedef { .. } => self.generate_type(
+            Api::ConcreteType { .. } => self.generate_type(
                 &name,
                 id,
                 TypeKind::Abstract,
                 false, // assume for now that these types can't be kept in a Vector
                 true,  // assume for now that these types can be put in a smart pointer
+                || None,
+                associated_methods,
+                None,
+                false,
+            ),
+            Api::ForwardDeclaration { .. } | Api::OpaqueTypedef { .. } => self.generate_type(
+                &name,
+                id,
+                TypeKind::Abstract,
+                false, // these types can't be kept in a Vector
+                false, // these types can't be put in a smart pointer
                 || None,
                 associated_methods,
                 None,
@@ -1042,6 +1051,7 @@ impl<'a> RsCodeGenerator<'a> {
                         extern_c_mod_items: vec![
                             self.generate_cxxbridge_type(name, false, doc_attrs)
                         ],
+                        bridge_items: create_impl_items(&id, movable, destroyable, self.config),
                         bindgen_mod_items,
                         materializations,
                         ..Default::default()

--- a/integration-tests/tests/builder_modifiers.rs
+++ b/integration-tests/tests/builder_modifiers.rs
@@ -14,11 +14,19 @@ pub(crate) fn make_cpp17_adder() -> Option<BuilderModifier> {
     make_clang_arg_adder(&["-std=c++17"])
 }
 
-struct ClangArgAdder(Vec<String>);
+struct ClangArgAdder(Vec<String>, Vec<String>);
 
 pub(crate) fn make_clang_arg_adder(args: &[&str]) -> Option<BuilderModifier> {
+    make_clang_optional_arg_adder(args, &[])
+}
+
+pub(crate) fn make_clang_optional_arg_adder(
+    args: &[&str],
+    optional_args: &[&str],
+) -> Option<BuilderModifier> {
     let args: Vec<_> = args.iter().map(|a| a.to_string()).collect();
-    Some(Box::new(ClangArgAdder(args)))
+    let optional_args: Vec<_> = optional_args.iter().map(|a| a.to_string()).collect();
+    Some(Box::new(ClangArgAdder(args, optional_args)))
 }
 
 impl BuilderModifierFns for ClangArgAdder {
@@ -33,6 +41,9 @@ impl BuilderModifierFns for ClangArgAdder {
     fn modify_cc_builder<'a>(&self, mut builder: &'a mut cc::Build) -> &'a mut cc::Build {
         for f in &self.0 {
             builder = builder.flag(f);
+        }
+        for f in &self.1 {
+            builder = builder.flag_if_supported(f);
         }
         builder
     }


### PR DESCRIPTION
Similarly to non-abstract types, if one `include_cpp!` section
`generate!`s an abstract type but never uses `unique_ptr` for that type,
but another one does, we need the explicit `impl UniquePtr` so that cxx
allows it.