### PR TITLE
Reduce the number of dependencies on std

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -1487,7 +1487,7 @@ impl<'a> FnAnalyzer<'a> {
                             AsRef < #to_type >
                         },
                         parse_quote! {
-                            &'a mut ::std::pin::Pin < &'a mut #from_type_path >
+                            &'a mut ::core::pin::Pin < &'a mut #from_type_path >
                         },
                         "as_ref",
                     ),
@@ -1496,7 +1496,7 @@ impl<'a> FnAnalyzer<'a> {
                             autocxx::PinMut < #to_type >
                         },
                         parse_quote! {
-                            ::std::pin::Pin < &'a mut #from_type_path >
+                            ::core::pin::Pin < &'a mut #from_type_path >
                         },
                         "pin_mut",
                     ),

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -478,7 +478,7 @@ impl<'a> TypeConverter<'a> {
                 // be a plain value. We should detect and abort.
                 let mut outer = elem.map(|elem| match mutability {
                     Some(_) => Type::Path(parse_quote! {
-                        ::std::pin::Pin < & #mutability #elem >
+                        ::core::pin::Pin < & #mutability #elem >
                     }),
                     None => Type::Reference(parse_quote! {
                         & #elem

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -67,7 +67,7 @@ impl TypeConversionPolicy {
                     _ => panic!("Not a ptr"),
                 };
                 let ty = parse_quote! {
-                    ::std::pin::Pin<&mut ::std::mem::MaybeUninit< #ty >>
+                    ::core::pin::Pin<&mut ::core::mem::MaybeUninit< #ty >>
                 };
                 RustParamConversion::Param {
                     ty,
@@ -84,13 +84,13 @@ impl TypeConversionPolicy {
                     _ => panic!("Not a ptr"),
                 };
                 let ty = parse_quote! {
-                    ::std::pin::Pin<autocxx::moveit::MoveRef< '_, #ty >>
+                    ::core::pin::Pin<autocxx::moveit::MoveRef< '_, #ty >>
                 };
                 RustParamConversion::Param {
                     ty,
                     local_variables: Vec::new(),
                     conversion: quote! {
-                        { let r: &mut _ = ::std::pin::Pin::into_inner_unchecked(#var.as_mut());
+                        { let r: &mut _ = ::core::pin::Pin::into_inner_unchecked(#var.as_mut());
                             r
                         }
                     },
@@ -138,10 +138,10 @@ impl TypeConversionPolicy {
                         ),
                         MaybeUnsafeStmt::binary(
                             quote! { let mut #space_var_name =
-                                unsafe { ::std::pin::Pin::new_unchecked(&mut #space_var_name) };
+                                unsafe { ::core::pin::Pin::new_unchecked(&mut #space_var_name) };
                             },
                             quote! { let mut #space_var_name =
-                                ::std::pin::Pin::new_unchecked(&mut #space_var_name);
+                                ::core::pin::Pin::new_unchecked(&mut #space_var_name);
                             },
                         ),
                         MaybeUnsafeStmt::needs_unsafe(

--- a/engine/src/conversion/codegen_rs/lifetime.rs
+++ b/engine/src/conversion/codegen_rs/lifetime.rs
@@ -167,7 +167,10 @@ fn add_lifetime_to_pinned_reference(
     ];
 
     for (seg, (expected_name, act)) in segments.iter_mut().zip(EXPECTED_SEGMENTS.iter()) {
-        if !expected_name.iter().any(|expected_name| seg.ident == expected_name) {
+        if !expected_name
+            .iter()
+            .any(|expected_name| seg.ident == expected_name)
+        {
             return Err(AddLifetimeError::WasNotPin);
         }
         if *act {

--- a/engine/src/conversion/codegen_rs/lifetime.rs
+++ b/engine/src/conversion/codegen_rs/lifetime.rs
@@ -160,14 +160,14 @@ enum AddLifetimeError {
 fn add_lifetime_to_pinned_reference(
     segments: &mut Punctuated<PathSegment, syn::token::Colon2>,
 ) -> Result<(), AddLifetimeError> {
-    static EXPECTED_SEGMENTS: &[(&str, bool)] = &[
-        ("std", false),
-        ("pin", false),
-        ("Pin", true), // true = act on the arguments of this segment
+    static EXPECTED_SEGMENTS: &[(&[&str], bool)] = &[
+        (&["std", "core"], false),
+        (&["pin"], false),
+        (&["Pin"], true), // true = act on the arguments of this segment
     ];
 
     for (seg, (expected_name, act)) in segments.iter_mut().zip(EXPECTED_SEGMENTS.iter()) {
-        if seg.ident != expected_name {
+        if !expected_name.iter().any(|expected_name| seg.ident == expected_name) {
             return Err(AddLifetimeError::WasNotPin);
         }
         if *act {

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -755,7 +755,7 @@ impl<'a> RsCodeGenerator<'a> {
         // TODO it would be nice to impl AsMut here but pin prevents us
         bindgen_mod_items.push(parse_quote! {
             impl super::super::super::#id {
-                pub fn pin_mut(&mut self) -> ::std::pin::Pin<&mut cxxbridge::#super_cxxxbridge_id> {
+                pub fn pin_mut(&mut self) -> ::core::pin::Pin<&mut cxxbridge::#super_cxxxbridge_id> {
                     use autocxx::subclass::CppSubclass;
                     self.peer_mut().#as_mut_id()
                 }
@@ -842,7 +842,7 @@ impl<'a> RsCodeGenerator<'a> {
                         .as_ref()
                         .#borrow()
                         .expect(#reentrancy_panic_msg);
-                    let r = ::std::ops::#deref_ty::#deref_call(& #mut_token b);
+                    let r = ::core::ops::#deref_ty::#deref_call(& #mut_token b);
                     #methods_trait :: #method_name
                         (r,
                         #args)

--- a/engine/src/conversion/codegen_rs/non_pod_struct.rs
+++ b/engine/src/conversion/codegen_rs/non_pod_struct.rs
@@ -87,7 +87,7 @@ pub(crate) fn make_non_pod(s: &mut ItemStruct, layout: Option<Layout>) {
                 let id = &gpt.ident;
                 let field_name = make_ident(format!("_phantom_{counter}"));
                 let toks = quote! {
-                    #field_name: ::std::marker::PhantomData<::std::cell::UnsafeCell< #id >>
+                    #field_name: ::core::marker::PhantomData<::core::cell::UnsafeCell< #id >>
                 };
                 Some(Field::parse_named.parse2(toks).unwrap())
             }

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -467,19 +467,10 @@ fn create_type_database() -> TypeDatabase {
     ));
 
     db.insert(TypeDetails::new(
-        "std::pin::Pin",
-        "Pin",
-        Behavior::RustByValue, // because this is actually Pin<&something>
-        None,
-        true,
-        false,
-    ));
-
-    db.insert(TypeDetails::new(
         "core::pin::Pin",
         "Pin",
         Behavior::RustByValue, // because this is actually Pin<&something>
-        None,
+        Some("std::pin::Pin".to_string()),
         true,
         false,
     ));

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -475,6 +475,15 @@ fn create_type_database() -> TypeDatabase {
         false,
     ));
 
+    db.insert(TypeDetails::new(
+        "core::pin::Pin",
+        "Pin",
+        Behavior::RustByValue, // because this is actually Pin<&something>
+        None,
+        true,
+        false,
+    ));
+
     let mut insert_ctype = |cname: &str| {
         let concatenated_name = cname.replace(' ', "");
         db.insert(TypeDetails::new(

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -1282,7 +1282,7 @@ fn test_define_str() {
         #define BOB \"foo\"
     "};
     let rs = quote! {
-        assert_eq!(std::str::from_utf8(ffi::BOB).unwrap().trim_end_matches(char::from(0)), "foo");
+        assert_eq!(core::str::from_utf8(ffi::BOB).unwrap().trim_end_matches(char::from(0)), "foo");
     };
     run_test(cxx, hdr, rs, &["BOB"], &[]);
 }
@@ -1429,7 +1429,7 @@ fn test_asan_working_as_expected_for_cpp_allocations() {
 #[test]
 fn test_asan_working_as_expected_for_rust_allocations() {
     perform_asan_doom_test(
-        quote! { Box::into_raw(std::pin::Pin::into_inner_unchecked(a)) },
+        quote! { Box::into_raw(core::pin::Pin::into_inner_unchecked(a)) },
         quote! { Box },
     )
 }
@@ -3043,7 +3043,7 @@ fn test_string_constant() {
         const char* STRING = \"Foo\";
     "};
     let rs = quote! {
-        let a = std::str::from_utf8(ffi::STRING).unwrap().trim_end_matches(char::from(0));
+        let a = core::str::from_utf8(ffi::STRING).unwrap().trim_end_matches(char::from(0));
         assert_eq!(a, "Foo");
     };
     run_test("", hdr, rs, &["STRING"], &[]);
@@ -8065,10 +8065,10 @@ fn test_pv_subclass_allocation_not_self_owned() {
             assert!(Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().a_called);
             let obs_superclass = obs.as_ref().unwrap(); // &subclass
-            let obs_superclass = unsafe { std::mem::transmute::<&ffi::MyTestObserverCpp, &ffi::TestObserver>(obs_superclass) };
+            let obs_superclass = unsafe { core::mem::transmute::<&ffi::MyTestObserverCpp, &ffi::TestObserver>(obs_superclass) };
             ffi::TriggerTestObserverA(obs_superclass);
             assert!(Lazy::force(&STATUS).lock().unwrap().a_called);
-            std::mem::drop(obs);
+            core::mem::drop(obs);
             Lazy::force(&STATUS).lock().unwrap().a_called = false;
             assert!(!Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().cpp_allocated);
@@ -8085,7 +8085,7 @@ fn test_pv_subclass_allocation_not_self_owned() {
             ffi::TriggerTestObserverA(obs.as_ref().borrow().as_ref());
             assert!(Lazy::force(&STATUS).lock().unwrap().a_called);
             Lazy::force(&STATUS).lock().unwrap().a_called = false;
-            std::mem::drop(obs);
+            core::mem::drop(obs);
             assert!(!Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().cpp_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().a_called);
@@ -8200,11 +8200,11 @@ fn test_pv_subclass_allocation_self_owned() {
             assert!(Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().a_called);
             let obs_superclass = obs.as_ref().unwrap(); // &subclass
-            let obs_superclass = unsafe { std::mem::transmute::<&ffi::MyTestObserverCpp, &ffi::TestObserver>(obs_superclass) };
+            let obs_superclass = unsafe { core::mem::transmute::<&ffi::MyTestObserverCpp, &ffi::TestObserver>(obs_superclass) };
 
             ffi::TriggerTestObserverA(obs_superclass);
             assert!(Lazy::force(&STATUS).lock().unwrap().a_called);
-            std::mem::drop(obs);
+            core::mem::drop(obs);
             Lazy::force(&STATUS).lock().unwrap().a_called = false;
             assert!(!Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().cpp_allocated);
@@ -8221,7 +8221,7 @@ fn test_pv_subclass_allocation_self_owned() {
 
             assert!(Lazy::force(&STATUS).lock().unwrap().a_called);
             Lazy::force(&STATUS).lock().unwrap().a_called = false;
-            std::mem::drop(obs);
+            core::mem::drop(obs);
             assert!(!Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().cpp_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().a_called);
@@ -8233,7 +8233,7 @@ fn test_pv_subclass_allocation_self_owned() {
             let obs_superclass_ptr: *const ffi::TestObserver = obs.as_ref().borrow().as_ref();
             // Retain just a pointer on the Rust side, so there is no Rust-side
             // ownership.
-            std::mem::drop(obs);
+            core::mem::drop(obs);
             assert!(Lazy::force(&STATUS).lock().unwrap().cpp_allocated);
             assert!(Lazy::force(&STATUS).lock().unwrap().rust_allocated);
             assert!(!Lazy::force(&STATUS).lock().unwrap().a_called);
@@ -9790,8 +9790,8 @@ fn size_and_alignment_test(pod: bool) {
         accumulator.extend(quote! {
             let c_size = ffi::#get_size_symbol();
             let c_align = ffi::#get_align_symbol();
-            assert_eq!(std::mem::size_of::<ffi::#type_symbol>(), c_size);
-            assert_eq!(std::mem::align_of::<ffi::#type_symbol>(), c_align);
+            assert_eq!(core::mem::size_of::<ffi::#type_symbol>(), c_size);
+            assert_eq!(core::mem::align_of::<ffi::#type_symbol>(), c_align);
         });
         accumulator
     });


### PR DESCRIPTION
Works on #1204

I separated the changes to the integration tests into a separate commit in case we don't want to change them.

Some other things I considered doing in this PR, but have other breakages:
 - change `std::os::raw::*` to `core::ffi::*`
   - My best guess is that this also requires changes to bindgen
 - change `String` to `alloc::string::String` when generating the string utilities
   - This would require putting an `extern crate alloc;` somewhere, and I'm not sure where we want to do that, or if we want to do that unconditionally.
 - change `std::boxed::Box` to `alloc::boxed::Box`
   - Same issues as String
   - Additionally, there is a question of how to handle this in known types. If you keep both std and alloc in there, then it causes duplicate codegen (in c++ iirc? maybe there's a flag we could use to disable codegen for one of them)

I'm not sure what changes I'd make to the readme for this, but I figure that's something to consider once the tests are fixed.

Testing to ensure this change does what I want it to is actually somewhat difficult, as ideally you'd test against a target that is no_std (so that accidental std inclusions get caught), but has a c++ toolchain with lib(std)c++ available (so that cxx compiles, and so that the generated autocxx code compiles). building with zig doesn't help because it doesn't build lib(std)c++ for you. There probably is a target that wouldn't be too difficult to set that up for, but I haven't put much time into looking for one.