### PR TITLE
Attempts to include all type params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,8 +155,7 @@ dependencies = [
 [[package]]
 name = "autocxx-bindgen"
 version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d41cf081e31a74378456586b47a5bae2b75a98e5f7c248c9d9bf433e3637f4"
+source = "git+https://github.com/adetaylor/rust-bindgen?branch=hacks-for-using-all-template-params#bc3b56e2b152466340000f6430399b79afacfbe3"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ moveit = { version = "0.6", features = [ "cxx" ] }
 members = ["parser", "engine", "gen/cmd", "gen/build", "macro", "demo", "tools/reduce", "tools/mdbook-preprocessor", "integration-tests"]
 exclude = ["examples/s2", "examples/steam-mini", "examples/subclass", "examples/chromium-fake-render-frame-host", "examples/pod", "examples/non-trivial-type-on-stack", "examples/llvm", "examples/reference-wrappers", "examples/cpp_calling_rust", "tools/stress-test"]
 
-#[patch.crates-io]
+[patch.crates-io]
 #cxx = { path="../cxx" }
 #cxx-gen = { path="../cxx/gen/lib" }
-#autocxx-bindgen = { path="../bindgen" }
+#autocxx-bindgen = { path="../bindgen/bindgen" }
 #moveit = { path="../moveit" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -30,8 +30,8 @@ log = "0.4"
 proc-macro2 = "1.0.11"
 quote = "1.0"
 indoc = "1.0"
-autocxx-bindgen = { version = "=0.71.1", default-features = false, features = ["logging", "which-rustfmt"] }
-#autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "merge-latest-upstream", default-features = false, features = ["logging", "which-rustfmt"] }
+#autocxx-bindgen = { version = "=0.71.1", default-features = false, features = ["logging", "which-rustfmt"] }
+autocxx-bindgen = { git = "https://github.com/adetaylor/rust-bindgen", branch = "hacks-for-using-all-template-params", default-features = false, features = ["logging", "which-rustfmt"] }
 itertools = "0.10.3"
 cc = { version = "1.0", optional = true }
 # Note: Keep the patch-level version of cxx-gen and cxx in sync.

--- a/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
+++ b/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
@@ -93,6 +93,7 @@ pub(crate) fn replace_hopeless_typedef_targets(
             Api::ForwardDeclaration {
                 name,
                 err: Some(ConvertErrorWithContext(err, ctx)),
+                ..
             } => Api::IgnoredItem { name, err, ctx },
             _ => api,
         })

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -466,6 +466,7 @@ pub(crate) enum Api<T: AnalysisPhase> {
     /// A forward declaration, which we mustn't store in a UniquePtr.
     ForwardDeclaration {
         name: ApiName,
+        is_templated: bool,
         /// If we found a problem parsing this forward declaration, we'll
         /// ephemerally store the error here, as opposed to immediately
         /// converting it to an `IgnoredItem`. That's because the
@@ -490,6 +491,7 @@ pub(crate) enum Api<T: AnalysisPhase> {
         name: ApiName,
         rs_definition: Option<Box<Type>>,
         cpp_definition: String,
+        depends_on_forward_declaration: bool,
     },
     /// A simple note that we want to make a constructor for
     /// a `std::string` on the heap.

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -550,23 +550,31 @@ impl<'a> RsCodeGenerator<'a> {
                     false,
                 )
             }
+            Api::ForwardDeclaration {
+                is_templated: false,
+                ..
+            }
+            | Api::OpaqueTypedef { .. }
+            | Api::ConcreteType {
+                depends_on_forward_declaration: true,
+                ..
+            } => self.generate_type(
+                &name,
+                id,
+                TypeKind::Abstract,
+                false, // these types can't be kept in a Vector
+                false, // these types can't be put in a smart pointer
+                || None,
+                associated_methods,
+                None,
+                false,
+            ),
             Api::ConcreteType { .. } => self.generate_type(
                 &name,
                 id,
                 TypeKind::Abstract,
                 false, // assume for now that these types can't be kept in a Vector
                 true,  // assume for now that these types can be put in a smart pointer
-                || None,
-                associated_methods,
-                None,
-                false,
-            ),
-            Api::ForwardDeclaration { .. } | Api::OpaqueTypedef { .. } => self.generate_type(
-                &name,
-                id,
-                TypeKind::Abstract,
-                false, // these types can't be kept in a Vector
-                false, // these types can't be put in a smart pointer
                 || None,
                 associated_methods,
                 None,
@@ -643,7 +651,11 @@ impl<'a> RsCodeGenerator<'a> {
                 ctx: Some(ctx),
                 ..
             } => Self::generate_error_entry(err, ctx),
-            Api::IgnoredItem { .. } | Api::SubclassTraitItem { .. } => RsCodegenResult::default(),
+            Api::IgnoredItem { .. }
+            | Api::SubclassTraitItem { .. }
+            | Api::ForwardDeclaration {
+                is_templated: true, ..
+            } => RsCodegenResult::default(),
         }
     }
 

