### PR TITLE
Rewrite reference_wrapper.rs to be structs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
         run: cargo build
       - name: Build reference-wrappers example
         working-directory: ./examples/reference-wrappers
+        if: matrix.rust == 'nightly'
         run: cargo build
         # We do not build the LLVM example because even 'apt-get install llvm-13-dev'
         # does not work to install the LLVM 13 headers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,6 @@ dependencies = [
  "autocxx-macro",
  "cxx",
  "moveit",
- "rustc_version",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "rustc_version",
  "serde_json",
  "strum_macros",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "autocxx-macro",
  "cxx",
  "moveit",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1169,6 +1170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1195,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust_info",
+ "rustc_version",
  "syn",
  "tempfile",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ cxx = "1.0.78" # ... also needed because expansion of type_id refers to ::cxx
 aquamarine = "0.1" # docs
 moveit = { version = "0.5", features = [ "cxx" ] }
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [workspace]
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce", "tools/mdbook-preprocessor", "integration-tests"]
 exclude = ["examples/s2", "examples/steam-mini", "examples/subclass", "examples/chromium-fake-render-frame-host", "examples/pod", "examples/non-trivial-type-on-stack", "examples/llvm", "examples/reference-wrappers", "tools/stress-test"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ cxx = "1.0.78" # ... also needed because expansion of type_id refers to ::cxx
 aquamarine = "0.1" # docs
 moveit = { version = "0.5", features = [ "cxx" ] }
 
+[build-dependencies]
+rustc_version = "0.4.0"
+
 [workspace]
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce", "tools/mdbook-preprocessor", "integration-tests"]
 exclude = ["examples/s2", "examples/steam-mini", "examples/subclass", "examples/chromium-fake-render-frame-host", "examples/pod", "examples/non-trivial-type-on-stack", "examples/llvm", "examples/reference-wrappers", "tools/stress-test"]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -51,6 +51,9 @@ regex = "1.5"
 indexmap = "1.8"
 prettyplease = { version = "0.1.15", features = ["verbatim"] }
 
+[build-dependencies]
+rustc_version = "0.4"
+
 [dependencies.syn]
 version = "1.0.39"
 features = [ "full", "printing" ]

--- a/engine/build.rs
+++ b/engine/build.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -389,30 +389,23 @@ impl<'a> FnGenerator<'a> {
             .map(|pd| pd.conversion.is_a_pointer())
             .unwrap_or(Pointerness::Not);
         let ty = impl_block_type_name.get_final_ident();
-        let ty = if self.reference_wrappers {
-            match receiver_pointerness {
-                Pointerness::MutPtr => ImplBlockKey {
-                    ty: parse_quote! {
-                        CppMutRef< 'a, #ty>
-                    },
-                    lifetime: Some(parse_quote! { 'a }),
+        let ty = match receiver_pointerness {
+            Pointerness::MutPtr if self.reference_wrappers => ImplBlockKey {
+                ty: parse_quote! {
+                    #ty
                 },
-                Pointerness::ConstPtr => ImplBlockKey {
-                    ty: parse_quote! {
-                        CppRef< 'a, #ty>
-                    },
-                    lifetime: Some(parse_quote! { 'a }),
+                lifetime: Some(parse_quote! { 'a }),
+            },
+            Pointerness::ConstPtr if self.reference_wrappers => ImplBlockKey {
+                ty: parse_quote! {
+                    #ty
                 },
-                Pointerness::Not => ImplBlockKey {
-                    ty: parse_quote! { # ty },
-                    lifetime: None,
-                },
-            }
-        } else {
-            ImplBlockKey {
+                lifetime: Some(parse_quote! { 'a }),
+            },
+            _ => ImplBlockKey {
                 ty: parse_quote! { # ty },
                 lifetime: None,
-            }
+            },
         };
         Box::new(ImplBlockDetails {
             item: ImplItem::Method(parse_quote! {

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -137,91 +137,6 @@ fn get_string_items() -> Vec<Item> {
     .to_vec()
 }
 
-fn get_cppref_items() -> Vec<Item> {
-    [
-        Item::Struct(parse_quote! {
-            #[repr(transparent)]
-            pub struct CppRef<'a, T>(pub *const T, pub ::std::marker::PhantomData<&'a T>);
-        }),
-        Item::Impl(parse_quote! {
-            impl<'a, T> autocxx::CppRef<'a, T> for CppRef<'a, T> {
-                fn as_ptr(&self) -> *const T {
-                    self.0
-                }
-            }
-        }),
-        Item::Struct(parse_quote! {
-            #[repr(transparent)]
-            pub struct CppMutRef<'a, T>(pub *mut T, pub ::std::marker::PhantomData<&'a T>);
-        }),
-        Item::Impl(parse_quote! {
-            impl<'a, T> autocxx::CppRef<'a, T> for CppMutRef<'a, T> {
-                fn as_ptr(&self) -> *const T {
-                    self.0
-                }
-            }
-        }),
-        Item::Impl(parse_quote! {
-            impl<'a, T> autocxx::CppMutRef<'a, T> for CppMutRef<'a, T> {
-                fn as_mut_ptr(&self) -> *mut T {
-                    self.0
-                }
-            }
-        }),
-        Item::Impl(parse_quote! {
-            impl<'a, T: ::cxx::private::UniquePtrTarget> CppMutRef<'a, T> {
-                /// Create a const C++ reference from this mutable C++ reference.
-                pub fn as_cpp_ref(&self) -> CppRef<'a, T> {
-                    use autocxx::CppRef;
-                    CppRef(self.as_ptr(), ::std::marker::PhantomData)
-                }
-            }
-        }),
-        Item::Struct(parse_quote! {
-            /// "Pins" a `UniquePtr` to an object, so that C++-compatible references can be created.
-            /// See [`::autocxx::CppPin`]
-            #[repr(transparent)]
-            pub struct CppUniquePtrPin<T: ::cxx::private::UniquePtrTarget>(::cxx::UniquePtr<T>);
-        }),
-        Item::Impl(parse_quote! {
-            impl<'a, T: 'a + ::cxx::private::UniquePtrTarget> autocxx::CppPin<'a, T> for CppUniquePtrPin<T>
-            {
-                type CppRef = CppRef<'a, T>;
-                type CppMutRef = CppMutRef<'a, T>;
-                fn as_ptr(&self) -> *const T {
-                    // TODO add as_ptr to cxx to avoid the ephemeral reference
-                    self.0.as_ref().unwrap() as *const T
-                }
-                fn as_mut_ptr(&mut self) -> *mut T {
-                    unsafe { ::std::pin::Pin::into_inner_unchecked(self.0.as_mut().unwrap()) as *mut T  }
-                }
-                fn as_cpp_ref(&self) -> Self::CppRef {
-                    CppRef(self.as_ptr(), ::std::marker::PhantomData)
-                }
-                fn as_cpp_mut_ref(&mut self) -> Self::CppMutRef {
-                    CppMutRef(self.as_mut_ptr(), ::std::marker::PhantomData)
-                }
-            }
-        }),
-        Item::Impl(parse_quote! {
-            impl<T: ::cxx::private::UniquePtrTarget> CppUniquePtrPin<T> {
-                pub fn new(item: ::cxx::UniquePtr<T>) -> Self {
-                    Self(item)
-                }
-            }
-        }),
-        Item::Fn(parse_quote! {
-            /// Pin this item so that we can create C++ references to it.
-            /// This makes it impossible to hold Rust references because Rust
-            /// references are fundamentally incompatible with C++ references.
-            pub fn cpp_pin_uniqueptr<T: ::cxx::private::UniquePtrTarget> (item: ::cxx::UniquePtr<T>) -> CppUniquePtrPin<T> {
-                CppUniquePtrPin::new(item)
-            }
-        })
-    ]
-    .to_vec()
-}
-
 /// Type which handles generation of Rust code.
 /// In practice, much of the "generation" involves connecting together
 /// existing lumps of code within the Api structures.
@@ -314,9 +229,6 @@ impl<'a> RsCodeGenerator<'a> {
         let mut extern_rust_mod_items = extern_rust_mod_items.into_iter().flatten().collect();
         // And a list of global items to include at the top level.
         let mut all_items: Vec<Item> = all_items.into_iter().flatten().collect();
-        if self.config.unsafe_policy.requires_cpprefs() {
-            all_items.append(&mut get_cppref_items())
-        }
         // And finally any C++ we need to generate. And by "we" I mean autocxx not cxx.
         let has_additional_cpp_needs = additional_cpp_needs.into_iter().any(std::convert::identity);
         extern_c_mod_items.extend(self.build_include_foreign_items(has_additional_cpp_needs));
@@ -458,9 +370,6 @@ impl<'a> RsCodeGenerator<'a> {
         let mut imports_from_super = vec!["cxxbridge"];
         if !self.config.exclude_utilities() {
             imports_from_super.push("ToCppString");
-        }
-        if self.config.unsafe_policy.requires_cpprefs() {
-            imports_from_super.extend(["CppRef", "CppMutRef"]);
         }
         let imports_from_super = imports_from_super.into_iter().map(make_ident);
         let super_duper = std::iter::repeat(make_ident("super")); // I'll get my coat

--- a/examples/reference-wrappers/build.rs
+++ b/examples/reference-wrappers/build.rs
@@ -10,7 +10,8 @@ fn main() -> miette::Result<()> {
     let path = std::path::PathBuf::from("src");
     let mut b = autocxx_build::Builder::new("src/main.rs", &[&path]).build()?;
     b.flag_if_supported("-std=c++14")
-    .file("src/input.cc").compile("autocxx-reference-wrapper-example");
+        .file("src/input.cc")
+        .compile("autocxx-reference-wrapper-example");
 
     println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/input.h");

--- a/examples/reference-wrappers/build.rs
+++ b/examples/reference-wrappers/build.rs
@@ -15,5 +15,6 @@ fn main() -> miette::Result<()> {
 
     println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/input.h");
+
     Ok(())
 }

--- a/examples/reference-wrappers/src/main.rs
+++ b/examples/reference-wrappers/src/main.rs
@@ -23,11 +23,16 @@
 // especially in the absence of the Rust "arbitrary self types"
 // feature.
 
+// Necessary to be able to call methods on reference wrappers.
+// For that reason, this example only builds on nightly Rust.
+#![feature(arbitrary_self_types)]
+
 use autocxx::prelude::*;
 
 include_cpp! {
     #include "input.h"
     // This next line enables C++ reference wrappers
+    // This is what requires the 'arbitrary_self_types' feature.
     safety!(unsafe_references_wrapped)
     generate!("Goat")
     generate!("Field")

--- a/examples/reference-wrappers/src/main.rs
+++ b/examples/reference-wrappers/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     // However, as soon as we want to pass a reference to the field
     // back to C++, we have to ensure we have no Rust references
     // in existence. So: we imprison the object in a "CppPin":
-    let field = ffi::cpp_pin_uniqueptr(field);
+    let field = CppUniquePtrPin::new(field);
     // We can no longer take Rust references to the field...
     //   let _field_rust_ref = field.as_ref();
     // However, we can take C++ references. And use such references
@@ -58,7 +58,7 @@ fn main() {
     assert_eq!(
         another_goat
             .describe() // returns a UniquePtr<CxxString>, there
-                // are no Rust or C++ references involved at this point.
+            // are no Rust or C++ references involved at this point.
             .as_ref()
             .unwrap()
             .to_string_lossy(),

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -37,6 +37,7 @@ indoc = "1.0"
 log = "0.4"
 cxx = "1.0.78"
 itertools = "0.10"
+rustc_version = "0.4.0"
 
 [dependencies.syn]
 version = "1.0.39"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -210,6 +210,7 @@ pub fn run_test(
         None,
         None,
         "unsafe_ffi",
+        None,
     )
     .unwrap()
 }
@@ -265,6 +266,7 @@ pub fn run_test_ex(
         code_checker,
         extra_rust,
         "unsafe_ffi",
+        None,
     )
     .unwrap()
 }
@@ -297,6 +299,7 @@ pub fn run_test_expect_fail(
         None,
         None,
         "unsafe_ffi",
+        None,
     )
     .expect_err("Unexpected success");
 }
@@ -319,6 +322,7 @@ pub fn run_test_expect_fail_ex(
         code_checker,
         extra_rust,
         "unsafe_ffi",
+        None,
     )
     .expect_err("Unexpected success");
 }
@@ -369,10 +373,13 @@ pub fn do_run_test(
     rust_code_checker: Option<CodeChecker>,
     extra_rust: Option<TokenStream>,
     safety_policy: &str,
+    module_attributes: Option<TokenStream>,
 ) -> Result<(), TestError> {
     let hexathorpe = Token![#](Span::call_site());
     let safety_policy = format_ident!("{}", safety_policy);
     let unexpanded_rust = quote! {
+            #module_attributes
+
             use autocxx::prelude::*;
 
             include_cpp!(

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -54,8 +54,11 @@ fn test_method_call_mut() {
     "},
         quote! {
             let goat = ffi::Goat::new().within_unique_ptr();
-            let mut goat = ffi::CppUniquePtrPin::new(goat);
-            goat.as_cpp_mut_ref().add_a_horn();
+            let mut goat = autocxx::CppUniquePtrPin::new(goat);
+            // Only nightly supports calling methods on cpp refs
+            if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {
+                goat.as_cpp_mut_ref().add_a_horn();
+            }
         },
         &["Goat"],
         &[],
@@ -87,8 +90,11 @@ fn test_method_call_const() {
     "},
         quote! {
             let goat = ffi::Goat::new().within_unique_ptr();
-            let goat = ffi::cpp_pin_uniqueptr(goat);
-            goat.as_cpp_ref().describe();
+            let goat = autocxx::CppUniquePtrPin::new(goat);
+            // Only nightly supports calling methods on cpp refs
+            if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {
+                goat.as_cpp_ref().describe();
+            }
         },
         &["Goat"],
         &[],

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -21,6 +21,10 @@ fn run_cpprefs_test(
     generate: &[&str],
     generate_pods: &[&str],
 ) {
+    if rustc_version::version_meta().unwrap().channel != rustc_version::Channel::Nightly {
+        // "unsafe_references_wrapped" requires arbitrary_self_types, which requires nightly.
+        return;
+    }
     do_run_test(
         cxx_code,
         header_code,
@@ -30,6 +34,9 @@ fn run_cpprefs_test(
         None,
         None,
         "unsafe_references_wrapped",
+        Some(quote! {
+            #![feature(arbitrary_self_types)]
+        }),
     )
     .unwrap()
 }

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5932,6 +5932,7 @@ fn test_double_destruction() {
         None,
         None,
         "unsafe_ffi",
+        None,
     ) {
         Err(TestError::CppBuild(_)) => {} // be sure this fails due to a static_assert
         // rather than some runtime problem

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(nightly, feature(receiver_trait))]
 
 // Copyright 2020 Google LLC
 //
@@ -19,7 +20,7 @@ mod rvalue_param;
 pub mod subclass;
 mod value_param;
 
-pub use reference_wrapper::{CppMutRef, CppPin, CppRef};
+pub use reference_wrapper::{AsCppMutRef, AsCppRef, CppMutRef, CppPin, CppRef, CppUniquePtrPin};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Include some C++ headers in your Rust project.
@@ -265,9 +266,11 @@ macro_rules! concrete {
 /// policy available here:
 /// `safety!(unsafe_references_wrapped)`
 /// This policy treats C++ references as scary and requires
-/// them to be wrapped in a `CppRef` type. This `CppRef`
-/// type is implemented within the generated bindings but
-/// follows the contract of [`CppRef`].
+/// them to be wrapped in a `CppRef` type: see [`CppRef`].
+/// This only works practically on nightly Rust because it
+/// depends upon an unstable feature. However, it should
+/// eliminate all undefined behavior related to Rust's
+/// stricter aliasing rules than C++.
 #[macro_export]
 macro_rules! safety {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
@@ -630,9 +633,12 @@ pub mod prelude {
     pub use crate::c_void;
     pub use crate::cpp_semantics;
     pub use crate::include_cpp;
+    pub use crate::AsCppMutRef;
+    pub use crate::AsCppRef;
     pub use crate::CppMutRef;
     pub use crate::CppPin;
     pub use crate::CppRef;
+    pub use crate::CppUniquePtrPin;
     pub use crate::PinMut;
     pub use crate::RValueParam;
     pub use crate::ValueParam;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,8 +267,9 @@ macro_rules! concrete {
 /// `safety!(unsafe_references_wrapped)`
 /// This policy treats C++ references as scary and requires
 /// them to be wrapped in a `CppRef` type: see [`CppRef`].
-/// This only works practically on nightly Rust because it
-/// depends upon an unstable feature. However, it should
+/// This only works on nightly Rust because it
+/// depends upon an unstable feature
+/// (`arbitrary_self_types`). However, it should
 /// eliminate all undefined behavior related to Rust's
 /// stricter aliasing rules than C++.
 #[macro_export]

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -131,9 +131,6 @@ impl<'a, T> CppRef<'a, T> {
     }
 }
 
-#[cfg(nightly)]
-impl<'a, T> core::ops::Receiver for CppRef<'a, T> {}
-
 impl<'a, T> core::ops::Deref for CppRef<'a, T> {
     type Target = T;
     #[inline]
@@ -204,9 +201,6 @@ impl<'a, T> CppMutRef<'a, T> {
         PhantomReferentMut(self.ptr)
     }
 }
-
-#[cfg(nightly)]
-impl<'a, T> core::ops::Receiver for CppMutRef<'a, T> {}
 
 impl<'a, T> core::ops::Deref for CppMutRef<'a, T> {
     type Target = T;
@@ -486,7 +480,7 @@ impl<T> AsCppMutRef<T> for PhantomReferentMut<T> {
     }
 }
 
-#[cfg(all(nightly, test))]
+#[cfg(all(feature = "arbitrary_self_types", test))]
 mod tests {
     use super::*;
 

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -45,7 +45,7 @@ use cxx::{memory::UniquePtrTarget, UniquePtr};
 /// you can use `lifetime_cast` to get a long-lived version.
 ///
 /// On the other hand, these references do not give you Rust's exclusivity
-/// guarantees. These references can be freely cloned, and using [`const_cast`]
+/// guarantees. These references can be freely cloned, and using [`CppRef::const_cast`]
 /// you can even make a mutable reference from an immutable reference.
 ///
 /// # Field access
@@ -282,7 +282,7 @@ impl<T> CppPinContents<T> {
 ///
 /// If you need C++ to access your Rust object, first imprison it in one of these
 /// objects, then use [`Self::as_cpp_ref`] to obtain C++ references to it.
-/// If you need the object back for use in the Rust domain, use [`extract`],
+/// If you need the object back for use in the Rust domain, use [`CppPin::extract`],
 /// but be aware of the safety invariants that you - as a human - will need
 /// to guarantee.
 ///

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -6,15 +6,66 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{marker::PhantomData, pin::Pin};
+
+use cxx::{memory::UniquePtrTarget, UniquePtr};
+
 /// A C++ const reference. These are different from Rust's `&T` in that
-/// these may exist even while the object is mutated elsewhere.
+/// these may exist even while the object is mutated elsewhere. See also
+/// [`CppMutRef`] for the mutable equivalent.
 ///
-/// This is a trait not a struct due to the nuances of Rust's orphan rule
-/// - implemntations of this trait are found in each set of generated bindings
-/// but they are essentially the same.
-pub trait CppRef<'a, T> {
+/// The key rule is: we *never* dereference these in Rust. Therefore, any
+/// UB here cannot manifest within Rust, but only across in C++, and therefore
+/// they are equivalently safe to using C++ references in pure-C++ codebases.
+///
+/// # Usage
+///
+/// These types of references are pretty useless in Rust. You can't do
+/// field access. But, you can pass them back into C++! And specifically,
+/// you can call methods on them (i.e. use this type as a `this`). So
+/// the common case here is when C++ gives you a reference to some type,
+/// then you want to call methods on that reference.
+///
+/// # Calling methods
+///
+/// As noted, one of the main reasons for this type is to call methods.
+/// Unfortunately, that depends on unstable Rust features. If you can't
+/// call methods on one of these references, check you're using nightly.
+///
+/// # Lifetimes and cloneability
+///
+/// Although these references implement C++ aliasing semantics, they
+/// do attempt to give you Rust lifetime tracking. This means if a C++ object
+/// gives you a reference, you won't be able to use that reference after the
+/// C++ object is no longer around.
+///
+/// This is usually what you need, since a C++ object will typically give
+/// you a reference to part of _itself_ or something that it owns. But,
+/// if you know that the returned reference lasts longer than its vendor,
+/// you can use `lifetime_cast` to get a long-lived version.
+///
+/// On the other hand, these references do not give you Rust's exclusivity
+/// guarantees. These references can be freely cloned, and using [`const_cast`]
+/// you can even make a mutable reference from an immutable reference.
+///
+/// # Field access
+///
+/// Field access would be achieved by adding C++ `get` and/or `set` methods.
+///
+/// # Implementation notes
+///
+/// Internally, this is represented as a raw pointer in Rust.
+#[repr(transparent)]
+pub struct CppRef<'a, T> {
+    ptr: *const T,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> CppRef<'a, T> {
     /// Retrieve the underlying C++ pointer.
-    fn as_ptr(&self) -> *const T;
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
 
     /// Get a regular Rust reference out of this C++ reference.
     ///
@@ -24,21 +75,108 @@ pub trait CppRef<'a, T> {
     /// C++ or Rust code while the returned reference exists. Callers must
     /// also guarantee that no mutable Rust reference is created to the
     /// referent while the returned reference exists.
-    unsafe fn as_ref(&self) -> &T {
+    pub unsafe fn as_ref(&self) -> &T {
         &*self.as_ptr()
+    }
+
+    /// Create a C++ reference from a raw pointer.
+    pub fn from_ptr(ptr: *const T) -> Self {
+        Self {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create a mutable version of this reference, roughly equivalent
+    /// to C++ `const_cast`.
+    ///
+    /// The opposite is to use [`AsCppRef::as_cpp_ref`] on a [`CppMutRef`]
+    /// to obtain a [`CppRef`].
+    ///
+    /// # Safety
+    ///
+    /// Because we never dereference a `CppRef` in Rust, this cannot create
+    /// undefined behavior _within Rust_ and is therefore not unsafe. It is
+    /// however generally unwise, just as it is in C++. Use sparingly.
+    pub fn const_cast(&self) -> CppMutRef<'a, T> {
+        CppMutRef {
+            ptr: self.ptr as *mut T,
+            phantom: self.phantom,
+        }
+    }
+
+    /// Extend the lifetime of the returned reference beyond normal Rust
+    /// borrow checker rules.
+    ///
+    /// Normally, a reference can't be used beyond the lifetime of the object
+    /// which gave it to you, but sometimes C++ APIs can return references
+    /// to global or other longer-lived objects. In such a case you should
+    /// use this method to get a longer-lived reference.
+    ///
+    /// # Usage
+    ///
+    /// When you're given a C++ reference and you know its referent is valid
+    /// for a long time, use this method. Store the resulting `PhantomReferent`
+    /// somewhere in Rust with an equivalent lifetime.
+    /// That object can then vend longer-lived `CppRef`s using
+    /// [`AsCppRef::as_cpp_ref`].
+    ///
+    /// # Safety
+    ///
+    /// Because `CppRef`s are never dereferenced in Rust, misuse of this API
+    /// cannot lead to undefined behavior _in Rust_ and is therefore not
+    /// unsafe. Nevertheless this can lead to UB in C++, so use carefully.
+    pub fn lifetime_cast(&self) -> PhantomReferent<T> {
+        PhantomReferent(self.ptr)
+    }
+}
+
+#[cfg(nightly)]
+impl<'a, T> core::ops::Receiver for CppRef<'a, T> {}
+
+impl<'a, T> core::ops::Deref for CppRef<'a, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // With `inline_const` we can simplify this to:
+        // const { panic!("you shouldn't deref CppRef!") }
+        struct C<T>(T);
+        impl<T> C<T> {
+            const V: core::convert::Infallible = panic!(
+                "You cannot directly obtain a Rust reference from a CppRef. Use CppRef::as_ref."
+            );
+        }
+        match C::<T>::V {}
+    }
+}
+
+impl<'a, T> Clone for CppRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr,
+            phantom: self.phantom,
+        }
     }
 }
 
 /// A C++ non-const reference. These are different from Rust's `&mut T` in that
 /// several C++ references can exist to the same underlying data ("aliasing")
-/// and that's not permitted in Rust.
+/// and that's not permitted for regular Rust references.
 ///
-/// This is a trait not a struct due to the nuances of Rust's orphan rule
-/// - implemntations of this trait are found in each set of generated bindings
-/// but they are essentially the same.
-pub trait CppMutRef<'a, T>: CppRef<'a, T> {
+/// See [`CppRef`] for details on safety, usage models and implementation.
+///
+/// You can convert this to a [`CppRef`] using the [`std::convert::Into`] trait.
+#[repr(transparent)]
+pub struct CppMutRef<'a, T> {
+    ptr: *mut T,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> CppMutRef<'a, T> {
     /// Retrieve the underlying C++ pointer.
-    fn as_mut_ptr(&self) -> *mut T;
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.ptr
+    }
 
     /// Get a regular Rust mutable reference out of this C++ reference.
     ///
@@ -48,16 +186,95 @@ pub trait CppMutRef<'a, T>: CppRef<'a, T> {
     /// C++ or Rust code while the returned reference exists. Callers must
     /// also guarantee that no other Rust reference is created to the referent
     /// while the returned reference exists.
-    unsafe fn as_mut(&mut self) -> &mut T {
+    pub unsafe fn as_mut(&mut self) -> &mut T {
         &mut *self.as_mut_ptr()
+    }
+
+    /// Create a C++ reference from a raw pointer.
+    pub fn from_ptr(ptr: *mut T) -> Self {
+        Self {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Extend the lifetime of the returned reference beyond normal Rust
+    /// borrow checker rules. See [`CppRef::lifetime_cast`].
+    pub fn lifetime_cast(&mut self) -> PhantomReferentMut<T> {
+        PhantomReferentMut(self.ptr)
     }
 }
 
-/// Any newtype wrapper which causes the contained object to obey C++ reference
-/// semantics rather than Rust reference semantics.
-///
-/// The complex generics here are working around the orphan rule - the only
-/// important generic is `T` which is the underlying stored type.
+#[cfg(nightly)]
+impl<'a, T> core::ops::Receiver for CppMutRef<'a, T> {}
+
+impl<'a, T> core::ops::Deref for CppMutRef<'a, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // With `inline_const` we can simplify this to:
+        // const { panic!("you shouldn't deref CppRef!") }
+        struct C<T>(T);
+        impl<T> C<T> {
+            const V: core::convert::Infallible = panic!("You cannot directly obtain a Rust reference from a CppMutRef. Use CppMutRef::as_mut.");
+        }
+        match C::<T>::V {}
+    }
+}
+
+impl<'a, T> Clone for CppMutRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr,
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<'a, T> From<CppMutRef<'a, T>> for CppRef<'a, T> {
+    fn from(mutable: CppMutRef<'a, T>) -> Self {
+        Self {
+            ptr: mutable.ptr,
+            phantom: mutable.phantom,
+        }
+    }
+}
+
+/// Any type which can return a C++ reference to its contents.
+pub trait AsCppRef<T> {
+    /// Returns a reference which obeys C++ reference semantics
+    fn as_cpp_ref(&self) -> CppRef<T>;
+}
+
+/// Any type which can return a C++ reference to its contents.
+pub trait AsCppMutRef<T>: AsCppRef<T> {
+    /// Returns a mutable reference which obeys C++ reference semantics
+    fn as_cpp_mut_ref(&mut self) -> CppMutRef<T>;
+}
+
+impl<'a, T> AsCppRef<T> for CppMutRef<'a, T> {
+    fn as_cpp_ref(&self) -> CppRef<T> {
+        CppRef::from_ptr(self.ptr)
+    }
+}
+
+/// Workaround for the inability to use std::ptr::addr_of! on the contents
+/// of a box.
+#[repr(transparent)]
+struct CppPinContents<T>(T);
+
+impl<T> CppPinContents<T> {
+    fn addr_of(&self) -> *const T {
+        std::ptr::addr_of!(self.0)
+    }
+    fn addr_of_mut(&mut self) -> *mut T {
+        std::ptr::addr_of_mut!(self.0)
+    }
+}
+
+/// A newtype wrapper which causes the contained object to obey C++ reference
+/// semantics rather than Rust reference semantics. That is, multiple aliasing
+/// mutable C++ references may exist to the contents.
 ///
 /// C++ references are permitted to alias one another, and commonly do.
 /// Rust references must alias according only to the narrow rules of the
@@ -65,27 +282,82 @@ pub trait CppMutRef<'a, T>: CppRef<'a, T> {
 ///
 /// If you need C++ to access your Rust object, first imprison it in one of these
 /// objects, then use [`Self::as_cpp_ref`] to obtain C++ references to it.
-pub trait CppPin<'a, T: 'a> {
-    /// The type of C++ reference created to the contained object.
-    type CppRef: CppRef<'a, T>;
+/// If you need the object back for use in the Rust domain, use [`extract`],
+/// but be aware of the safety invariants that you - as a human - will need
+/// to guarantee.
+///
+/// # Usage models
+///
+/// From fairly safe to fairly unsafe:
+///
+/// * *Configure a thing in Rust then give it to C++*. Take your Rust object,
+///   set it up freely using Rust references, methods and data, then imprison
+///   it in a `CppPin` and keep it around while you work with it in C++.
+///   There is no possibility of _aliasing_ UB in this usage model, but you
+///   still need to be careful of use-after-free bugs, just as if you were
+///   to create a reference to any data in C++. The Rust borrow checker will
+///   help you a little by ensuring that your `CppRef` objects don't outlive
+///   the `CppPin`, but once those references pass into C++, it can't help.
+/// * *Pass a thing to C++, have it operate on it synchronously, then take
+///   it back*. To do this, you'd imprison your Rust object in a `CppPin`,
+///   then pass mutable C++ references (using [`AsCppMutRef::as_cpp_mut_ref`])
+///   into a C++ function. C++ would duly operate on the object, and thereafter
+///   you could reclaim the object with `extract()`. At this point, you (as
+///   a human) will need to give a guarantee that no references remain in the
+///   C++ domain. If your object was just locally used by a single C++ function,
+///   which has now returned, this type of local analysis may well be practical.
+/// * *Share a thing between Rust and C++*. This object can vend both C++
+///   references and Rust references (via `as_ref` etc.) It may be possible
+///   for you to guarantee that C++ does not mutate the object while any Rust
+///   reference exists. If you choose this model, you'll need to carefully
+///   track exactly what happens to references and pointers on both sides,
+///   and document your evidence for why you are sure this is safe.
+///   Failure here is bad: Rust makes all sorts of optimization decisions based
+///   upon its borrow checker guarantees, so mistakes can lead to undebuggable
+///   action-at-a-distance crashes.
+///
+/// # See also
+///
+/// See also [`CppUniquePtrPin`], which is equivalent for data which is in
+/// a [`cxx::UniquePtr`].
+pub struct CppPin<T>(Box<CppPinContents<T>>);
 
-    /// The type of C++ mutable reference created to the contained object..
-    type CppMutRef: CppMutRef<'a, T>;
+impl<T> CppPin<T> {
+    /// Imprison the Rust data within a `CppPin`. This eliminates any remaining
+    /// Rust references (since we take the item by value) and this object
+    /// subsequently only vends C++ style references, not Rust references,
+    /// until or unless `extract` is called.
+    pub fn new(item: T) -> Self {
+        Self(Box::new(CppPinContents(item)))
+    }
+
+    /// Imprison the boxed Rust data within a `CppPin`. This eliminates any remaining
+    /// Rust references (since we take the item by value) and this object
+    /// subsequently only vends C++ style references, not Rust references,
+    /// until or unless `extract` is called.
+    ///
+    /// If the item is already in a `Box`, this is slightly more efficient than
+    /// `new` because it will avoid moving/reallocating it.
+    pub fn from_box(item: Box<T>) -> Self {
+        // Safety: CppPinContents<T> is #[repr(transparent)] so
+        // this transmute from
+        //   Box<T>
+        // to
+        //   Box<CppPinContents<T>>
+        // is safe.
+        let contents = unsafe { std::mem::transmute(item) };
+        Self(contents)
+    }
 
     /// Get an immutable pointer to the underlying object.
-    fn as_ptr(&self) -> *const T;
+    pub fn as_ptr(&self) -> *const T {
+        self.0.addr_of()
+    }
 
     /// Get a mutable pointer to the underlying object.
-    fn as_mut_ptr(&mut self) -> *mut T;
-
-    /// Returns a reference which obeys C++ reference semantics
-    fn as_cpp_ref(&self) -> Self::CppRef;
-
-    /// Returns a mutable reference which obeys C++ reference semantics.
-    ///
-    /// Note that this requires unique ownership of `self`, but this is
-    /// advisory since the resulting reference can be cloned.
-    fn as_cpp_mut_ref(&mut self) -> Self::CppMutRef;
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.addr_of_mut()
+    }
 
     /// Get a normal Rust reference to the underlying object. This is unsafe.
     ///
@@ -93,7 +365,7 @@ pub trait CppPin<'a, T: 'a> {
     ///
     /// You must guarantee that C++ will not mutate the object while the
     /// reference exists.
-    unsafe fn as_ref(&self) -> &T {
+    pub unsafe fn as_ref(&self) -> &T {
         &*self.as_ptr()
     }
 
@@ -103,7 +375,183 @@ pub trait CppPin<'a, T: 'a> {
     ///
     /// You must guarantee that C++ will not mutate the object while the
     /// reference exists.
-    unsafe fn as_mut(&mut self) -> &mut T {
+    pub unsafe fn as_mut(&mut self) -> &mut T {
         &mut *self.as_mut_ptr()
+    }
+
+    /// Extract the object from within its prison, for re-use again within
+    /// the domain of normal Rust references.
+    ///
+    /// This returns a `Box<T>`: if you want the underlying `T` you can extract
+    /// it using `*`.
+    ///
+    /// # Safety
+    ///
+    /// Callers promise that no remaining C++ references exist either
+    /// in the form of Rust [`CppRef`]/[`CppMutRef`] or any remaining pointers/
+    /// references within C++.
+    pub unsafe fn extract(self) -> Box<T> {
+        // Safety: CppPinContents<T> is #[repr(transparent)] so
+        // this transmute from
+        //   Box<CppPinContents<T>>
+        // to
+        //   Box<T>
+        // is safe.
+        std::mem::transmute(self.0)
+    }
+}
+
+impl<T> AsCppRef<T> for CppPin<T> {
+    fn as_cpp_ref(&self) -> CppRef<T> {
+        CppRef::from_ptr(self.as_ptr())
+    }
+}
+
+impl<T> AsCppMutRef<T> for CppPin<T> {
+    fn as_cpp_mut_ref(&mut self) -> CppMutRef<T> {
+        CppMutRef::from_ptr(self.as_mut_ptr())
+    }
+}
+
+/// Any newtype wrapper which causes the contained [`UniquePtr`] target to obey C++ reference
+/// semantics rather than Rust reference semantics. That is, multiple aliasing
+/// mutable C++ references may exist to the contents.
+///
+/// C++ references are permitted to alias one another, and commonly do.
+/// Rust references must alias according only to the narrow rules of the
+/// borrow checker.
+pub struct CppUniquePtrPin<T: UniquePtrTarget>(UniquePtr<T>);
+
+impl<T: UniquePtrTarget> CppUniquePtrPin<T> {
+    /// Imprison the type within a `CppPin`. This eliminates any remaining
+    /// Rust references (since we take the item by value) and this object
+    /// subsequently only vends C++ style references, not Rust references.
+    pub fn new(item: UniquePtr<T>) -> Self {
+        Self(item)
+    }
+
+    /// Get an immutable pointer to the underlying object.
+    pub fn as_ptr(&self) -> *const T {
+        // TODO - avoid brief reference here
+        self.0
+            .as_ref()
+            .expect("UniquePtr was null; we can't make a C++ reference")
+    }
+}
+
+impl<T: UniquePtrTarget> AsCppRef<T> for CppUniquePtrPin<T> {
+    fn as_cpp_ref(&self) -> CppRef<T> {
+        CppRef::from_ptr(self.as_ptr())
+    }
+}
+
+impl<T: UniquePtrTarget> AsCppMutRef<T> for CppUniquePtrPin<T> {
+    fn as_cpp_mut_ref(&mut self) -> CppMutRef<T> {
+        let pinnned_ref: Pin<&mut T> = self
+            .0
+            .as_mut()
+            .expect("UniquePtr was null; we can't make a C++ reference");
+        let ptr = unsafe { Pin::into_inner_unchecked(pinnned_ref) };
+        CppMutRef::from_ptr(ptr)
+    }
+}
+
+/// A structure used to extend the lifetime of a returned C++ reference,
+/// to indicate to Rust that it's beyond the normal Rust lifetime rules.
+/// See [`CppRef::lifetime_cast`].
+#[repr(transparent)]
+pub struct PhantomReferent<T>(*const T);
+
+impl<T> AsCppRef<T> for PhantomReferent<T> {
+    fn as_cpp_ref(&self) -> CppRef<T> {
+        CppRef::from_ptr(self.0)
+    }
+}
+
+/// A structure used to extend the lifetime of a returned C++ mutable reference,
+/// to indicate to Rust that it's beyond the normal Rust lifetime rules.
+/// See [`CppRef::lifetime_cast`].
+#[repr(transparent)]
+pub struct PhantomReferentMut<T>(*mut T);
+
+impl<T> AsCppRef<T> for PhantomReferentMut<T> {
+    fn as_cpp_ref(&self) -> CppRef<T> {
+        CppRef::from_ptr(self.0)
+    }
+}
+
+impl<T> AsCppMutRef<T> for PhantomReferentMut<T> {
+    fn as_cpp_mut_ref(&mut self) -> CppMutRef<T> {
+        CppMutRef::from_ptr(self.0)
+    }
+}
+
+#[cfg(all(nightly, test))]
+mod tests {
+    use super::*;
+
+    struct CppOuter {
+        _a: u32,
+        inner: CppInner,
+        global: *const CppInner,
+    }
+
+    impl CppOuter {
+        fn get_inner_ref<'a>(self: &CppRef<'a, CppOuter>) -> CppRef<'a, CppInner> {
+            // Safety: emulating C++ code for test purposes. This is safe
+            // because we know the data isn't modified during the lifetime of
+            // the returned reference.
+            let self_rust_ref = unsafe { self.as_ref() };
+            CppRef::from_ptr(std::ptr::addr_of!(self_rust_ref.inner))
+        }
+        fn get_global_ref<'a>(self: &CppRef<'a, CppOuter>) -> CppRef<'a, CppInner> {
+            // Safety: emulating C++ code for test purposes. This is safe
+            // because we know the data isn't modified during the lifetime of
+            // the returned reference.
+            let self_rust_ref = unsafe { self.as_ref() };
+            CppRef::from_ptr(self_rust_ref.global)
+        }
+    }
+
+    struct CppInner {
+        b: u32,
+    }
+
+    impl CppInner {
+        fn value_is(self: &CppRef<Self>) -> u32 {
+            // Safety: emulating C++ code for test purposes. This is safe
+            // because we know the data isn't modified during the lifetime of
+            // the returned reference.
+            let self_rust_ref = unsafe { self.as_ref() };
+            self_rust_ref.b
+        }
+    }
+
+    #[test]
+    fn cpp_objects() {
+        let mut global = CppInner { b: 7 };
+        let global_ref_lifetime_phantom;
+        {
+            let outer = CppOuter {
+                _a: 12,
+                inner: CppInner { b: 3 },
+                global: &mut global,
+            };
+            let outer = CppPin::new(outer);
+            let inner_ref = outer.as_cpp_ref().get_inner_ref();
+            assert_eq!(inner_ref.value_is(), 3);
+            global_ref_lifetime_phantom = Some(outer.as_cpp_ref().get_global_ref().lifetime_cast());
+        }
+        let global_ref = global_ref_lifetime_phantom.unwrap();
+        let global_ref = global_ref.as_cpp_ref();
+        assert_eq!(global_ref.value_is(), 7);
+    }
+
+    #[test]
+    fn cpp_pin() {
+        let a = RustThing { _a: 4 };
+        let a = CppPin::new(a);
+        let _ = a.as_cpp_ref();
+        let _ = a.as_cpp_ref();
     }
 }


### PR DESCRIPTION
Building on researches explained [here](https://medium.com/@adetaylor/are-we-reference-yet-c-references-in-rust-72c1c6c7015a).