### PR TITLE
Fix soundness issue due to moveit DerefMove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,8 +961,7 @@ dependencies = [
 [[package]]
 name = "moveit"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d756ffe4e38013507d35bf726a93fcdae2cae043ab5ce477f13857a335030d"
+source = "git+https://github.com/silvanshade/moveit?branch=fix-deref-move-soundness-hole#a58583572255ec36bff49416f754f01291ccc927"
 dependencies = [
  "cxx",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,9 @@ moveit = { version = "0.5", features = [ "cxx" ] }
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce", "tools/mdbook-preprocessor", "integration-tests"]
 exclude = ["examples/s2", "examples/steam-mini", "examples/subclass", "examples/chromium-fake-render-frame-host", "examples/pod", "examples/non-trivial-type-on-stack", "examples/llvm", "examples/reference-wrappers", "examples/cpp_calling_rust", "tools/stress-test"]
 
-#[patch.crates-io]
+[patch.crates-io]
 #cxx = { path="../cxx" }
 #cxx-gen = { path="../cxx/gen/lib" }
 #autocxx-bindgen = { path="../bindgen" }
 #moveit = { path="../moveit" }
+moveit = { git = "https://github.com/silvanshade/moveit", branch = "fix-deref-move-soundness-hole" }

--- a/src/value_param.rs
+++ b/src/value_param.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use cxx::{memory::UniquePtrTarget, UniquePtr};
-use moveit::{CopyNew, DerefMove, MoveNew, New};
+use moveit::{AsMove, CopyNew, MoveNew, New};
 use std::{marker::PhantomPinned, mem::MaybeUninit, ops::Deref, pin::Pin};
 
 /// A trait representing a parameter to a C++ function which is received
@@ -205,9 +205,9 @@ where
 }
 
 /// Explicitly force a value parameter to be taken usign C++ move semantics.
-pub fn as_mov<P: DerefMove + Deref<Target = T>, T>(ptr: P) -> impl ValueParam<T>
+pub fn as_mov<P, T>(ptr: impl AsMove<P>) -> impl ValueParam<T>
 where
-    P: DerefMove,
+    P: Deref<Target = T>,
     P::Target: MoveNew,
 {
     ByNew(crate::moveit::new::mov(ptr))


### PR DESCRIPTION
This is a companion PR to https://github.com/google/moveit/pull/37.

Some background on this:

I recently started working on some rather complicated bindings to parts of LLVM and was originally using plain `cxx` but decided to try `autocxx` to hopefully save some time and generate more complete bindings.

The new machinery in `autocxx` relating to constructors seems very interesting and powerful, but I noticed (when I was trying to understand originally how to use it), that I was able to do some suspicious things, like create a new instance of some unpin type `T: !Unpin` as a `Pin<MoveRef<T>>`, but then actually get a `T` back out with a combination of `&move *val` followed by `MakeRef::into_inner`.

This didn't seem like it should be possible without `unsafe` and after a bit of searching I saw https://github.com/google/moveit/issues/34.

The associated PR in the `moveit` repo fixes the issue but slightly changes the interface to `mov`, hence this PR.