### PR TITLE
Add integration tests for 'using declarations' with std::string

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -12387,6 +12387,32 @@ fn test_cpp_union_pod() {
 }
 
 #[test]
+fn test_using_string_function() {
+    let hdr = indoc! {"
+        #include <string>
+        using std::string;
+        void foo(const string &a);
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["foo"], &[]);
+}
+
+#[test]
+fn test_using_string_method() {
+    let hdr = indoc! {"
+        #include <string>
+        using std::string;
+        class Foo
+        {
+        public:
+            Foo bar(const string &a);
+        };
+    "};
+    let rs = quote! {};
+    run_test("", hdr, rs, &["Foo"], &[]);
+}
+
+#[test]
 #[ignore] // https://github.com/google/autocxx/issues/1382
 fn test_override_typedef_fn() {
     let hdr = indoc! {"


### PR DESCRIPTION
Adding two integration tests for #1379. Each one produces the same underlying error but seemingly in different parts of autocxx.

Inlining the `std::string` in place of the `string` usages causes the tests to pass correctly, so this does appear to be something in autocxx or bindgen not correctly identifying `std::string` in order to replace it with `CxxString`.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR