### PR TITLE
Test and fix for 1289 ("Support for anonymous enums")

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -4240,6 +4240,29 @@ fn test_abstract_nested_type() {
 }
 
 #[test]
+fn test_nested_unnamed_enum() {
+    let hdr = indoc! {"
+        namespace N {
+            struct A {
+                enum {
+                    LOW_VAL = 1,
+                    HIGH_VAL = 1000,
+                };
+            };
+        }
+    "};
+    run_test_ex(
+        "",
+        hdr,
+        quote! {},
+        quote! { generate_ns!("N")},
+        None,
+        None,
+        None,
+    );
+}
+
+#[test]
 fn test_nested_type_constructor() {
     let hdr = indoc! {"
         #include <string>


### PR DESCRIPTION
Test and draft fix for #1289

The actual fix patch is very crude and I doubt this is the best way to do it, but it makes the tests pass at least, and I didn't have that much time to go through the `autocxx` source.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR