### PR TITLE
Test for a failing double-template with default

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -12403,6 +12403,37 @@ fn test_override_typedef_fn() {
     run_test("", hdr, quote! {}, &["Foo"], &[]);
 }
 
+#[test]
+fn test_double_template_w_default() {
+    let hdr = indoc! {"
+        class Widget {};
+
+        template <class T>
+        class RefPtr {
+        private:
+            T* m_ptr;
+        };
+
+        class Container {
+            void* data_;
+        };
+
+        class FakeAlloc {};
+
+        template <typename T, typename A=FakeAlloc>
+        class Holder {
+            A alloc;
+        };
+
+        typedef Holder<RefPtr<Widget>> WidgetRefHolder;
+        class Problem {
+        public:
+            WidgetRefHolder& getWidgets();
+        };
+    "};
+    run_test("", hdr, quote! {}, &["Problem"], &[]);
+}
+
 // Yet to test:
 // - Ifdef
 // - Out param pointers


### PR DESCRIPTION
Integration test for #1413 

autocxx appears to drop the first template, and then the C++ compiler cannot handle the resulting incompatible types.