### PR TITLE
Roll to autocxx-bindgen 0.70.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,8 @@ dependencies = [
 
 [[package]]
 name = "autocxx-bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81238f7571a7fe1743bebbfaf218ad9aeceaec0f1f25c74b2d3f42b16fa17ea"
+version = "0.70.1"
+source = "git+https://github.com/adetaylor/rust-bindgen?branch=merge-0.70.1#fc466bfb6c690bb93264db324ad8d519b34d0da9"
 dependencies = [
  "bitflags 2.3.3",
  "cexpr",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -30,8 +30,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = { version = "=0.69.5", default-features = false, features = ["logging", "which-rustfmt"] }
-#autocxx-bindgen = { git = "https://github.com/maurer/rust-bindgen", branch = "update-0.65.1", default-features = false, features = ["logging", "which-rustfmt"] }
+#autocxx-bindgen = { version = "=0.69.5", default-features = false, features = ["logging", "which-rustfmt"] }
+autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "merge-0.70.1", default-features = false, features = ["logging", "which-rustfmt"] }
 itertools = "0.10.3"
 cc = { version = "1.0", optional = true }
 # Note: Keep the patch-level version of cxx-gen and cxx in sync.

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -30,8 +30,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-#autocxx-bindgen = { version = "=0.69.5", default-features = false, features = ["logging", "which-rustfmt"] }
-autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "merge-0.70.1", default-features = false, features = ["logging", "which-rustfmt"] }
+autocxx-bindgen = { version = "=0.70.1", default-features = false, features = ["logging", "which-rustfmt"] }
+#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "merge-0.70.1", default-features = false, features = ["logging", "which-rustfmt"] }
 itertools = "0.10.3"
 cc = { version = "1.0", optional = true }
 # Note: Keep the patch-level version of cxx-gen and cxx in sync.


### PR DESCRIPTION
Tests against merge to bindgen 0.70.1.