### PR TITLE
Bump miette to v5.x for examples/cpp_calling_rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
         working-directory: ./examples/reference-wrappers
         if: matrix.rust == 'nightly'
         run: cargo build
+      - name: Build cpp_calling_rust example
+        working-directory: ./examples/cpp_calling_rust
+        run: cargo build
         # We do not build the LLVM example because even 'apt-get install llvm-13-dev'
         # does not work to install the LLVM 13 headers.
 

--- a/examples/cpp_calling_rust/Cargo.toml
+++ b/examples/cpp_calling_rust/Cargo.toml
@@ -23,4 +23,4 @@ fastrand = "1.5.0"
 [build-dependencies]
 autocxx-build = { path = "../../gen/build", version="0.23.1" }
 regex = "1.5.4"
-miette = { version="4.3", features = [ "fancy" ] }
+miette = { version="5", features = [ "fancy" ] }


### PR DESCRIPTION
This patch bumps miette version to "5".

Fixes https://github.com/google/autocxx/issues/1207

- [X] Tests pass
- [X] Appropriate changes to README are included in PR