### PR TITLE
Add integration tests for functions taking array parameters

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -5002,6 +5002,43 @@ fn test_take_array_in_struct() {
 }
 
 #[test]
+fn test_take_struct_built_array_in_function() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    struct data {
+        char a[4];
+    };
+    uint32_t take_array(char a[4]) {
+        return a[0] + a[2];
+    }
+    "};
+    let rs = quote! {
+        let mut c = ffi::data { a: [ 10, 20, 30, 40 ] };
+        unsafe {
+            assert_eq!(ffi::take_array(c.a.as_mut_ptr()), 40);
+        }
+    };
+    run_test("", hdr, rs, &["take_array"], &["data"]);
+}
+
+#[test]
+fn test_take_array_in_function() {
+    let hdr = indoc! {"
+    #include <cstdint>
+    uint32_t take_array(char a[4]) {
+        return a[0] + a[2];
+    }
+    "};
+    let rs = quote! {
+        let mut a: [i8; 4] = [ 10, 20, 30, 40 ];
+        unsafe {
+            assert_eq!(ffi::take_array(a.as_mut_ptr()), 40);
+        }
+    };
+    run_test("", hdr, rs, &["take_array"], &[]);
+}
+
+#[test]
 fn test_union_ignored() {
     let hdr = indoc! {"
     #include <cstdint>


### PR DESCRIPTION
# Description

Work towards #989.

> We should add more tests to find out what happens if we allow arrays as actual function parameters, etc.

This pull request adds two unit tests which pass arrays from Rust code as parameters to C++ functions which take arrays:

- `test_take_struct_built_array_in_function`, a modification to `test_take_array_in_struct`, re-using ffi to a struct containing an array to construct the array, then an `unsafe` call to `as_mut_ptr` to get the array data to pass to the C++ code.
- `test_take_array_in_function`, removes the need for ffi to construct the array in C++, instead just constructing an array of the appropriate type in rust, then again using an `unsafe` call to `as_mut_ptr` to get the array data to pass to the C++ code.

If this is what was intended by #989, this seems very promising for current the support of arrays. If it is agreed these tests constitute proof of support for functions taking arrays as arguments, perhaps the next steps are modifying the documentation to give examples of this use case?

# Checklist

- [x] Tests pass
- [x] There are no relevant changes to the README