### PR TITLE
fix: feature flag for runtime

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["ffi"]
 categories = ["development-tools::ffi", "api-bindings"]
 
 [features]
-default = ["reproduction_case"]
+default = ["reproduction_case", "runtime"]
 build = ["cc"]
 nightly = []                                                           # for doc generation purposes only; used by docs.rs
 reproduction_case = ["serde_json", "autocxx-parser/reproduction_case"]
@@ -30,7 +30,7 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = "=0.62.1"
+autocxx-bindgen = { version = "=0.62.1", default-features = false, features = ["logging", "which-rustfmt"] }
 #autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "merge-upstream-0.62" }
 itertools = "0.10.3"
 cc = { version = "1.0", optional = true }


### PR DESCRIPTION
Fixes #1276

explicitly specify features for `autocxx-bindgen` and disable default features such that the `runtime` is excluded from dependencies but added over the `runtime` features of this crate, to avoid having `static` feature flag conflicts with the `runtime` feature in the `autocxx-bindgen`. 


- [x] Tests pass
- [x] Appropriate changes to README are included in PR