### PR TITLE
Fix comment about `AUTOCXX_RS_JSON_ARCHIVE`

### DIFF
--- a/engine/src/output_generators.rs
+++ b/engine/src/output_generators.rs
@@ -19,7 +19,7 @@ pub struct RsOutput<'a> {
 
 /// Creates an on-disk archive (actually a JSON file) of the Rust side of the bindings
 /// for multiple `include_cpp` macros. If you use this, you will want to tell
-/// `autocxx_macro` how to find this file using the `AUTOCXX_RS_ARCHIVE`
+/// `autocxx_macro` how to find this file using the `AUTOCXX_RS_JSON_ARCHIVE`
 /// environment variable.
 pub fn generate_rs_archive<'a>(rs_outputs: impl Iterator<Item = RsOutput<'a>>) -> String {
     let mut multi_bindings = MultiBindings::default();


### PR DESCRIPTION
This patch fixes an instruction about the usage of `AUTOCXX_RS_JSON_ARCHIVE`.
It mentioned to use `AUTOCXX_RS_ARCHIVE` (missing `_JSON_`) but the correct variable should be `AUTOCXX_RS_JSON_ARCHIVE`.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR