### PR TITLE
Remove unnecessary memory include in subclass examples

### DIFF
--- a/book/src/rust_calls.md
+++ b/book/src/rust_calls.md
@@ -36,8 +36,7 @@ void feed_goat() {
     }
 }
 ",
-"#include <memory>
-class GoatObserver {
+"class GoatObserver {
 public:
     virtual void goat_full() const = 0;
     virtual ~GoatObserver() {}

--- a/examples/subclass/src/messages.h
+++ b/examples/subclass/src/messages.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <string>
-#include <memory>
 
 class MessageProducer {
 public:


### PR DESCRIPTION
This patch removes unnecessary memory include in subclass examples.

The examples and [docs](https://google.github.io/autocxx/rust_calls.html#subclasses) but it should not be necessary.