### PR TITLE
Automatically create `outdir` if it doesn't exist

### DIFF
--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -283,6 +283,14 @@ fn main() -> miette::Result<()> {
 
     // Finally start to write the C++ and Rust out.
     let outdir: PathBuf = matches.value_of_os("outdir").unwrap().into();
+
+    if !outdir.exists() {
+        use miette::WrapErr as _;
+        std::fs::create_dir_all(&outdir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to create `outdir` '{}'", outdir.display()))?;
+    }
+
     let mut writer = FileWriter {
         depfile: &depfile,
         outdir: &outdir,


### PR DESCRIPTION
This fixes a small issue in the gen cmd where running it with an outdir that didn't exist would give an unhelpful "No such file or directory" error.