### PR TITLE
Convert to arbitrary_self_types_pointers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [ ".github", "book", "tools" ]
 resolver = "2"
 
 [features]
-arbitrary_self_types = []
+arbitrary_self_types_pointers = []
 
 [dependencies]
 autocxx-macro = { path="macro", version="0.27.0" }

--- a/examples/reference-wrappers/src/main.rs
+++ b/examples/reference-wrappers/src/main.rs
@@ -25,7 +25,7 @@
 
 // Necessary to be able to call methods on reference wrappers.
 // For that reason, this example only builds on nightly Rust.
-#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
 
 use autocxx::prelude::*;
 use std::pin::Pin;

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -26,7 +26,7 @@ fn run_cpprefs_test(
     generate_pods: &[&str],
 ) {
     if !arbitrary_self_types_supported() {
-        // "unsafe_references_wrapped" requires arbitrary_self_types, which requires nightly.
+        // "unsafe_references_wrapped" requires arbitrary_self_types_pointers, which requires nightly.
         return;
     }
     do_run_test(

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -39,7 +39,7 @@ fn run_cpprefs_test(
         None,
         "unsafe_references_wrapped",
         Some(quote! {
-            #![feature(arbitrary_self_types)]
+            #![feature(arbitrary_self_types_pointers)]
         }),
     )
     .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ macro_rules! concrete {
 /// them to be wrapped in a `CppRef` type: see [`CppRef`].
 /// This only works on nightly Rust because it
 /// depends upon an unstable feature
-/// (`arbitrary_self_types`). However, it should
+/// (`arbitrary_self_types_pointers`). However, it should
 /// eliminate all undefined behavior related to Rust's
 /// stricter aliasing rules than C++.
 #[macro_export]

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -38,7 +38,7 @@ use cxx::{memory::UniquePtrTarget, UniquePtr};
 /// As noted, one of the main reasons for this type is to call methods.
 /// Unfortunately, that depends on unstable Rust features. If you can't
 /// call methods on one of these references, check you're using nightly
-/// and add `#![feature(arbitrary_self_types)]` to your crate.
+/// and add `#![feature(arbitrary_self_types_pointers)]` to your crate.
 ///
 /// # Lifetimes and cloneability
 ///
@@ -566,7 +566,7 @@ impl<T: ?Sized> AsCppMutRef<T> for PhantomReferentMut<T> {
     }
 }
 
-#[cfg(all(feature = "arbitrary_self_types", test))]
+#[cfg(all(feature = "arbitrary_self_types_pointers", test))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
arbitrary_self_types has been split into arbitrary_self_types and arbitrary_self_types_pointers. We need the latter.
