### PR TITLE
Fix generated wrapper for nested struct with static fn

### DIFF
--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -531,13 +531,22 @@ impl<'a> CppCodeGenerator<'a> {
                 }
             },
             CppFunctionBody::StaticMethodCall(ns, ty_id, fn_id) => {
+                // handle nested struct: A_B -> A::B
+                let full_name = QualifiedName::new(ns, ty_id.clone());
+                let using_nested_struct = self
+                    .original_name_map
+                    .get(&full_name)
+                    .map_or("".to_string(), |nested_struct| {
+                        format!("using {ty_id} = {nested_struct};")
+                    });
+
                 let underlying_function_call = ns
                     .into_iter()
                     .cloned()
                     .chain([ty_id.to_string(), fn_id.to_string()].iter().cloned())
                     .join("::");
                 (
-                    format!("{underlying_function_call}({arg_list})"),
+                    format!("{using_nested_struct} {underlying_function_call}({arg_list})"),
                     "".to_string(),
                     false,
                 )

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -2603,6 +2603,21 @@ fn test_nested_with_destructor() {
     run_test("", hdr, rs, &["A", "A_B"], &[]);
 }
 
+#[test]
+fn test_nested_with_static_call() {
+    let hdr = indoc! {"
+        struct A {
+            struct B {
+                static void f() {}
+            };
+        };
+    "};
+    let rs = quote! {
+        ffi::A_B::new().within_unique_ptr();
+    };
+    run_test("", hdr, rs, &["A", "A_B"], &[]);
+}
+
 // Even without a `safety!`, we still need to generate a safe `fn drop`.
 #[test]
 fn test_destructor_no_safety() {


### PR DESCRIPTION
This PR fixes an issue with the wrappers for static functions in nested structs.

See the added test case: 

```cpp
struct A {
    struct B {
        static void f() {}
    };
};
```

Currently, `autocxx` would generates erroneous code `namespace::A_B::f()` instead of `namespace::A::B::f()`.