### PR TITLE
Add failing test case, issue 1143

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -11541,6 +11541,21 @@ fn test_issue_1125() {
     );
 }
 
+#[test]
+#[ignore]
+fn test_issue_1143() {
+    let hdr = indoc! {
+        "namespace mapnik {
+            class Map {
+            public:
+              int &a(long);
+            };
+        }"
+    };
+
+    run_test("", hdr, quote! {}, &["mapnik::Map"], &[]);
+}
+
 // Yet to test:
 // - Ifdef
 // - Out param pointers


### PR DESCRIPTION
This is for issue 1143. Method returns a reference to an int, and
takes a long by value.