### PR TITLE
Newtype wrapper for more concise syn debug output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,6 @@ dependencies = [
  "regex",
  "rustversion",
  "serde_json",
- "strum_macros",
  "syn 2.0.18",
  "tempfile",
  "thiserror",
@@ -805,12 +804,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1481,19 +1474,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "supports-color"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -43,7 +43,6 @@ version_check = "0.9"
 aquamarine = "0.1"                                             # docs
 tempfile = "3.4"
 once_cell = "1.7"
-strum_macros = "0.24"
 serde_json = { version = "1.0", optional = true }
 miette = "5"
 thiserror = "1"

--- a/engine/src/conversion/analysis/allocators.rs
+++ b/engine/src/conversion/analysis/allocators.rs
@@ -18,6 +18,7 @@ use crate::{
         },
         apivec::ApiVec,
     },
+    minisyn::minisynize_punctuated,
     types::{make_ident, QualifiedName},
 };
 
@@ -76,8 +77,8 @@ fn create_alloc_and_free(ty_name: QualifiedName) -> impl Iterator<Item = Api<Pod
                 fun: Box::new(FuncToConvert {
                     ident,
                     doc_attrs: Vec::new(),
-                    inputs,
-                    output,
+                    inputs: minisynize_punctuated(inputs),
+                    output: output.into(),
                     vis: parse_quote! { pub },
                     virtualness: crate::conversion::api::Virtualness::None,
                     cpp_vis: CppVisibility::Public,

--- a/engine/src/conversion/analysis/casts.rs
+++ b/engine/src/conversion/analysis/casts.rs
@@ -6,9 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::minisyn::FnArg;
 use itertools::Itertools;
 use quote::quote;
-use syn::{parse_quote, FnArg};
+use syn::parse_quote;
 
 use crate::{
     conversion::{

--- a/engine/src/conversion/analysis/ctypes.rs
+++ b/engine/src/conversion/analysis/ctypes.rs
@@ -8,7 +8,7 @@
 
 use indexmap::map::IndexMap as HashMap;
 
-use syn::Ident;
+use crate::minisyn::Ident;
 
 use crate::conversion::api::ApiName;
 use crate::conversion::apivec::ApiVec;

--- a/engine/src/conversion/analysis/deps.rs
+++ b/engine/src/conversion/analysis/deps.rs
@@ -6,8 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use itertools::Itertools;
-
 use crate::{
     conversion::api::{Api, TypeKind},
     types::QualifiedName,
@@ -22,10 +20,6 @@ use super::{
 pub(crate) trait HasDependencies {
     fn name(&self) -> &QualifiedName;
     fn deps(&self) -> Box<dyn Iterator<Item = &QualifiedName> + '_>;
-
-    fn format_deps(&self) -> String {
-        self.deps().join(",")
-    }
 }
 
 impl HasDependencies for Api<FnPrePhase1> {

--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -8,7 +8,7 @@
 
 use indexmap::map::IndexMap as HashMap;
 
-use syn::Ident;
+use crate::minisyn::Ident;
 
 use crate::{
     conversion::{

--- a/engine/src/conversion/analysis/pod/byvalue_checker.rs
+++ b/engine/src/conversion/analysis/pod/byvalue_checker.rs
@@ -102,7 +102,7 @@ impl ByValueChecker {
                             _ => None,
                         },
                         TypedefKind::Use(_, ref ty) => match **ty {
-                            Type::Path(ref typ) => {
+                            crate::minisyn::Type(Type::Path(ref typ)) => {
                                 let target_tn = QualifiedName::from_type_path(typ);
                                 known_types().consider_substitution(&target_tn)
                             }
@@ -147,7 +147,7 @@ impl ByValueChecker {
 
     fn ingest_struct(&mut self, def: &ItemStruct, ns: &Namespace) {
         // For this struct, work out whether it _could_ be safe as a POD.
-        let tyname = QualifiedName::new(ns, def.ident.clone());
+        let tyname = QualifiedName::new(ns, def.ident.clone().into());
         let mut field_safety_problem = PodState::SafeToBePod;
         let fieldlist = Self::get_field_types(def);
         for ty_id in &fieldlist {
@@ -272,10 +272,11 @@ impl ByValueChecker {
 #[cfg(test)]
 mod tests {
     use super::ByValueChecker;
+    use crate::minisyn::ItemStruct;
     use crate::types::{Namespace, QualifiedName};
-    use syn::{parse_quote, Ident, ItemStruct};
+    use syn::parse_quote;
 
-    fn ty_from_ident(id: &Ident) -> QualifiedName {
+    fn ty_from_ident(id: &syn::Ident) -> QualifiedName {
         QualifiedName::new_from_cpp_name(&id.to_string())
     }
 

--- a/engine/src/conversion/analysis/pod/mod.rs
+++ b/engine/src/conversion/analysis/pod/mod.rs
@@ -13,7 +13,7 @@ use indexmap::set::IndexSet as HashSet;
 
 use autocxx_parser::IncludeCppConfig;
 use byvalue_checker::ByValueChecker;
-use syn::{ItemEnum, ItemStruct, Type, Visibility};
+use syn::{ItemStruct, Type, Visibility};
 
 use crate::{
     conversion::{
@@ -30,11 +30,14 @@ use crate::{
 
 use super::tdef::{TypedefAnalysis, TypedefPhase};
 
+#[derive(std::fmt::Debug)]
+
 pub(crate) struct FieldInfo {
     pub(crate) ty: Type,
     pub(crate) type_kind: type_converter::TypeKind,
 }
 
+#[derive(std::fmt::Debug)]
 pub(crate) struct PodAnalysis {
     pub(crate) kind: TypeKind,
     pub(crate) bases: HashSet<QualifiedName>,
@@ -54,6 +57,7 @@ pub(crate) struct PodAnalysis {
     pub(crate) in_anonymous_namespace: bool,
 }
 
+#[derive(std::fmt::Debug)]
 pub(crate) struct PodPhase;
 
 impl AnalysisPhase for PodPhase {
@@ -123,7 +127,7 @@ pub(crate) fn analyze_pod_apis(
 
 fn analyze_enum(
     name: ApiName,
-    mut item: ItemEnum,
+    mut item: crate::minisyn::ItemEnum,
 ) -> Result<Box<dyn Iterator<Item = Api<PodPhase>>>, ConvertErrorWithContext> {
     let metadata = BindgenSemanticAttributes::new_retaining_others(&mut item.attrs);
     metadata.check_for_fatal_attrs(&name.name.get_final_ident())?;

--- a/engine/src/conversion/analysis/tdef.rs
+++ b/engine/src/conversion/analysis/tdef.rs
@@ -24,6 +24,7 @@ use crate::{
     types::QualifiedName,
 };
 
+#[derive(std::fmt::Debug)]
 pub(crate) struct TypedefAnalysis {
     pub(crate) kind: TypedefKind,
     pub(crate) deps: HashSet<QualifiedName>,
@@ -31,6 +32,7 @@ pub(crate) struct TypedefAnalysis {
 
 /// Analysis phase where typedef analysis has been performed but no other
 /// analyses just yet.
+#[derive(std::fmt::Debug)]
 pub(crate) struct TypedefPhase;
 
 impl AnalysisPhase for TypedefPhase {
@@ -57,7 +59,7 @@ pub(crate) fn convert_typedef_targets(
             Ok(Box::new(std::iter::once(match item {
                 TypedefKind::Type(ity) => get_replacement_typedef(
                     name,
-                    ity,
+                    ity.into(),
                     old_tyname,
                     &mut type_converter,
                     &mut extra_apis,
@@ -116,10 +118,10 @@ fn get_replacement_typedef(
             extra_apis.append(&mut final_type.extra_apis);
             Ok(Api::Typedef {
                 name,
-                item: TypedefKind::Type(ity),
+                item: TypedefKind::Type(ity.into()),
                 old_tyname,
                 analysis: TypedefAnalysis {
-                    kind: TypedefKind::Type(converted_type),
+                    kind: TypedefKind::Type(converted_type.into()),
                     deps: final_type.types_encountered,
                 },
             })

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -34,7 +34,7 @@ use super::tdef::TypedefAnalysis;
 pub(crate) enum TypeKind {
     Regular,
     Pointer,
-    SubclassHolder(Ident),
+    SubclassHolder(crate::minisyn::Ident),
     Reference,
     RValueReference,
     MutableReference,
@@ -556,7 +556,7 @@ impl<'a> TypeConverter<'a> {
                 let api = UnanalyzedApi::ConcreteType {
                     name: ApiName::new_in_root_namespace(make_ident(synthetic_ident)),
                     cpp_definition: cpp_definition.clone(),
-                    rs_definition: Some(Box::new(rs_definition.clone())),
+                    rs_definition: Some(Box::new(rs_definition.clone().into())),
                 };
                 self.concrete_templates
                     .insert(cpp_definition, api.name().clone());

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -34,6 +34,7 @@ use crate::{
         },
         api::{Pointerness, UnsafetyNeeded},
     },
+    minisyn::minisynize_vec,
     types::{Namespace, QualifiedName},
 };
 use crate::{
@@ -104,7 +105,7 @@ pub(super) fn gen_function(
     let params = analysis.params;
     let vis = analysis.vis;
     let kind = analysis.kind;
-    let doc_attrs = fun.doc_attrs;
+    let doc_attrs = minisynize_vec(fun.doc_attrs);
 
     let mut cpp_name_attr = Vec::new();
     let mut impl_entry = None;
@@ -169,10 +170,10 @@ pub(super) fn gen_function(
         FnKind::Method { .. } | FnKind::TraitMethod { .. } => None,
         FnKind::Function => match analysis.rust_rename_strategy {
             _ if analysis.rust_wrapper_needed => {
-                Some(Use::SpecificNameFromBindgen(make_ident(rust_name)))
+                Some(Use::SpecificNameFromBindgen(make_ident(rust_name).into()))
             }
             RustRenameStrategy::RenameInOutputMod(ref alias) => {
-                Some(Use::UsedFromCxxBridgeWithAlias(alias.clone()))
+                Some(Use::UsedFromCxxBridgeWithAlias(alias.clone().into()))
             }
             _ => Some(Use::UsedFromCxxBridge),
         },
@@ -262,10 +263,10 @@ impl<'a> FnGenerator<'a> {
         let mut any_conversion_requires_unsafe = false;
         let mut variable_counter = 0usize;
         for pd in self.param_details {
-            let wrapper_arg_name = if pd.self_type.is_some() && !avoid_self {
+            let wrapper_arg_name: syn::Pat = if pd.self_type.is_some() && !avoid_self {
                 parse_quote!(self)
             } else {
-                pd.name.clone()
+                pd.name.clone().into()
             };
             let rust_for_param = pd
                 .conversion

--- a/engine/src/conversion/convert_error.rs
+++ b/engine/src/conversion/convert_error.rs
@@ -8,10 +8,10 @@
 
 use indexmap::set::IndexSet as HashSet;
 
+use crate::minisyn::Ident;
 use itertools::Itertools;
 use miette::{Diagnostic, SourceSpan};
 use proc_macro2::Span;
-use syn::Ident;
 use thiserror::Error;
 
 use crate::{
@@ -201,17 +201,17 @@ impl LocatedConvertErrorFromRust {
 
 /// Ensures that error contexts are always created using the constructors in this
 /// mod, therefore undergoing identifier sanitation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct PhantomSanitized;
 
 /// The context of an error, e.g. whether it applies to a function or a method.
 /// This is used to generate suitable rustdoc in the output codegen so that
 /// the errors can be revealed in rust-analyzer-based IDEs, etc.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct ErrorContext(Box<ErrorContextType>, PhantomSanitized);
 
 /// All idents in this structure are guaranteed to be something we can safely codegen for.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum ErrorContextType {
     Item(Ident),
     SanitizedItem(Ident),

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use syn::ItemEnum;
+use crate::minisyn::ItemEnum;
 
 use super::{
     api::{AnalysisPhase, Api, ApiName, FuncToConvert, StructDetails, TypedefKind},

--- a/engine/src/conversion/mod.rs
+++ b/engine/src/conversion/mod.rs
@@ -28,9 +28,7 @@ use convert_error::ConvertErrorFromCpp;
 use itertools::Itertools;
 use syn::{Item, ItemMod};
 
-use crate::{
-    conversion::analysis::deps::HasDependencies, CodegenOptions, CppFilePair, UnsafePolicy,
-};
+use crate::{CodegenOptions, CppFilePair, UnsafePolicy};
 
 use self::{
     analysis::{
@@ -39,7 +37,6 @@ use self::{
         casts::add_casts,
         check_names,
         constructor_deps::decorate_types_with_constructor_deps,
-        fun::FnPhase,
         gc::filter_apis_by_following_edges_from_allowlist,
         pod::analyze_pod_apis,
         remove_ignored::filter_apis_by_ignored_dependents,
@@ -89,23 +86,10 @@ impl<'a> BridgeConverter<'a> {
     fn dump_apis<T: AnalysisPhase>(label: &str, apis: &ApiVec<T>) {
         if LOG_APIS {
             log::info!(
-                "APIs after {}:\n{}",
+                "##### APIs after {}:\n{}",
                 label,
                 apis.iter()
                     .map(|api| { format!("  {api:?}") })
-                    .sorted()
-                    .join("\n")
-            )
-        }
-    }
-
-    fn dump_apis_with_deps(label: &str, apis: &ApiVec<FnPhase>) {
-        if LOG_APIS {
-            log::info!(
-                "APIs after {}:\n{}",
-                label,
-                apis.iter()
-                    .map(|api| { format!("  {:?}, deps={}", api, api.format_deps()) })
                     .sorted()
                     .join("\n")
             )
@@ -174,9 +158,9 @@ impl<'a> BridgeConverter<'a> {
                 // Annotate structs with a note of any copy/move constructors which
                 // we may want to retain to avoid garbage collecting them later.
                 let analyzed_apis = decorate_types_with_constructor_deps(analyzed_apis);
-                Self::dump_apis_with_deps("adding constructor deps", &analyzed_apis);
+                Self::dump_apis("adding constructor deps", &analyzed_apis);
                 let analyzed_apis = discard_ignored_functions(analyzed_apis);
-                Self::dump_apis_with_deps("ignoring ignorable fns", &analyzed_apis);
+                Self::dump_apis("ignoring ignorable fns", &analyzed_apis);
                 // Remove any APIs whose names are not compatible with cxx.
                 let analyzed_apis = check_names(analyzed_apis);
                 // During parsing or subsequent processing we might have encountered
@@ -184,14 +168,14 @@ impl<'a> BridgeConverter<'a> {
                 // There might be other items depending on such things. Let's remove them
                 // too.
                 let analyzed_apis = filter_apis_by_ignored_dependents(analyzed_apis);
-                Self::dump_apis_with_deps("removing ignored dependents", &analyzed_apis);
+                Self::dump_apis("removing ignored dependents", &analyzed_apis);
 
                 // We now garbage collect the ones we don't need...
                 let mut analyzed_apis =
                     filter_apis_by_following_edges_from_allowlist(analyzed_apis, self.config);
                 // Determine what variably-sized C types (e.g. int) we need to include
                 analysis::ctypes::append_ctype_information(&mut analyzed_apis);
-                Self::dump_apis_with_deps("GC", &analyzed_apis);
+                Self::dump_apis("GC", &analyzed_apis);
                 // And finally pass them to the code gen phases, which outputs
                 // code suitable for cxx to consume.
                 let cxxgen_header_name = codegen_options

--- a/engine/src/conversion/parse/bindgen_semantic_attributes.rs
+++ b/engine/src/conversion/parse/bindgen_semantic_attributes.rs
@@ -59,12 +59,12 @@ impl BindgenSemanticAttributes {
         if self.has_attr("unused_template_param") {
             Err(ConvertErrorWithContext(
                 ConvertErrorFromCpp::UnusedTemplateParam,
-                Some(ErrorContext::new_for_item(id_for_context.clone())),
+                Some(ErrorContext::new_for_item(id_for_context.clone().into())),
             ))
         } else if self.get_cpp_visibility() != CppVisibility::Public {
             Err(ConvertErrorWithContext(
                 ConvertErrorFromCpp::NonPublicNestedType,
-                Some(ErrorContext::new_for_item(id_for_context.clone())),
+                Some(ErrorContext::new_for_item(id_for_context.clone().into())),
             ))
         } else {
             Ok(())
@@ -154,12 +154,12 @@ impl BindgenSemanticAttributes {
             } else if a.is_ident("arg_type_reference") {
                 let r: Result<Ident, syn::Error> = a.parse_args();
                 if let Ok(ls) = r {
-                    results.ref_params.insert(ls);
+                    results.ref_params.insert(ls.into());
                 }
             } else if a.is_ident("arg_type_rvalue_reference") {
                 let r: Result<Ident, syn::Error> = a.parse_args();
                 if let Ok(ls) = r {
-                    results.rvalue_ref_params.insert(ls);
+                    results.rvalue_ref_params.insert(ls.into());
                 }
             }
         }

--- a/engine/src/conversion/parse/parse_foreign_mod.rs
+++ b/engine/src/conversion/parse/parse_foreign_mod.rs
@@ -15,6 +15,7 @@ use crate::conversion::{
     convert_error::ConvertErrorWithContext,
     convert_error::ErrorContext,
 };
+use crate::minisyn::{minisynize_punctuated, minisynize_vec};
 use crate::{
     conversion::ConvertErrorFromCpp,
     types::{Namespace, QualifiedName},
@@ -72,11 +73,11 @@ impl ParseForeignMod {
                 self.funcs_to_convert.push(FuncToConvert {
                     provenance: Provenance::Bindgen,
                     self_ty: None,
-                    ident: item.sig.ident,
-                    doc_attrs,
-                    inputs: item.sig.inputs,
-                    output: item.sig.output,
-                    vis: item.vis,
+                    ident: item.sig.ident.into(),
+                    doc_attrs: minisynize_vec(doc_attrs),
+                    inputs: minisynize_punctuated(item.sig.inputs),
+                    output: item.sig.output.into(),
+                    vis: item.vis.into(),
                     virtualness: annotations.get_virtualness(),
                     cpp_vis: annotations.get_cpp_visibility(),
                     special_member: annotations.special_member_kind(),
@@ -94,7 +95,7 @@ impl ParseForeignMod {
             }
             ForeignItem::Static(item) => Err(ConvertErrorWithContext(
                 ConvertErrorFromCpp::StaticData(item.ident.to_string()),
-                Some(ErrorContext::new_for_item(item.ident)),
+                Some(ErrorContext::new_for_item(item.ident.into())),
             )),
             _ => Err(ConvertErrorWithContext(
                 ConvertErrorFromCpp::UnexpectedForeignItem,
@@ -118,7 +119,7 @@ impl ParseForeignMod {
                 };
                 self.method_receivers.insert(
                     effective_fun_name,
-                    QualifiedName::new(&self.ns, ty_id.clone()),
+                    QualifiedName::new(&self.ns, ty_id.clone().into()),
                 );
             }
         }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -17,6 +17,7 @@ mod ast_discoverer;
 mod conversion;
 mod cxxbridge;
 mod known_types;
+mod minisyn;
 mod output_generators;
 mod parse_callbacks;
 mod parse_file;

--- a/engine/src/minisyn.rs
+++ b/engine/src/minisyn.rs
@@ -1,0 +1,187 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Newtype wrappers for `syn` types implementing a different
+//! `Debug` implementation that results in more concise output.
+
+use std::fmt::Display;
+
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::punctuated::{Pair, Punctuated};
+
+macro_rules! minisyn_no_parse {
+    ($syntype:ident) => {
+        /// Equivalent to the identically-named `syn` type except
+        /// that its `Debug` implementation is more concise.
+        #[derive(Clone, Hash, Eq, PartialEq)]
+        pub struct $syntype(pub ::syn::$syntype);
+        impl std::fmt::Debug for $syntype {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                write!(f, "{}", self.0.to_token_stream().to_string())
+            }
+        }
+        impl ToTokens for $syntype
+        where
+            ::syn::$syntype: ToTokens,
+        {
+            fn to_tokens(&self, tokens: &mut TokenStream) {
+                self.0.to_tokens(tokens)
+            }
+
+            fn to_token_stream(&self) -> TokenStream {
+                self.0.to_token_stream()
+            }
+            fn into_token_stream(self) -> TokenStream
+            where
+                Self: Sized,
+            {
+                self.0.into_token_stream()
+            }
+        }
+        impl std::ops::Deref for $syntype {
+            type Target = ::syn::$syntype;
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+        impl std::ops::DerefMut for $syntype {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+        impl std::convert::From<::syn::$syntype> for $syntype {
+            fn from(inner: ::syn::$syntype) -> Self {
+                Self(inner)
+            }
+        }
+        impl std::convert::From<$syntype> for syn::$syntype {
+            fn from(inner: $syntype) -> Self {
+                inner.0
+            }
+        }
+    };
+}
+
+macro_rules! minisyn {
+    ($syntype:ident) => {
+        minisyn_no_parse!($syntype);
+
+        impl syn::parse::Parse for $syntype {
+            fn parse(input: syn::parse::ParseStream<'_>) -> syn::parse::Result<Self> {
+                syn::parse::Parse::parse(input).map(Self)
+            }
+        }
+    };
+}
+
+minisyn!(ItemMod);
+minisyn_no_parse!(Attribute);
+minisyn_no_parse!(AssocConst);
+minisyn_no_parse!(AssocType);
+minisyn!(Expr);
+minisyn!(ExprAssign);
+minisyn!(ExprAwait);
+minisyn!(ExprBinary);
+minisyn!(ExprBlock);
+minisyn!(ExprBreak);
+minisyn!(ExprConst);
+minisyn!(ExprCast);
+minisyn!(ExprField);
+minisyn_no_parse!(ExprGroup);
+minisyn!(ExprLet);
+minisyn!(ExprParen);
+minisyn!(ExprReference);
+minisyn!(ExprTry);
+minisyn!(ExprUnary);
+minisyn_no_parse!(Field);
+minisyn_no_parse!(Fields);
+minisyn!(ForeignItem);
+minisyn!(FnArg);
+minisyn!(GenericArgument);
+minisyn!(GenericParam);
+minisyn!(Ident);
+minisyn!(ImplItem);
+minisyn!(Item);
+minisyn!(ItemConst);
+minisyn!(ItemEnum);
+minisyn!(ItemForeignMod);
+minisyn!(ItemStruct);
+minisyn!(ItemType);
+minisyn!(ItemUse);
+minisyn!(LitBool);
+minisyn!(LitInt);
+minisyn!(Macro);
+minisyn_no_parse!(Pat);
+minisyn_no_parse!(PatType);
+minisyn_no_parse!(PatReference);
+minisyn_no_parse!(PatSlice);
+minisyn_no_parse!(PatTuple);
+minisyn!(Path);
+minisyn_no_parse!(PathArguments);
+minisyn!(PathSegment);
+minisyn!(Receiver);
+minisyn!(ReturnType);
+minisyn!(Signature);
+minisyn!(Stmt);
+minisyn!(TraitItem);
+minisyn!(Type);
+minisyn!(TypeArray);
+minisyn!(TypeGroup);
+minisyn!(TypeParamBound);
+minisyn!(TypeParen);
+minisyn!(TypePath);
+minisyn!(TypePtr);
+minisyn!(TypeReference);
+minisyn!(TypeSlice);
+minisyn!(Visibility);
+
+/// Converts a `syn::Punctuated` from being full of `syn` types to being
+/// full of `minisyn` types or vice-versa.
+pub(crate) fn minisynize_punctuated<T1, T2, S>(input: Punctuated<T1, S>) -> Punctuated<T2, S>
+where
+    T1: Into<T2>,
+{
+    input
+        .into_pairs()
+        .map(|p| match p {
+            Pair::Punctuated(t, p) => Pair::Punctuated(t.into(), p),
+            Pair::End(t) => Pair::End(t.into()),
+        })
+        .collect()
+}
+
+/// Converts a `Vec` from being full of `syn` types to being
+/// full of `minisyn` types or vice-versa.
+pub(crate) fn minisynize_vec<T1, T2>(input: Vec<T1>) -> Vec<T2>
+where
+    T1: Into<T2>,
+{
+    input.into_iter().map(Into::into).collect()
+}
+
+impl Ident {
+    pub(crate) fn new(string: &str, span: proc_macro2::Span) -> Self {
+        Self(syn::Ident::new(string, span))
+    }
+}
+
+impl Display for Ident {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.to_string())
+    }
+}
+
+impl<T> PartialEq<T> for Ident
+where
+    T: AsRef<str> + ?Sized,
+{
+    fn eq(&self, rhs: &T) -> bool {
+        self.0.eq(rhs)
+    }
+}

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -6,12 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::minisyn::Ident;
 use itertools::Itertools;
 use proc_macro2::Span;
 use quote::ToTokens;
 use std::iter::Peekable;
 use std::{fmt::Display, sync::Arc};
-use syn::{parse_quote, Ident, PathSegment, TypePath};
+use syn::{parse_quote, PathSegment, TypePath};
 use thiserror::Error;
 
 use crate::known_types::known_types;
@@ -85,7 +86,7 @@ impl<'a> IntoIterator for &'a Namespace {
 /// either. It doesn't directly have functionality to convert
 /// from one to the other; `replace_type_path_without_arguments`
 /// does that.
-#[derive(Debug, PartialEq, PartialOrd, Eq, Hash, Clone)]
+#[derive(PartialEq, PartialOrd, Eq, Hash, Clone)]
 pub struct QualifiedName(Namespace, String);
 
 impl QualifiedName {
@@ -222,6 +223,12 @@ impl Display for QualifiedName {
             f.write_str("::")?;
         }
         f.write_str(&self.1)
+    }
+}
+
+impl std::fmt::Debug for QualifiedName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
This improves our internal debug logging substantially, so that all details of each API are recorded at every stage of conversion. Previously this was impractical due to the extreme verbosity of syn's Debug implementation. This change wraps every stored syn type in a newtype wrapper which uses to_tokens() to produce more concise Debug output.