### PR TITLE
Add failing test for extern_rust_function

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -7036,6 +7036,26 @@ fn test_extern_rust_method() {
 }
 
 #[test]
+fn test_extern_rust_fn_callback() {
+    let hdr = indoc! {"
+        struct a {};
+    "};
+    let hexathorpe = Token![#](Span::call_site());
+    let rs = quote! {
+        use autocxx::prelude::*;
+        autocxx::include_cpp! {
+            #hexathorpe include "input.h"
+            safety!(unsafe_ffi)
+            generate!("a")
+        }
+
+        #[autocxx::extern_rust::extern_rust_function]
+        pub fn called_from_cpp(a: Pin<&mut ffi::a>) {}
+    };
+    do_run_test_manual("", hdr, rs, None, None).unwrap();
+}
+
+#[test]
 fn test_rust_reference_no_autodiscover() {
     let hdr = indoc! {"
     #include <cstdint>


### PR DESCRIPTION
Per the Contributing section, the best way to submit a bug is to submit a PR of a failing integration test, so, here's a minimal case from some code I've been trying to write, where a Rust function receives a C++ context, and `cxx` rejects the generated code with an `unsupported type` error (lacking a span, which makes it unhelpful).