### PR TITLE
Fix typo in autocxx::concrete

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ macro_rules! name {
 
 /// A concrete type to make, for example
 /// `concrete!("Container<Contents>")`.
-/// All types msut already be on the allowlist by having used
+/// All types must already be on the allowlist by having used
 /// `generate!` or similar.
 ///
 /// A directive to be included inside


### PR DESCRIPTION
This patch fixes a tiny typo in `autocxx::concrete`.