### PR TITLE
Partial fix for issue 1097.

### DIFF
--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -175,7 +175,7 @@ impl QualifiedName {
     pub(crate) fn get_final_cpp_item(&self) -> String {
         let special_cpp_name = known_types().special_cpp_name(self);
         match special_cpp_name {
-            Some(name) => name,
+            Some(name) => Self::new_from_cpp_name(&name).1,
             None => self.1.to_string(),
         }
     }


### PR DESCRIPTION
We no longer attempt to call a destructor with ptr->~namespace::Ident, but there are other remaining problems with ambiguities between rust::Str and the types declared in the test.

Partial fix for #1097.