--- a/engine/src/conversion/error_reporter.rs
+++ b/engine/src/conversion/error_reporter.rs
@@ -94,17 +94,22 @@ pub(crate) fn convert_apis<FF, SF, EF, TF, A, B>(
                 name,
                 rs_definition,
                 cpp_definition,
+                depends_on_forward_declaration,
             } => Ok(Box::new(std::iter::once(Api::ConcreteType {
                 name,
                 rs_definition,
                 cpp_definition,
+                depends_on_forward_declaration,
             }))),
-            Api::ForwardDeclaration { name, err } => {
-                Ok(Box::new(std::iter::once(Api::ForwardDeclaration {
-                    name,
-                    err,
-                })))
-            }
+            Api::ForwardDeclaration {
+                name,
+                is_templated,
+                err,
+            } => Ok(Box::new(std::iter::once(Api::ForwardDeclaration {
+                name,
+                is_templated,
+                err,
+            }))),
             Api::OpaqueTypedef {
                 name,
                 forward_declaration,

--- a/engine/src/conversion/parse/bindgen_semantic_attributes.rs
+++ b/engine/src/conversion/parse/bindgen_semantic_attributes.rs
@@ -56,12 +56,7 @@ impl BindgenSemanticAttributes {
         &self,
         id_for_context: &Ident,
     ) -> Result<(), ConvertErrorWithContext> {
-        if self.has_attr("unused_template_param") {
-            Err(ConvertErrorWithContext(
-                ConvertErrorFromCpp::UnusedTemplateParam,
-                Some(ErrorContext::new_for_item(id_for_context.clone().into())),
-            ))
-        } else if self.get_cpp_visibility() != CppVisibility::Public {
+        if self.get_cpp_visibility() != CppVisibility::Public {
             Err(ConvertErrorWithContext(
                 ConvertErrorFromCpp::NonPublicNestedType,
                 Some(ErrorContext::new_for_item(id_for_context.clone().into())),

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -11656,13 +11656,43 @@ fn test_typedef_unsupported_type_pub() {
 }
 
 #[test]
-fn test_typedef_unsupported_type_pri() {
+fn test_typedef_unsupported_type_pri_prob() {
     let hdr = indoc! {"
         #include <set>
         namespace NS{
             class cls{
                 private:
                     typedef std::set<int> InnerType;
+                };
+        }
+    "};
+
+    run_test_ex(
+        "",
+        hdr,
+        quote! {},
+        quote! { generate_ns!("NS") },
+        None,
+        None,
+        None,
+    );
+}
+
+#[test]
+fn test_typedef_unsupported_type_pri_self_contained() {
+    let hdr = indoc! {"
+        namespace fakestd {
+            struct less {};
+            struct allocator {};
+            template<typename Key, typename Compare=less, typename Alloc=allocator>
+            struct set {
+                Key key;
+            };
+        }
+        namespace NS{
+            class cls{
+                private:
+                    typedef fakestd::set<int> InnerType;
                 };
         }
     "};


### PR DESCRIPTION
bindgen can handle a large fraction of C++ code, even with templates, and
autocxx can in turn handle a very large fraction of bindgen output. Pretty much
the only things autocxx can't handle are:

* bindgen opaque types passed by value
* Types with unused template parameters

This change, with its associated bindgen change, tries to make progress to
removing this second category of unhandled thing.

It alters bindgen such that it always uses all template parameters, adding a
PhantomData field where necessary.

It's not quite right yet.