### PR TITLE
book/tutorial: Rename `path` variable to self-describing `include_path`

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -33,13 +33,16 @@ Now, add a `build.rs` next to your `Cargo.toml` (this is a standard `cargo` [bui
 
 ```rust,ignore
 fn main() -> miette::Result<()> {
-    let path = std::path::PathBuf::from("src"); // include path
-    let mut b = autocxx_build::Builder::new("src/main.rs", &[&path]).build()?;
-        // This assumes all your C++ bindings are in main.rs
+    let include_path = std::path::PathBuf::from("src");
+
+    // This assumes all your C++ bindings are in main.rs
+    let mut b = autocxx_build::Builder::new("src/main.rs", &[&include_path]).build()?;
     b.flag_if_supported("-std=c++14")
      .compile("autocxx-demo"); // arbitrary library name, pick anything
     println!("cargo:rerun-if-changed=src/main.rs");
+
     // Add instructions to link to any C++ libraries you need.
+
     Ok(())
 }
 ```


### PR DESCRIPTION
Having a `path` variable with an extra code comment "include path" seems a bit redundant. Instead we can just call the variable `include_path` and remove the comment.

This also fixes the indentation of another code comment and adds a couple of blank lines to make the snippet a little easier to digest.