### PR TITLE
Support `extern_cpp_type!` with a different name

### DIFF
--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -1142,13 +1142,16 @@ impl<'a> RsCodeGenerator<'a> {
         let id = name.type_path_from_root();
         let super_duper = std::iter::repeat(make_ident("super"));
         let supers = super_duper.take(ns_depth + 2);
+        let name_final = name.get_final_ident();
         let use_statement = parse_quote! {
             pub use #(#supers)::* :: #id;
         };
         RsCodegenResult {
             bindgen_mod_items: vec![use_statement],
             extern_c_mod_items: vec![self.generate_cxxbridge_type(name, true, Vec::new())],
-            materializations: vec![Use::Custom(Box::new(parse_quote! { pub use #rust_path; }))],
+            materializations: vec![Use::Custom(Box::new(
+                parse_quote! { pub use #rust_path as #name_final; },
+            ))],
             ..Default::default()
         }
     }


### PR DESCRIPTION
This came up for me when dealing with flatbuffers: some modules end up
working with autocxx-generated types based on flatbuffers-C++-generated
types and flatbuffers-Rust-generated types with the same names. Being
able to import the autocxx wrappers under different names is helpful for
keeping them straight.