### PR TITLE
Add an option to `autocxx_gen` to create `cxx.h`

### DIFF
--- a/engine/src/builder.rs
+++ b/engine/src/builder.rs
@@ -11,7 +11,7 @@ use miette::Diagnostic;
 use thiserror::Error;
 
 use crate::{generate_rs_single, CodegenOptions};
-use crate::{strip_system_headers, CppCodegenOptions, ParseError, RebuildDependencyRecorder};
+use crate::{get_cxx_header_bytes, CppCodegenOptions, ParseError, RebuildDependencyRecorder};
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs::File;
@@ -221,7 +221,7 @@ impl<CTX: BuilderContext> Builder<'_, CTX> {
         write_to_file(
             &incdir,
             "cxx.h",
-            &Self::get_cxx_header_bytes(
+            &get_cxx_header_bytes(
                 self.codegen_options
                     .cpp_codegen_options
                     .suppress_system_headers,
@@ -276,10 +276,6 @@ impl<CTX: BuilderContext> Builder<'_, CTX> {
         } else {
             Ok(BuilderSuccess(builder, generated_rs, generated_cpp))
         }
-    }
-
-    fn get_cxx_header_bytes(suppress_system_headers: bool) -> Vec<u8> {
-        strip_system_headers(crate::HEADER.as_bytes().to_vec(), suppress_system_headers)
     }
 }
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -614,7 +614,11 @@ pub fn do_cxx_cpp_generation(
     })
 }
 
-pub(crate) fn strip_system_headers(input: Vec<u8>, suppress_system_headers: bool) -> Vec<u8> {
+pub fn get_cxx_header_bytes(suppress_system_headers: bool) -> Vec<u8> {
+    strip_system_headers(cxx_gen::HEADER.as_bytes().to_vec(), suppress_system_headers)
+}
+
+fn strip_system_headers(input: Vec<u8>, suppress_system_headers: bool) -> Vec<u8> {
     if suppress_system_headers {
         std::str::from_utf8(&input)
             .unwrap()

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -11,8 +11,8 @@
 mod depfile;
 
 use autocxx_engine::{
-    generate_rs_archive, generate_rs_single, parse_file, AutocxxgenHeaderNamer, CxxgenHeaderNamer,
-    RebuildDependencyRecorder,
+    generate_rs_archive, generate_rs_single, get_cxx_header_bytes, parse_file,
+    AutocxxgenHeaderNamer, CxxgenHeaderNamer, RebuildDependencyRecorder,
 };
 use clap::{crate_authors, crate_version, Arg, ArgGroup, Command};
 use depfile::Depfile;
@@ -177,6 +177,11 @@ fn main() -> miette::Result<()> {
                 .takes_value(true),
         )
         .arg(
+            Arg::new("generate-cxx-h")
+                .long("generate-cxx-h")
+                .help("whether to generate cxx.h header file. If you already knew where to find cxx.h, consider using --cxx-h-path")
+        )
+        .arg(
             Arg::new("cxx-h-path")
                 .long("cxx-h-path")
                 .value_name("PREFIX")
@@ -332,6 +337,14 @@ fn main() -> miette::Result<()> {
             name_autocxxgen_h,
         )?;
     }
+
+    if matches.is_present("generate-cxx-h") {
+        writer.write_to_file(
+            "cxx.h".to_string(),
+            &get_cxx_header_bytes(suppress_system_headers),
+        )?;
+    }
+
     if matches.is_present("gen-rs-include") {
         if !matches.is_present("fix-rs-include-name") && desired_number.is_some() {
             return Err(miette::Report::msg(

--- a/gen/cmd/tests/cmd_test.rs
+++ b/gen/cmd/tests/cmd_test.rs
@@ -88,7 +88,8 @@ where
         .arg(demo_code_dir.to_str().unwrap())
         .arg("--outdir")
         .arg(tmp_dir.path().to_str().unwrap())
-        .arg("--gen-cpp");
+        .arg("--gen-cpp")
+        .arg("--generate-cxx-h");
     cmd.arg(match rs_gen_mode {
         RsGenMode::Single => "--gen-rs-include",
         RsGenMode::Archive => "--gen-rs-archive",
@@ -109,8 +110,6 @@ where
 fn test_gen() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Single, |_| {})?;
-    File::create(tmp_dir.path().join("cxx.h"))
-        .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
     std::env::set_var("OUT_DIR", tmp_dir.path().to_str().unwrap());
     let r = build_from_folder(
         tmp_dir.path(),
@@ -130,8 +129,6 @@ fn test_gen() -> Result<(), Box<dyn std::error::Error>> {
 fn test_gen_archive() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Archive, |_| {})?;
-    File::create(tmp_dir.path().join("cxx.h"))
-        .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
     let r = build_from_folder(
         tmp_dir.path(),
         &tmp_dir.path().join("demo/main.rs"),
@@ -150,8 +147,6 @@ fn test_gen_archive() -> Result<(), Box<dyn std::error::Error>> {
 fn test_gen_archive_first_entry() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Archive, |_| {})?;
-    File::create(tmp_dir.path().join("cxx.h"))
-        .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
     let r = build_from_folder(
         tmp_dir.path(),
         &tmp_dir.path().join("demo/main.rs"),
@@ -176,8 +171,6 @@ fn test_gen_archive_first_entry() -> Result<(), Box<dyn std::error::Error>> {
 fn test_gen_archive_second_entry() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = tempdir()?;
     base_test(&tmp_dir, RsGenMode::Archive, |_| {})?;
-    File::create(tmp_dir.path().join("cxx.h"))
-        .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
     let r = build_from_folder(
         tmp_dir.path(),
         &tmp_dir.path().join("demo/main.rs"),
@@ -217,8 +210,6 @@ fn test_gen_multiple_in_archive() -> Result<(), Box<dyn std::error::Error>> {
         files,
         vec!["directive1.rs", "directive2.rs"],
     )?;
-    File::create(tmp_dir.path().join("cxx.h"))
-        .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
     // We've asked to create 8 C++ files, mostly blank. Build 'em all.
     let cpp_files = (0..7).map(|id| format!("gen{id}.cc")).collect_vec();
     let cpp_files = cpp_files.iter().map(|s| s.as_str()).collect_vec();
@@ -273,8 +264,6 @@ fn test_gen_fixed_num() -> Result<(), Box<dyn std::error::Error>> {
     assert_not_contentful(&tmp_dir, "autocxxgen1.h");
     assert_contentful(&tmp_dir, "gen0.include.rs");
     assert_contentful(&tmp_dir, "test.d");
-    File::create(tmp_dir.path().join("cxx.h"))
-        .and_then(|mut cxx_h| cxx_h.write_all(autocxx_engine::HEADER.as_bytes()))?;
     let r = build_from_folder(
         tmp_dir.path(),
         &tmp_dir.path().join("demo/main.rs"),


### PR DESCRIPTION
Fixes https://github.com/google/autocxx/issues/1246

This patch adds an additional command line option to `autocxx_gen` to create `cxx.h`.

Currently `cxx.h` needs to be present and `autocxx_gen` specifies the location of `cxx.h`.
This patch allows users to generate `cxx.h` like `autocxx_build`.

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR
