### PR TITLE
Print the number of files generated in the error of `--generate-exact`

### DIFF
--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -399,7 +399,7 @@ impl<'a> FileWriter<'a> {
     ) -> miette::Result<()> {
         if let Some(desired_number) = desired_number {
             if counter > desired_number {
-                return Err(miette::Report::msg("More files were generated than expected. Increase the value passed to --generate-exact or reduce the number of include_cpp! sections."));
+                return Err(miette::Report::msg(format!("{counter} files were generated. Increase the value passed to --generate-exact or reduce the number of include_cpp! sections.")));
             }
             while counter < desired_number {
                 let fname = filename(counter);


### PR DESCRIPTION
The log tells us that `"More files were generated than expected. Increase the value ...` so it is not clear how many files were generated.

So this patch makes a tiny change to the number of files generated in the error of `--generate-exact`.

The log message after this PR:

```
$ ./target/debug/autocxx-gen demo/src/main.rs --inc=demo/src --outdir=/tmp --generate-exact 1 --gen-cpp
Error:
  x 2 files were generated. Increase the value passed to --generate-exact or reduce the number of include_cpp! sections.
```

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR