### PR TITLE
628-thread-safe-subclass-mode: shared pointer abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .vscode/
+.idea/

--- a/engine/src/conversion/analysis/deps.rs
+++ b/engine/src/conversion/analysis/deps.rs
@@ -40,6 +40,7 @@ impl HasDependencies for Api<FnPrePhase1> {
             Api::Subclass {
                 name: _,
                 superclass,
+                ..
             } => Box::new(std::iter::once(superclass)),
             Api::RustSubclassFn { details, .. } => Box::new(details.dependencies.iter()),
             Api::RustFn { deps, .. } => Box::new(deps.iter()),
@@ -93,6 +94,7 @@ impl HasDependencies for Api<FnPhase> {
             Api::Subclass {
                 name: _,
                 superclass,
+                ..
             } => Box::new(std::iter::once(superclass)),
             Api::RustSubclassFn { details, .. } => Box::new(details.dependencies.iter()),
             Api::RustFn { deps, .. } => Box::new(deps.iter()),

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::conversion::api::SubclassDetails;
 use crate::minisyn::Ident;
 use crate::{
     conversion::{api::SubclassName, type_helpers::extract_pinned_mutable_reference_type},
@@ -13,7 +14,6 @@ use crate::{
 };
 use quote::ToTokens;
 use syn::{parse_quote, Type, TypeReference};
-use crate::conversion::api::SubclassDetails;
 
 #[derive(Clone, Debug)]
 pub(crate) enum CppConversionType {

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use quote::ToTokens;
 use syn::{parse_quote, Type, TypeReference};
+use crate::conversion::api::SubclassDetails;
 
 #[derive(Clone, Debug)]
 pub(crate) enum CppConversionType {
@@ -51,7 +52,7 @@ impl CppConversionType {
 pub(crate) enum RustConversionType {
     None,
     FromStr,
-    ToBoxedUpHolder(SubclassName),
+    ToBoxedUpHolder(SubclassName, SubclassDetails),
     FromPinMaybeUninitToPtr,
     FromPinMoveRefToPtr,
     FromTypeToPtr,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -610,6 +610,8 @@ impl<'a> FnAnalyzer<'a> {
                 Some(analysis.rust_name.clone()),
             );
             for sub in self.subclasses_by_superclass(sup) {
+                let sub_details = self.subclass_details[&sub].clone();
+
                 // For each subclass, we need to create a plain-C++ method to call its superclass
                 // and a Rust/C++ bridge API to call _that_.
                 // What we're generating here is entirely about the subclass, so the
@@ -651,6 +653,7 @@ impl<'a> FnAnalyzer<'a> {
                 results.push(create_subclass_function(
                     // RustSubclassFn
                     &sub,
+                    &sub_details,
                     &simpler_analysis,
                     &name,
                     receiver_mutability,

--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -45,6 +45,7 @@ use syn::{
     Type, TypePath, TypePtr, TypeReference, Visibility,
 };
 
+use crate::conversion::api::SubclassDetails;
 use crate::{
     conversion::{
         api::{AnalysisPhase, Api, TypeKind},
@@ -52,7 +53,6 @@ use crate::{
     },
     types::{make_ident, validate_ident_ok_for_cxx, Namespace, QualifiedName},
 };
-use crate::conversion::api::SubclassDetails;
 
 use self::{
     bridge_name_tracker::BridgeNameTracker,

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -129,6 +129,7 @@ pub(super) fn create_subclass_trait_item(
 
 pub(super) fn create_subclass_function(
     sub: &SubclassName,
+    sub_details: &SubclassDetails,
     analysis: &super::FnAnalysis,
     name: &ApiName,
     receiver_mutability: &ReceiverMutability,
@@ -167,6 +168,7 @@ pub(super) fn create_subclass_function(
     Api::RustSubclassFn {
         name: ApiName::new_in_root_namespace(rust_call_name.clone()),
         subclass: sub.clone(),
+        subclass_details: sub_details.clone(),
         details: Box::new(RustSubclassFnDetails {
             params,
             ret: analysis.ret_type.clone(),

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -14,10 +14,7 @@ use syn::{parse_quote, FnArg, PatType, Type, TypePtr};
 
 use crate::conversion::analysis::fun::{FnKind, MethodKind, ReceiverMutability, UnsafePolicy};
 use crate::conversion::analysis::pod::PodPhase;
-use crate::conversion::api::{
-    CppVisibility, FuncToConvert, Provenance, RustSubclassFnDetails, SubclassConstructorDetails,
-    SubclassName, SuperclassMethod, UnsafetyNeeded, Virtualness,
-};
+use crate::conversion::api::{CppVisibility, FuncToConvert, Provenance, RustSubclassFnDetails, SubclassConstructorDetails, SubclassDetails, SubclassName, SuperclassMethod, UnsafetyNeeded, Virtualness};
 use crate::conversion::apivec::ApiVec;
 use crate::minisyn::minisynize_punctuated;
 use crate::{
@@ -38,7 +35,7 @@ pub(super) fn subclasses_by_superclass(
     let mut subclasses_per_superclass: HashMap<QualifiedName, Vec<SubclassName>> = HashMap::new();
 
     for api in apis.iter() {
-        if let Api::Subclass { name, superclass } = api {
+        if let Api::Subclass { name, superclass, .. } = api {
             subclasses_per_superclass
                 .entry(superclass.clone())
                 .or_default()
@@ -46,6 +43,22 @@ pub(super) fn subclasses_by_superclass(
         }
     }
     subclasses_per_superclass
+}
+
+pub(super) fn subclass_details(
+    apis: &ApiVec<PodPhase>,
+) -> HashMap<SubclassName, SubclassDetails> {
+    let mut subclass_details: HashMap<SubclassName, SubclassDetails> = HashMap::new();
+
+    for api in apis.iter() {
+        if let Api::Subclass { name, details, .. } = api {
+            subclass_details
+                .entry(name.clone())
+                .or_insert(details.clone());
+        }
+    }
+
+    subclass_details
 }
 
 pub(super) fn create_subclass_fn_wrapper(

--- a/engine/src/conversion/analysis/fun/subclass.rs
+++ b/engine/src/conversion/analysis/fun/subclass.rs
@@ -14,7 +14,10 @@ use syn::{parse_quote, FnArg, PatType, Type, TypePtr};
 
 use crate::conversion::analysis::fun::{FnKind, MethodKind, ReceiverMutability, UnsafePolicy};
 use crate::conversion::analysis::pod::PodPhase;
-use crate::conversion::api::{CppVisibility, FuncToConvert, Provenance, RustSubclassFnDetails, SubclassConstructorDetails, SubclassDetails, SubclassName, SuperclassMethod, UnsafetyNeeded, Virtualness};
+use crate::conversion::api::{
+    CppVisibility, FuncToConvert, Provenance, RustSubclassFnDetails, SubclassConstructorDetails,
+    SubclassDetails, SubclassName, SuperclassMethod, UnsafetyNeeded, Virtualness,
+};
 use crate::conversion::apivec::ApiVec;
 use crate::minisyn::minisynize_punctuated;
 use crate::{
@@ -35,7 +38,10 @@ pub(super) fn subclasses_by_superclass(
     let mut subclasses_per_superclass: HashMap<QualifiedName, Vec<SubclassName>> = HashMap::new();
 
     for api in apis.iter() {
-        if let Api::Subclass { name, superclass, .. } = api {
+        if let Api::Subclass {
+            name, superclass, ..
+        } = api
+        {
             subclasses_per_superclass
                 .entry(superclass.clone())
                 .or_default()
@@ -45,9 +51,7 @@ pub(super) fn subclasses_by_superclass(
     subclasses_per_superclass
 }
 
-pub(super) fn subclass_details(
-    apis: &ApiVec<PodPhase>,
-) -> HashMap<SubclassName, SubclassDetails> {
+pub(super) fn subclass_details(apis: &ApiVec<PodPhase>) -> HashMap<SubclassName, SubclassDetails> {
     let mut subclass_details: HashMap<SubclassName, SubclassDetails> = HashMap::new();
 
     for api in apis.iter() {

--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -52,6 +52,7 @@ pub(crate) fn check_names(apis: ApiVec<FnPhase>) -> ApiVec<FnPhase> {
         Api::Subclass {
             name: SubclassName(ref name),
             ref superclass,
+            ..
         } => {
             validate_all_segments_ok_for_cxx(name.name.segment_iter())?;
             validate_all_segments_ok_for_cxx(superclass.segment_iter())?;

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -581,8 +581,8 @@ pub(crate) struct SubclassDetails {
 impl SubclassDetails {
     pub(crate) fn ptr_path(&self, path: TypePath) -> TypePath {
         match self.multithreaded {
-            true => parse_quote! { std::sync::Arc<std::sync::RwLock<#path>> },
-            false => parse_quote! { std::rc::Rc<std::cell::RefCell<#path>> },
+            true => parse_quote! { ::std::sync::Arc<::std::sync::RwLock<#path>> },
+            false => parse_quote! { ::std::rc::Rc<::std::cell::RefCell<#path>> },
         }
     }
 }

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -9,7 +9,12 @@
 use indexmap::set::IndexSet as HashSet;
 use std::fmt::Display;
 
-use syn::{parse::Parse, parse_quote, punctuated::Punctuated, token::{Comma, Unsafe}};
+use syn::{
+    parse::Parse,
+    parse_quote,
+    punctuated::Punctuated,
+    token::{Comma, Unsafe},
+};
 
 use crate::minisyn::{
     Attribute, FnArg, Ident, ItemConst, ItemEnum, ItemStruct, ItemType, ItemUse, LitBool, LitInt,

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -550,6 +550,7 @@ pub(crate) enum Api<T: AnalysisPhase> {
     RustSubclassFn {
         name: ApiName,
         subclass: SubclassName,
+        subclass_details: SubclassDetails,
         details: Box<RustSubclassFnDetails>,
     },
     /// A Rust subclass of a C++ class.

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -209,7 +209,9 @@ impl<'a> CppCodeGenerator<'a> {
 
         for api in deferred_apis.into_iter() {
             match api {
-                Api::Subclass { name, superclass, .. } => self.generate_subclass(
+                Api::Subclass {
+                    name, superclass, ..
+                } => self.generate_subclass(
                     superclass,
                     name,
                     constructors_by_subclass.remove(name).unwrap_or_default(),

--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -209,7 +209,7 @@ impl<'a> CppCodeGenerator<'a> {
 
         for api in deferred_apis.into_iter() {
             match api {
-                Api::Subclass { name, superclass } => self.generate_subclass(
+                Api::Subclass { name, superclass, .. } => self.generate_subclass(
                     superclass,
                     name,
                     constructors_by_subclass.remove(name).unwrap_or_default(),

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -46,12 +46,14 @@ impl TypeConversionPolicy {
                 conversion: quote! ( #var .into_cpp() ),
                 conversion_requires_unsafe: false,
             },
-            RustConversionType::ToBoxedUpHolder(ref sub) => {
+            RustConversionType::ToBoxedUpHolder(ref sub, ref details) => {
                 let holder_type = sub.holder();
                 let id = sub.id();
+                let ptr_path = details.ptr_path(parse_quote! { super::super::super::#id });
                 let ty = parse_quote! { autocxx::subclass::CppSubclassRustPeerHolder<
-                    super::super::super:: #id,
-                    std::rc::Rc<std::cell::RefCell<super::super::super:: #id>>>
+                        super::super::super:: #id,
+                        #ptr_path,
+                    >
                 };
                 RustParamConversion::Param {
                     ty,

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -50,7 +50,8 @@ impl TypeConversionPolicy {
                 let holder_type = sub.holder();
                 let id = sub.id();
                 let ty = parse_quote! { autocxx::subclass::CppSubclassRustPeerHolder<
-                    super::super::super:: #id>
+                    super::super::super:: #id,
+                    std::rc::Rc<std::cell::RefCell<super::super::super:: #id>>>
                 };
                 RustParamConversion::Param {
                     ty,

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -57,8 +57,8 @@ use super::{
     codegen_cpp::type_to_cpp::CppNameMap,
 };
 use super::{convert_error::ErrorContext, ConvertErrorFromCpp};
-use quote::quote;
 use crate::conversion::api::SubclassDetails;
+use quote::quote;
 
 #[derive(Clone, Hash, PartialEq, Eq)]
 struct ImplBlockKey {
@@ -625,7 +625,9 @@ impl<'a> RsCodeGenerator<'a> {
                 details, subclass, ..
             } => Self::generate_subclass_fn(id.into(), *details, subclass),
             Api::Subclass {
-                name, superclass, ref details,
+                name,
+                superclass,
+                ref details,
             } => {
                 let methods = associated_methods.get(&superclass);
                 let generate_peer_constructor = subclasses_with_a_single_trivial_constructor.contains(&name.0.name) &&
@@ -633,7 +635,13 @@ impl<'a> RsCodeGenerator<'a> {
                     // constructor instead? Need to create unsafe versions of everything that uses
                     // it too.
                     matches!(self.unsafe_policy, UnsafePolicy::AllFunctionsSafe);
-                self.generate_subclass(name, &superclass, details, methods, generate_peer_constructor)
+                self.generate_subclass(
+                    name,
+                    &superclass,
+                    details,
+                    methods,
+                    generate_peer_constructor,
+                )
             }
             Api::ExternCppType {
                 details: ExternCppType { rust_path, .. },

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -137,10 +137,12 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                 name,
                 subclass,
                 details,
+                subclass_details,
             } => Ok(Box::new(std::iter::once(Api::RustSubclassFn {
                 name,
                 subclass,
                 details,
+                subclass_details,
             }))),
             Api::Subclass {
                 name,

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -142,7 +142,11 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                 subclass,
                 details,
             }))),
-            Api::Subclass { name, superclass, details } => Ok(Box::new(std::iter::once(Api::Subclass {
+            Api::Subclass {
+                name,
+                superclass,
+                details,
+            } => Ok(Box::new(std::iter::once(Api::Subclass {
                 name,
                 superclass,
                 details,

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -142,9 +142,10 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B: 'static>(
                 subclass,
                 details,
             }))),
-            Api::Subclass { name, superclass } => Ok(Box::new(std::iter::once(Api::Subclass {
+            Api::Subclass { name, superclass, details } => Ok(Box::new(std::iter::once(Api::Subclass {
                 name,
                 superclass,
+                details,
             }))),
             Api::IgnoredItem { name, err, ctx } => {
                 Ok(Box::new(std::iter::once(Api::IgnoredItem {

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 use autocxx_parser::{IncludeCppConfig, RustPath};
 use syn::{parse_quote, Fields, Ident, Item, Type, TypePath, UseTree};
+use crate::conversion::api::SubclassDetails;
 
 use super::{
     super::utilities::generate_utilities, bindgen_semantic_attributes::BindgenSemanticAttributes,
@@ -101,6 +102,9 @@ impl<'a> ParseBindgen<'a> {
             .extend(self.config.subclasses.iter().map(|sc| Api::Subclass {
                 name: SubclassName::new(sc.subclass.clone().into()),
                 superclass: QualifiedName::new_from_cpp_name(&sc.superclass),
+                details: SubclassDetails {
+                    multithreaded: sc.multithreaded,
+                },
             }));
         for fun in &self.config.extern_rust_funs {
             let id = fun.sig.ident.clone();

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -9,6 +9,7 @@
 use indexmap::map::IndexMap as HashMap;
 use indexmap::set::IndexSet as HashSet;
 
+use crate::conversion::api::SubclassDetails;
 use crate::{
     conversion::{
         api::{Api, ApiName, NullPhase, StructDetails, SubclassName, TypedefKind, UnanalyzedApi},
@@ -28,7 +29,6 @@ use crate::{
 };
 use autocxx_parser::{IncludeCppConfig, RustPath};
 use syn::{parse_quote, Fields, Ident, Item, Type, TypePath, UseTree};
-use crate::conversion::api::SubclassDetails;
 
 use super::{
     super::utilities::generate_utilities, bindgen_semantic_attributes::BindgenSemanticAttributes,

--- a/engine/src/parse_file.rs
+++ b/engine/src/parse_file.rs
@@ -165,7 +165,11 @@ fn parse_file_contents(
                         attr.path()
                             .segments
                             .last()
-                            .map(|seg| seg.ident == "is_subclass" || seg.ident == SUBCLASS || seg.ident == SUBCLASS_MULTITHREADED)
+                            .map(|seg| {
+                                seg.ident == "is_subclass"
+                                    || seg.ident == SUBCLASS
+                                    || seg.ident == SUBCLASS_MULTITHREADED
+                            })
                             .unwrap_or(false)
                     });
                     if let Some(is_superclass_attr) = is_superclass_attr {

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -8164,10 +8164,10 @@ fn test_subclass_no_safety() {
 
         use autocxx::subclass::{CppSubclass, CppPeerConstructor, CppSubclassRustPeerHolder};
         use cxx::UniquePtr;
-        impl CppPeerConstructor<ffi::MyObserverCpp> for MyObserver {
+        impl CppPeerConstructor<ffi::MyObserverCpp, std::rc::Rc<std::cell::RefCell<MyObserver>>> for MyObserver {
             fn make_peer(
                 &mut self,
-                peer_holder: CppSubclassRustPeerHolder<Self>,
+                peer_holder: CppSubclassRustPeerHolder<Self, std::rc::Rc<std::cell::RefCell<Self>>>,
             ) -> UniquePtr<ffi::MyObserverCpp> {
                 UniquePtr::emplace(unsafe { ffi::MyObserverCpp::new(peer_holder) })
             }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -58,8 +58,8 @@ fn subclass_impl(
     let id = &s.ident;
     let cpp_ident = Ident::new(&format!("{id}Cpp"), Span::call_site());
     let ptr_ident = match threading {
-        SubclassThreadingOption::SingleThreaded => quote! { std::rc::Rc<std::cell::RefCell<#id>> },
-        SubclassThreadingOption::MultiThreaded => quote! { std::sync::Arc<std::sync::RwLock<#id>> },
+        SubclassThreadingOption::SingleThreaded => quote! { ::std::rc::Rc<::std::cell::RefCell<#id>> },
+        SubclassThreadingOption::MultiThreaded => quote! { ::std::sync::Arc<::std::sync::RwLock<#id>> },
     };
     let input = quote! {
         cpp_peer: autocxx::subclass::CppSubclassCppPeerHolder<ffi:: #cpp_ident>

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -44,7 +44,11 @@ pub fn subclass_multithreaded(attr: TokenStream, item: TokenStream) -> TokenStre
     subclass_impl(attr, item, SubclassThreadingOption::MultiThreaded)
 }
 
-fn subclass_impl(attr: TokenStream, item: TokenStream, threading: SubclassThreadingOption) -> TokenStream {
+fn subclass_impl(
+    attr: TokenStream,
+    item: TokenStream,
+    threading: SubclassThreadingOption,
+) -> TokenStream {
     let mut s: ItemStruct =
         syn::parse(item).unwrap_or_else(|_| abort!(Span::call_site(), "Expected a struct"));
     if !matches!(s.vis, Visibility::Public(..)) {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -158,6 +158,7 @@ impl Default for Allowlist {
 #[derive(Debug, Hash)]
 pub struct Subclass {
     pub superclass: String,
+    pub multithreaded: bool,
     pub subclass: Ident,
 }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -36,6 +36,7 @@ pub mod directive_names {
     pub static EXTERN_RUST_TYPE: &str = "extern_rust_type";
     pub static EXTERN_RUST_FUN: &str = "extern_rust_function";
     pub static SUBCLASS: &str = "subclass";
+    pub static SUBCLASS_MULTITHREADED: &str = "subclass_multithreaded";
 }
 
 /// Core of the autocxx engine. See `generate` for most details

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(return_position_impl_trait_in_trait)]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(nightly, feature(unsize))]
 #![cfg_attr(nightly, feature(dispatch_from_dyn))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(return_position_impl_trait_in_trait)]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(nightly, feature(unsize))]
 #![cfg_attr(nightly, feature(dispatch_from_dyn))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,12 @@ macro_rules! subclass {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
+/// See [`subclass::subclass`].
+#[macro_export]
+macro_rules! subclass_multithreaded {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
 /// Indicates that a C++ type can definitely be instantiated. This has effect
 /// only in a very specific case:
 /// * the type is a typedef to something else

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -433,11 +433,11 @@ impl<T> CppSubclassPeerPtr<T> for Arc<RwLock<T>> {
     }
 
     fn try_get_ref<'a>(&'a self) -> Result<Self::Ref<'a>, Box<dyn Error + 'a>> {
-        self.read().map_err(move |e| Box::new(e) as Box<dyn Error>)
+        self.try_read().map_err(move |e| Box::new(e) as Box<dyn Error>)
     }
 
     fn try_get_mut<'a>(&'a mut self) -> Result<Self::RefMut<'a>, Box<dyn Error + 'a>> {
-        self.write().map_err(move |e| Box::new(e) as Box<dyn Error>)
+        self.try_write().map_err(move |e| Box::new(e) as Box<dyn Error>)
     }
 
     fn clone(&self) -> Self::Ptr {


### PR DESCRIPTION
Parent issue: #628 

Wanted to open this as a draft to get feedback before going any deeper. Using some ugly trait shenanigans to paper over `Rc<RefCell<T>>` and `Arc<RwLock<T>>`.

Outstanding comments/questions/issues:
- Is this approach okay?
- What's the best way to expose this to users? My initially approach was to duplicate the subclass proc macro which works fine for that bit, but I have no idea the best way to propagate this choice into codegen. Hard coded `Rc<RefCell<T>>` there for now just to get tests to pass. I think there might be a better API here, or at least need advice on how best to approach this.
- Well want some more tests obviously.
- Depends on RPITIT but that shouldn't be a problem soon.

As an aside, I'm using the subclass functionality for a project and it is literally _lifesaving_. This feature would be helpful for ensuring additional safety since I'm interfacing with a parent application's plugin API that does #whoknows with references we give them.

---------

TODO:
- [ ] Docs
- [ ] Add more tests
- [ ] Examples