### PR TITLE
book/building: Fix `expect_build()` call

### DIFF
--- a/book/src/building.md
+++ b/book/src/building.md
@@ -11,7 +11,8 @@ fn main() {
     let path = std::path::PathBuf::from("src"); // include path
     let mut b = autocxx_build::Builder::new("src/main.rs", &[&path])
         .extra_clang_args(&["-std=c++17"])
-        .expect_build();
+        .build()
+        .unwrap();
     b.flag_if_supported("-std=c++17") // use "-std:c++17" here if using msvc on windows
         .compile("autocxx-demo"); // arbitrary library name, pick anything
     println!("cargo:rerun-if-changed=src/main.rs");


### PR DESCRIPTION
`expect_build()` does not seem to be a thing (anymore)? The tutorial uses `build()?`, so I've adapted the snippet to use `build().unwrap()` since the snippet is not using `miette` at the moment.
