### PR TITLE
Add test for issue #1229

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -11827,6 +11827,47 @@ fn test_issue_1214() {
     run_test("", hdr, quote! {}, &["C"], &[]);
 }
 
+#[test]
+fn test_issue_1229() {
+    let hdr = indoc! {"
+    struct Thing {
+        float id;
+    
+        Thing(float id) : id(id) {}
+    };
+
+    struct Item {
+        float id;
+    
+        Item(float id) : id(id) {}
+    };
+    "};
+    let hexathorpe = Token![#](Span::call_site());
+    let rs = quote! {
+        use autocxx::WithinUniquePtr;
+
+        autocxx::include_cpp! {
+            #hexathorpe include "input.h"
+            name!(thing)
+            safety!(unsafe)
+            generate!("Thing")
+        }
+        autocxx::include_cpp! {
+            #hexathorpe include "input.h"
+            name!(item)
+            safety!(unsafe)
+            generate!("Item")
+        }
+
+        fn main() {
+            let thing = thing::Thing::new(15.).within_unique_ptr();
+            let item = item::Item::new(15.).within_unique_ptr();
+        }
+    };
+
+    do_run_test_manual("", hdr, rs, None, None).unwrap();
+}
+
 // Yet to test:
 // - Ifdef
 // - Out param pointers


### PR DESCRIPTION
Issue #1229 <-

Turns out it can be in one file and doesn't have to be in different ones so it made writing the test a bit easier.

Fails building with (abridged):
```
gen2.cxx:(.text.cxxbridge1$new_autocxx_autocxx_wrapper+0x0): multiple definition of `cxxbridge1$new_autocxx_autocxx_wrapper'; /tmp/.tmpfDPHVE/libautocxx-demo.a(gen0.o):gen0.cxx:(.text.cxxbridge1$new_autocxx_autocxx_wrapper+0x0): first defined here
```