### PR TITLE
Fix namespaced destructors and reject unions

### DIFF
--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -152,6 +152,12 @@ impl ByValueChecker {
         let fieldlist = Self::get_field_types(def);
         for ty_id in &fieldlist {
             match self.results.get(ty_id) {
+                None if ty_id.get_final_item() == "__BindgenUnionField" => {
+                    field_safety_problem = PodState::UnsafeToBePod(format!(
+                        "Type {tyname} could not be POD because it is a union"
+                    ));
+                    break;
+                }
                 None => {
                     field_safety_problem = PodState::UnsafeToBePod(format!(
                         "Type {tyname} could not be POD because its dependent type {ty_id} isn't known"

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -10,7 +10,7 @@ use crate::{
     conversion::{
         api::{AnalysisPhase, Api, ApiName, NullPhase, TypedefKind, UnanalyzedApi},
         apivec::ApiVec,
-        codegen_cpp::type_to_cpp::type_to_cpp,
+        codegen_cpp::type_to_cpp::CppNameMap,
         ConvertErrorFromCpp,
     },
     known_types::{known_types, CxxGenericType},
@@ -130,6 +130,7 @@ pub(crate) struct TypeConverter<'a> {
     forward_declarations: HashSet<QualifiedName>,
     ignored_types: HashSet<QualifiedName>,
     config: &'a IncludeCppConfig,
+    original_name_map: CppNameMap,
 }
 
 impl<'a> TypeConverter<'a> {
@@ -144,6 +145,7 @@ impl<'a> TypeConverter<'a> {
             forward_declarations: Self::find_incomplete_types(apis),
             ignored_types: Self::find_ignored_types(apis),
             config,
+            original_name_map: CppNameMap::new_from_apis(apis),
         }
     }
 
@@ -521,7 +523,7 @@ impl<'a> TypeConverter<'a> {
         // We just use this as a hash key, essentially.
         // TODO: Once we've completed the TypeConverter refactoring (see #220),
         // pass in an actual original_name_map here.
-        let cpp_definition = type_to_cpp(rs_definition, &HashMap::new())?;
+        let cpp_definition = self.original_name_map.type_to_cpp(rs_definition)?;
         let e = self.concrete_templates.get(&cpp_definition);
         match e {
             Some(tn) => Ok((tn.clone(), None)),

--- a/engine/src/conversion/codegen_cpp/function_wrapper_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/function_wrapper_cpp.rs
@@ -14,7 +14,7 @@ use crate::conversion::{
     ConvertErrorFromCpp,
 };
 
-use super::type_to_cpp::{type_to_cpp, CppNameMap};
+use super::type_to_cpp::CppNameMap;
 
 impl TypeConversionPolicy {
     pub(super) fn unconverted_type(
@@ -49,7 +49,7 @@ impl TypeConversionPolicy {
                 Ok(format!(
                     "{}{}*",
                     const_string,
-                    type_to_cpp(ty, cpp_name_map)?
+                    cpp_name_map.type_to_cpp(ty)?
                 ))
             }
             _ => self.unwrapped_type_as_string(cpp_name_map),
@@ -60,7 +60,7 @@ impl TypeConversionPolicy {
         &self,
         cpp_name_map: &CppNameMap,
     ) -> Result<String, ConvertErrorFromCpp> {
-        type_to_cpp(self.cxxbridge_type(), cpp_name_map)
+        cpp_name_map.type_to_cpp(self.cxxbridge_type())
     }
 
     pub(crate) fn is_a_pointer(&self) -> Pointerness {

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -483,12 +483,19 @@ impl<'a> CppCodeGenerator<'a> {
                 CppFunctionBody::Destructor(ns, id) => {
                     let full_name = QualifiedName::new(ns, id.clone());
                     let ty_id = self.original_name_map.get_final_item(&full_name);
-                    let full_name = self.original_name_map.map(&full_name);
-                    (
-                        format!("{arg_list}->{full_name}::~{ty_id}()"),
-                        "".to_string(),
-                        false,
-                    )
+                    let destructor_call = format!("{arg_list}->{ty_id}::~{ty_id}()");
+                    let destructor_call = if ns.is_empty() {
+                        destructor_call
+                    } else {
+                        // Annoyingly, there seems to be no way to fully qualify
+                        // a destructor name for an unnamed struct (e.g.
+                        // typedef struct { .. } A) if it's in a namepace.
+                        // We have to bring the type into scope so we can call
+                        // its destructor name.
+                        let path = self.original_name_map.map(&full_name);
+                        format!("{{ using {path}; {destructor_call}; }}")
+                    };
+                    (destructor_call, "".to_string(), false)
                 }
                 CppFunctionBody::FunctionCall(ns, id) => match receiver {
                     Some(receiver) => (

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -483,9 +483,7 @@ impl<'a> CppCodeGenerator<'a> {
                 CppFunctionBody::Destructor(ns, id) => {
                     let full_name = QualifiedName::new(ns, id.clone());
                     let ty_id = self.original_name_map.get_final_item(&full_name);
-                    let full_name = self
-                        .original_name_map
-                        .namespaced_name_using_original_name_map(&full_name);
+                    let full_name = self.original_name_map.map(&full_name);
                     (
                         format!("{arg_list}->{full_name}::~{ty_id}()"),
                         "".to_string(),
@@ -602,8 +600,7 @@ impl<'a> CppCodeGenerator<'a> {
     }
 
     fn namespaced_name(&self, name: &QualifiedName) -> String {
-        self.original_name_map
-            .namespaced_name_using_original_name_map(name)
+        self.original_name_map.map(name)
     }
 
     fn generate_ctype_typedef(&mut self, tn: &QualifiedName) {

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -493,7 +493,7 @@ impl<'a> CppCodeGenerator<'a> {
                         // We have to bring the type into scope so we can call
                         // its destructor name.
                         let path = self.original_name_map.map(&full_name);
-                        format!("{{ using {path}; {destructor_call}; }}")
+                        format!("{{ using {ty_id} = {path}; {destructor_call}; }}")
                     };
                     (destructor_call, "".to_string(), false)
                 }

--- a/engine/src/conversion/codegen_cpp/type_to_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/type_to_cpp.rs
@@ -19,121 +19,132 @@ use syn::{Token, Type};
 /// Map from QualifiedName to original C++ name. Original C++ name does not
 /// include the namespace; this can be assumed to be the same as the namespace
 /// in the QualifiedName.
-pub(crate) type CppNameMap = HashMap<QualifiedName, String>;
+/// The "original C++ name" is mostly relevant in the case of nested types,
+/// where the typename might be A::B within a namespace C::D.
+pub(crate) struct CppNameMap(HashMap<QualifiedName, String>);
 
-pub(crate) fn original_name_map_from_apis<T: AnalysisPhase>(apis: &ApiVec<T>) -> CppNameMap {
-    apis.iter()
-        .filter_map(|api| {
-            api.cpp_name()
-                .as_ref()
-                .map(|cpp_name| (api.name().clone(), cpp_name.clone()))
-        })
-        .collect()
-}
-
-pub(crate) fn namespaced_name_using_original_name_map(
-    qual_name: &QualifiedName,
-    original_name_map: &CppNameMap,
-) -> String {
-    if let Some(cpp_name) = original_name_map.get(qual_name) {
-        qual_name
-            .get_namespace()
-            .iter()
-            .chain(once(cpp_name))
-            .join("::")
-    } else {
-        qual_name.to_cpp_name()
-    }
-}
-
-pub(crate) fn final_ident_using_original_name_map(
-    qual_name: &QualifiedName,
-    original_name_map: &CppNameMap,
-) -> String {
-    match original_name_map.get(qual_name) {
-        Some(original_name) => {
-            // If we have an original name, this may be a nested struct
-            // (e.g. A::B). The final ident here is just 'B' so...
-            original_name
-                .rsplit_once("::")
-                .map_or(original_name.clone(), |(_, original_name)| {
-                    original_name.to_string()
+impl CppNameMap {
+    /// Look through the APIs we've found to assemble the original name
+    /// map.
+    pub(crate) fn new_from_apis<T: AnalysisPhase>(apis: &ApiVec<T>) -> Self {
+        Self(
+            apis.iter()
+                .filter_map(|api| {
+                    api.cpp_name()
+                        .as_ref()
+                        .map(|cpp_name| (api.name().clone(), cpp_name.clone()))
                 })
-        }
-        None => qual_name.get_final_cpp_item(),
+                .collect(),
+        )
     }
-}
 
-pub(crate) fn type_to_cpp(
-    ty: &Type,
-    cpp_name_map: &CppNameMap,
-) -> Result<String, ConvertErrorFromCpp> {
-    match ty {
-        Type::Path(typ) => {
-            // If this is a std::unique_ptr we do need to pass
-            // its argument through.
-            let qual_name = QualifiedName::from_type_path(typ);
-            let root = namespaced_name_using_original_name_map(&qual_name, cpp_name_map);
-            if root == "Pin" {
-                // Strip all Pins from type names when describing them in C++.
-                let inner_type = &typ.path.segments.last().unwrap().arguments;
-                if let syn::PathArguments::AngleBracketed(ab) = inner_type {
-                    let inner_type = ab.args.iter().next().unwrap();
-                    if let syn::GenericArgument::Type(gat) = inner_type {
-                        return type_to_cpp(gat, cpp_name_map);
-                    }
-                }
-                panic!("Pin<...> didn't contain the inner types we expected");
-            }
-            let suffix = match &typ.path.segments.last().unwrap().arguments {
-                syn::PathArguments::AngleBracketed(ab) => {
-                    let results: Result<Vec<_>, _> = ab
-                        .args
-                        .iter()
-                        .map(|x| match x {
-                            syn::GenericArgument::Type(gat) => type_to_cpp(gat, cpp_name_map),
-                            _ => Ok("".to_string()),
-                        })
-                        .collect();
-                    Some(results?.join(", "))
-                }
-                syn::PathArguments::None | syn::PathArguments::Parenthesized(_) => None,
-            };
-            match suffix {
-                None => Ok(root),
-                Some(suffix) => Ok(format!("{root}<{suffix}>")),
-            }
+    /// Imagine a nested struct in namespace::outer::inner
+    /// This function converts from the bindgen name, namespace::outer_inner,
+    /// to namespace::outer::inner.
+    pub(crate) fn namespaced_name_using_original_name_map(
+        &self,
+        qual_name: &QualifiedName,
+    ) -> String {
+        if let Some(cpp_name) = self.0.get(qual_name) {
+            qual_name
+                .get_namespace()
+                .iter()
+                .chain(once(cpp_name))
+                .join("::")
+        } else {
+            qual_name.to_cpp_name()
         }
-        Type::Reference(typr) => match &*typr.elem {
-            Type::Path(typ) if typ.path.is_ident("str") => Ok("rust::Str".into()),
-            _ => Ok(format!(
-                "{}{}&",
-                get_mut_string(&typr.mutability),
-                type_to_cpp(typr.elem.as_ref(), cpp_name_map)?
+    }
+
+    /// Get a stringified version of the last ident in the name.
+    /// e.g. for namespace::outer_inner this will return inner.
+    /// This is useful for doing things such as calling constructors
+    /// such as inner() or destructors such as ~inner()
+    pub(crate) fn get_final_item<'b>(&'b self, qual_name: &'b QualifiedName) -> &'b str {
+        match self.get(qual_name) {
+            Some(n) => match n.rsplit_once("::") {
+                Some((_, suffix)) => suffix,
+                None => qual_name.get_final_item(),
+            },
+            None => qual_name.get_final_item(),
+        }
+    }
+
+    /// Convert a type to its C++ spelling.
+    pub(crate) fn type_to_cpp(&self, ty: &Type) -> Result<String, ConvertErrorFromCpp> {
+        match ty {
+            Type::Path(typ) => {
+                // If this is a std::unique_ptr we do need to pass
+                // its argument through.
+                let qual_name = QualifiedName::from_type_path(typ);
+                let root = self.namespaced_name_using_original_name_map(&qual_name);
+                if root == "Pin" {
+                    // Strip all Pins from type names when describing them in C++.
+                    let inner_type = &typ.path.segments.last().unwrap().arguments;
+                    if let syn::PathArguments::AngleBracketed(ab) = inner_type {
+                        let inner_type = ab.args.iter().next().unwrap();
+                        if let syn::GenericArgument::Type(gat) = inner_type {
+                            return self.type_to_cpp(gat);
+                        }
+                    }
+                    panic!("Pin<...> didn't contain the inner types we expected");
+                }
+                let suffix = match &typ.path.segments.last().unwrap().arguments {
+                    syn::PathArguments::AngleBracketed(ab) => {
+                        let results: Result<Vec<_>, _> = ab
+                            .args
+                            .iter()
+                            .map(|x| match x {
+                                syn::GenericArgument::Type(gat) => self.type_to_cpp(gat),
+                                _ => Ok("".to_string()),
+                            })
+                            .collect();
+                        Some(results?.join(", "))
+                    }
+                    syn::PathArguments::None | syn::PathArguments::Parenthesized(_) => None,
+                };
+                match suffix {
+                    None => Ok(root),
+                    Some(suffix) => Ok(format!("{root}<{suffix}>")),
+                }
+            }
+            Type::Reference(typr) => match &*typr.elem {
+                Type::Path(typ) if typ.path.is_ident("str") => Ok("rust::Str".into()),
+                _ => Ok(format!(
+                    "{}{}&",
+                    get_mut_string(&typr.mutability),
+                    self.type_to_cpp(typr.elem.as_ref())?
+                )),
+            },
+            Type::Ptr(typp) => Ok(format!(
+                "{}{}*",
+                get_mut_string(&typp.mutability),
+                self.type_to_cpp(typp.elem.as_ref())?
             )),
-        },
-        Type::Ptr(typp) => Ok(format!(
-            "{}{}*",
-            get_mut_string(&typp.mutability),
-            type_to_cpp(typp.elem.as_ref(), cpp_name_map)?
-        )),
-        Type::Array(_)
-        | Type::BareFn(_)
-        | Type::Group(_)
-        | Type::ImplTrait(_)
-        | Type::Infer(_)
-        | Type::Macro(_)
-        | Type::Never(_)
-        | Type::Paren(_)
-        | Type::Slice(_)
-        | Type::TraitObject(_)
-        | Type::Tuple(_)
-        | Type::Verbatim(_) => Err(ConvertErrorFromCpp::UnsupportedType(
-            ty.to_token_stream().to_string(),
-        )),
-        _ => Err(ConvertErrorFromCpp::UnknownType(
-            ty.to_token_stream().to_string(),
-        )),
+            Type::Array(_)
+            | Type::BareFn(_)
+            | Type::Group(_)
+            | Type::ImplTrait(_)
+            | Type::Infer(_)
+            | Type::Macro(_)
+            | Type::Never(_)
+            | Type::Paren(_)
+            | Type::Slice(_)
+            | Type::TraitObject(_)
+            | Type::Tuple(_)
+            | Type::Verbatim(_) => Err(ConvertErrorFromCpp::UnsupportedType(
+                ty.to_token_stream().to_string(),
+            )),
+            _ => Err(ConvertErrorFromCpp::UnknownType(
+                ty.to_token_stream().to_string(),
+            )),
+        }
+    }
+
+    /// Check an individual item in the name map. Returns a thing if
+    /// it's an inner type, otherwise returns none.
+    pub(crate) fn get(&self, name: &QualifiedName) -> Option<&String> {
+        self.0.get(name)
     }
 }
 

--- a/engine/src/conversion/codegen_cpp/type_to_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/type_to_cpp.rs
@@ -41,10 +41,7 @@ impl CppNameMap {
     /// Imagine a nested struct in namespace::outer::inner
     /// This function converts from the bindgen name, namespace::outer_inner,
     /// to namespace::outer::inner.
-    pub(crate) fn namespaced_name_using_original_name_map(
-        &self,
-        qual_name: &QualifiedName,
-    ) -> String {
+    pub(crate) fn map(&self, qual_name: &QualifiedName) -> String {
         if let Some(cpp_name) = self.0.get(qual_name) {
             qual_name
                 .get_namespace()
@@ -77,7 +74,7 @@ impl CppNameMap {
                 // If this is a std::unique_ptr we do need to pass
                 // its argument through.
                 let qual_name = QualifiedName::from_type_path(typ);
-                let root = self.namespaced_name_using_original_name_map(&qual_name);
+                let root = self.map(&qual_name);
                 if root == "Pin" {
                     // Strip all Pins from type names when describing them in C++.
                     let inner_type = &typ.path.segments.last().unwrap().arguments;

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -55,9 +55,7 @@ use super::{
 use super::{
     api::{Layout, Provenance, RustSubclassFnDetails, SuperclassMethod, TraitImplSignature},
     apivec::ApiVec,
-    codegen_cpp::type_to_cpp::{
-        namespaced_name_using_original_name_map, original_name_map_from_apis, CppNameMap,
-    },
+    codegen_cpp::type_to_cpp::CppNameMap,
 };
 use super::{convert_error::ErrorContext, ConvertErrorFromCpp};
 use quote::quote;
@@ -163,7 +161,7 @@ impl<'a> RsCodeGenerator<'a> {
             unsafe_policy,
             include_list,
             bindgen_mod,
-            original_name_map: original_name_map_from_apis(&all_apis),
+            original_name_map: CppNameMap::new_from_apis(&all_apis),
             config,
             header_name,
         };
@@ -1137,7 +1135,9 @@ impl<'a> RsCodeGenerator<'a> {
     }
 
     fn generate_extern_type_impl(&self, type_kind: TypeKind, tyname: &QualifiedName) -> Vec<Item> {
-        let tynamestring = namespaced_name_using_original_name_map(tyname, &self.original_name_map);
+        let tynamestring = self
+            .original_name_map
+            .namespaced_name_using_original_name_map(tyname);
         let fulltypath = tyname.get_bindgen_path_idents();
         let kind_item = match type_kind {
             TypeKind::Pod => "Trivial",

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -1135,9 +1135,7 @@ impl<'a> RsCodeGenerator<'a> {
     }
 
     fn generate_extern_type_impl(&self, type_kind: TypeKind, tyname: &QualifiedName) -> Vec<Item> {
-        let tynamestring = self
-            .original_name_map
-            .namespaced_name_using_original_name_map(tyname);
+        let tynamestring = self.original_name_map.map(tyname);
         let fulltypath = tyname.get_bindgen_path_idents();
         let kind_item = match type_kind {
             TypeKind::Pod => "Trivial",

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -53,11 +53,15 @@ impl Namespace {
     pub(crate) fn depth(&self) -> usize {
         self.0.len()
     }
+
+    pub(crate) fn to_cpp_path(&self) -> String {
+        self.0.join("::")
+    }
 }
 
 impl Display for Namespace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0.join("::"))
+        f.write_str(&self.to_cpp_path())
     }
 }
 
@@ -170,14 +174,6 @@ impl QualifiedName {
         match special_cpp_name {
             Some(name) => name,
             None => self.0.iter().chain(std::iter::once(&self.1)).join("::"),
-        }
-    }
-
-    pub(crate) fn get_final_cpp_item(&self) -> String {
-        let special_cpp_name = known_types().special_cpp_name(self);
-        match special_cpp_name {
-            Some(name) => Self::new_from_cpp_name(&name).1,
-            None => self.1.to_string(),
         }
     }
 

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -4981,6 +4981,77 @@ fn test_union_ignored() {
     run_test("", hdr, rs, &["B"], &[]);
 }
 
+#[test]
+fn test_union_nonpod() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    union A {
+        uint32_t a;
+        float b;
+    };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["A"], &[]);
+}
+
+#[test]
+fn test_union_pod() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    union A {
+        uint32_t a;
+        float b;
+    };
+    "};
+    let rs = quote! {};
+    run_test_expect_fail("", hdr, rs, &[], &["A"]);
+}
+
+#[test]
+fn test_type_aliased_anonymous_union_ignored() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    namespace test {
+        typedef union {
+        int a;
+        } Union;
+        };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["test::Union"], &[]);
+}
+
+#[test]
+fn test_type_aliased_anonymous_struct_ignored() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    namespace test {
+        typedef struct {
+            int a;
+        } Struct;
+        };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["test::Struct"], &[]);
+}
+
+#[test]
+fn test_type_aliased_anonymous_nested_struct_ignored() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    namespace test {
+        struct Outer {
+            typedef struct {
+                int a;
+            } Struct;
+            int b;
+        };
+    };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["test::Outer_Struct"], &[]);
+}
+
 #[ignore] // https://github.com/google/autocxx/issues/1251
 #[test]
 fn test_double_underscores_ignored() {

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5029,7 +5029,7 @@ fn test_type_aliased_anonymous_struct_ignored() {
         typedef struct {
             int a;
         } Struct;
-        };
+    };
     "};
     let rs = quote! {};
     run_test("", hdr, rs, &["test::Struct"], &[]);


### PR DESCRIPTION
This commit fixes a few issues reported in #1261 (thanks!)

Specifically,
* We were correctly refusing to generate POD bindings to unions, but we were rejecting them with a nonsensical error. We now reject with a specific message.
* Types in namespaces sometimes had misgenerated code to call their C++ destructors.

I also took the opportunity to rework `CppNameMap` slightly by making some functions members. This is primarily a textual change.

Issue #1261