### PR TITLE
Reference wrapper changes

### DIFF
--- a/examples/reference-wrappers/src/main.rs
+++ b/examples/reference-wrappers/src/main.rs
@@ -38,6 +38,26 @@ include_cpp! {
     generate!("Field")
 }
 
+impl ffi::Goat {
+    // Methods can be called on a CppRef<T> or &CppRef<T>
+    fn bleat(self: CppRef<Self>) {
+        println!("Bleat");
+    }
+}
+
+trait FarmProduce {
+    // Traits can be defined on a CppRef<T> so long as Self: Sized
+    fn sell(self: &CppRef<Self>)
+    where
+        Self: Sized;
+}
+
+impl FarmProduce for ffi::Goat {
+    fn sell(self: &CppRef<Self>) {
+        println!("Selling goat");
+    }
+}
+
 fn main() {
     // Create a cxx::UniquePtr as normal for a Field object.
     let field = ffi::Field::new().within_unique_ptr();
@@ -58,6 +78,8 @@ fn main() {
     // However, we can take C++ references. And use such references
     // to call methods...
     let another_goat = field.as_cpp_ref().get_goat();
+    another_goat.clone().bleat();
+    another_goat.sell();
     // The 'get_goat' method in C++ returns a reference, so this is
     // another CppRef, not a Rust reference.
     assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 
+#![feature(dispatch_from_dyn)]
+#![feature(unsize)]
+
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-#![feature(dispatch_from_dyn)]
-#![feature(unsize)]
-
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -67,7 +67,7 @@ use cxx::{memory::UniquePtrTarget, UniquePtr};
 /// unstable Rust `arbitrary_self_types` features uses to determine callable
 /// methods. However, actually calling `Deref::deref` is not permitted and will
 /// result in a compilation failure. If you wish to create a Rust reference
-/// from the C++ reference, see [`as_ref`].
+/// from the C++ reference, see [`CppRef::as_ref`].
 ///
 /// # Nullness
 ///

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -84,7 +84,7 @@ use cxx::{memory::UniquePtrTarget, UniquePtr};
 /// Internally, this is represented as a raw pointer in Rust. See the note above
 /// about Nullness for why we don't use [`core::ptr::NonNull`].
 #[repr(transparent)]
-pub struct CppRef<'a, T> {
+pub struct CppRef<'a, T: ?Sized> {
     ptr: *const T,
     phantom: PhantomData<&'a T>,
 }
@@ -195,7 +195,7 @@ impl<'a, T> Clone for CppRef<'a, T> {
 ///
 /// You can convert this to a [`CppRef`] using the [`std::convert::Into`] trait.
 #[repr(transparent)]
-pub struct CppMutRef<'a, T> {
+pub struct CppMutRef<'a, T: ?Sized> {
     ptr: *mut T,
     phantom: PhantomData<&'a T>,
 }

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -140,9 +140,9 @@ impl<'a, T> CppRef<'a, T> {
 }
 
 impl<'a, T> core::ops::Deref for CppRef<'a, T> {
-    type Target = T;
+    type Target = *const T;
     #[inline]
-    fn deref(&self) -> &T {
+    fn deref(&self) -> &Self::Target {
         // With `inline_const` we can simplify this to:
         // const { panic!("you shouldn't deref CppRef!") }
         struct C<T>(T);
@@ -211,9 +211,9 @@ impl<'a, T> CppMutRef<'a, T> {
 }
 
 impl<'a, T> core::ops::Deref for CppMutRef<'a, T> {
-    type Target = T;
+    type Target = *const T;
     #[inline]
-    fn deref(&self) -> &T {
+    fn deref(&self) -> &Self::Target {
         // With `inline_const` we can simplify this to:
         // const { panic!("you shouldn't deref CppRef!") }
         struct C<T>(T);


### PR DESCRIPTION
The primary change here is that the `type Target` within `Deref` of a `CppRef<T>` is no longer a `&T` but instead `&*const T` because method dispatch works just as well, and it reduces the "risk" of Rust references being deemed OK.

