### PR TITLE
[DRAFT] Feature/throws exception

### DIFF
--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -236,7 +236,7 @@ impl TypeConversionPolicy {
                     conversion,
                     conversion_requires_unsafe,
                 } => {
-                    let ty = parse_quote!( ::std::result::Result< #ty, ::cxx::Exception> );
+                    let ty = parse_quote!( impl autocxx::moveit::new::TryNew<Output = #ty, Error =::cxx::Exception> );
                     RustParamConversion::Param {
                         ty,
                         local_variables,

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -417,9 +417,7 @@ impl IncludeCppConfig {
     }
 
     pub fn is_throwable(&self, fun: &str) -> bool {
-        let r = self.throwlist.iter().any(|f| f == fun);
-        eprintln!("===DBG{{is_throwable}}=== {fun} == {r:?}");
-        r
+        self.throwlist.iter().any(|f| f == fun)
     }
 
     fn is_rust_type_name(&self, possible_ty: &str) -> bool {

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -219,6 +219,7 @@ pub struct IncludeCppConfig {
     pub allowlist: Allowlist,
     pub(crate) blocklist: Vec<String>,
     pub(crate) constructor_blocklist: Vec<String>,
+    pub(crate) throwlist: Vec<String>,
     pub instantiable: Vec<String>,
     pub(crate) exclude_utilities: bool,
     pub(crate) mod_name: Option<Ident>,
@@ -365,6 +366,7 @@ impl IncludeCppConfig {
             || self.is_rust_fun(cpp_name)
             || self.is_rust_type_name(cpp_name)
             || self.is_concrete_type(cpp_name)
+            || self.is_throwable(cpp_name)
             || match &self.allowlist {
                 Allowlist::Unspecified(_) => panic!("Eek no allowlist yet"),
                 Allowlist::All => true,
@@ -412,6 +414,12 @@ impl IncludeCppConfig {
     pub fn is_rust_type(&self, id: &Ident) -> bool {
         let id_string = id.to_string();
         self.is_rust_type_name(&id_string) || self.is_subclass_holder(&id_string)
+    }
+
+    pub fn is_throwable(&self, fun: &str) -> bool {
+        let r = self.throwlist.iter().any(|f| f == fun);
+        eprintln!("===DBG{{is_throwable}}=== {fun} == {r:?}");
+        r
     }
 
     fn is_rust_type_name(&self, possible_ty: &str) -> bool {

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -93,6 +93,13 @@ pub(crate) fn get_directives() -> &'static DirectivesMap {
                 |config| &config.exclude_utilities,
             )),
         );
+        need_exclamation.insert(
+            "throws".into(),
+            Box::new(StringList(
+                |config| &mut config.throwlist,
+                |config| &config.throwlist,
+            )),
+        );
         need_exclamation.insert("name".into(), Box::new(ModName));
         need_exclamation.insert("concrete".into(), Box::new(Concrete));
         need_exclamation.insert("rust_type".into(), Box::new(RustType { output: false }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,12 @@ macro_rules! subclass {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
+/// See [`subclass::subclass`].
+#[macro_export]
+macro_rules! throws {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
 /// Indicates that a C++ type can definitely be instantiated. This has effect
 /// only in a very specific case:
 /// * the type is a typedef to something else


### PR DESCRIPTION
Fixes #1412 


_This is an early draft to solicit feedback. It is functional, but there are a couple of implementation details that felt rather clumsy:_
- _Mapping a user specified qualified name (eg `Xapian::Database::add_document`) to the mangled representations available during function analysis_
- _Representing the transformations themselves within the existing machinery (the throwable bit is more or less just bolted on at this phase)_

_And of course some obvious missing bits like documentation, additional test cases, etc. Let me know what you think about the current approach, and anything you'd like to see improved -- I'm happy to iterate!_

This patch introduces a `throws!` macro, so that individual functions and methods can be marked as throwing an exception. Example usage can be found in the provided unit tests, but generally resembles:

```rust
import_cpp! {
    #include "foo.h"
    generate!("do_something")
    throws!("do_something")
}
```

- [x] CLA signed
- [x] Tests pass
- [ ] Appropriate changes to README are included in PR