### PR TITLE
Attempt to better name overloads

### DIFF
--- a/engine/src/conversion/analysis/fun/overload_tracker.rs
+++ b/engine/src/conversion/analysis/fun/overload_tracker.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashMap;
+use indexmap::IndexMap as HashMap;
 
 type Offsets = HashMap<String, usize>;
 

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -2280,8 +2280,28 @@ fn test_overload_functions() {
 }
 
 #[test]
-#[ignore] // At present, bindgen generates two separate 'daft1'
-          // functions here, and there's not much we can do about that.
+fn test_overload_single_numeric_function() {
+    let cxx = indoc! {"
+        void daft1(uint32_t) {}
+        void daft(float) {}
+        void daft(uint32_t) {}
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        void daft1(uint32_t a);
+        void daft(uint32_t a);
+        void daft(float a);
+    "};
+    let rs = quote! {
+        use ffi::ToCppString;
+        ffi::daft(32);
+        ffi::daft1(8);
+        ffi::daft_autocxx_overload1(3.2);
+    };
+    run_test(cxx, hdr, rs, &["daft", "daft1"], &[]);
+}
+
+#[test]
 fn test_overload_numeric_functions() {
     // Because bindgen deals with conflicting overloaded functions by
     // appending a numeric suffix, let's see if we can cope.


### PR DESCRIPTION
Work towards #1316 and #995.

This doesn't currently work because ApiVec rejects duplicated APIs at
an earlier stage based upon bindgen function names.