### PR TITLE
Add lifetimes to functions returning `CppRef<'a, T>`

### DIFF
--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -719,10 +719,3 @@ impl<T: AnalysisPhase> Api<T> {
         Ok(Box::new(std::iter::once(Api::Enum { name, item })))
     }
 }
-
-/// Whether a type is a pointer of some kind.
-pub(crate) enum Pointerness {
-    Not,
-    ConstPtr,
-    MutPtr,
-}

--- a/engine/src/conversion/codegen_cpp/function_wrapper_cpp.rs
+++ b/engine/src/conversion/codegen_cpp/function_wrapper_cpp.rs
@@ -10,7 +10,6 @@ use syn::{Type, TypePtr};
 
 use crate::conversion::{
     analysis::fun::function_wrapper::{CppConversionType, TypeConversionPolicy},
-    api::Pointerness,
     ConvertErrorFromCpp,
 };
 
@@ -61,17 +60,6 @@ impl TypeConversionPolicy {
         cpp_name_map: &CppNameMap,
     ) -> Result<String, ConvertErrorFromCpp> {
         cpp_name_map.type_to_cpp(self.cxxbridge_type())
-    }
-
-    pub(crate) fn is_a_pointer(&self) -> Pointerness {
-        match self.cxxbridge_type() {
-            Type::Ptr(TypePtr {
-                mutability: Some(_),
-                ..
-            }) => Pointerness::MutPtr,
-            Type::Ptr(_) => Pointerness::ConstPtr,
-            _ => Pointerness::Not,
-        }
     }
 
     fn unique_ptr_wrapped_type(

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -133,6 +133,7 @@ pub(super) fn gen_function(
         params,
         Cow::Borrowed(&ret_type),
         non_pod_types,
+        &ret_conversion,
     );
 
     if analysis.rust_wrapper_needed {
@@ -308,6 +309,7 @@ impl<'a> FnGenerator<'a> {
             wrapper_params,
             ret_type,
             self.non_pod_types,
+            self.ret_conversion,
         );
 
         let cxxbridge_name = self.cxxbridge_name;

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -96,7 +96,6 @@ pub(super) fn gen_function(
     }
     let cxxbridge_name = analysis.cxxbridge_name;
     let rust_name = &analysis.rust_name;
-    eprintln!("GENERATING {rust_name}");
     let ret_type = analysis.ret_type;
     let ret_conversion = analysis.ret_conversion;
     let param_details = analysis.param_details;

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use autocxx_parser::IncludeCppConfig;
 use indexmap::set::IndexSet as HashSet;
 use std::borrow::Cow;
 
@@ -24,7 +23,7 @@ use super::{
     function_wrapper_rs::RustParamConversion,
     maybe_unsafes_to_tokens,
     unqualify::{unqualify_params, unqualify_ret_type},
-    ImplBlockDetails, ImplBlockKey, MaybeUnsafeStmt, RsCodegenResult, TraitImplBlockDetails, Use,
+    ImplBlockDetails, MaybeUnsafeStmt, RsCodegenResult, TraitImplBlockDetails, Use,
 };
 use crate::{
     conversion::{
@@ -32,7 +31,7 @@ use crate::{
             function_wrapper::TypeConversionPolicy, ArgumentAnalysis, FnAnalysis, FnKind,
             MethodKind, RustRenameStrategy, TraitMethodDetails,
         },
-        api::{Pointerness, UnsafetyNeeded},
+        api::UnsafetyNeeded,
     },
     minisyn::minisynize_vec,
     types::{Namespace, QualifiedName},
@@ -91,13 +90,13 @@ pub(super) fn gen_function(
     analysis: FnAnalysis,
     cpp_call_name: String,
     non_pod_types: &HashSet<QualifiedName>,
-    config: &IncludeCppConfig,
 ) -> RsCodegenResult {
     if analysis.ignore_reason.is_err() || !analysis.externally_callable {
         return RsCodegenResult::default();
     }
     let cxxbridge_name = analysis.cxxbridge_name;
     let rust_name = &analysis.rust_name;
+    eprintln!("GENERATING {rust_name}");
     let ret_type = analysis.ret_type;
     let ret_conversion = analysis.ret_conversion;
     let param_details = analysis.param_details;
@@ -125,7 +124,6 @@ pub(super) fn gen_function(
         non_pod_types,
         ret_type: &ret_type,
         ret_conversion: &ret_conversion,
-        reference_wrappers: config.unsafe_policy.requires_cpprefs(),
     };
     // In rare occasions, we might need to give an explicit lifetime.
     let (lifetime_tokens, params, ret_type) = add_explicit_lifetime_if_necessary(
@@ -239,7 +237,6 @@ struct FnGenerator<'a> {
     always_unsafe_due_to_trait_definition: bool,
     doc_attrs: &'a Vec<Attribute>,
     non_pod_types: &'a HashSet<QualifiedName>,
-    reference_wrappers: bool,
 }
 
 impl<'a> FnGenerator<'a> {
@@ -396,31 +393,7 @@ impl<'a> FnGenerator<'a> {
         let rust_name = make_ident(self.rust_name);
         let unsafety = self.unsafety.wrapper_token();
         let doc_attrs = self.doc_attrs;
-        let receiver_pointerness = self
-            .param_details
-            .iter()
-            .next()
-            .map(|pd| pd.conversion.is_a_pointer())
-            .unwrap_or(Pointerness::Not);
         let ty = impl_block_type_name.get_final_ident();
-        let ty = match receiver_pointerness {
-            Pointerness::MutPtr if self.reference_wrappers => ImplBlockKey {
-                ty: parse_quote! {
-                    #ty
-                },
-                lifetime: Some(parse_quote! { 'a }),
-            },
-            Pointerness::ConstPtr if self.reference_wrappers => ImplBlockKey {
-                ty: parse_quote! {
-                    #ty
-                },
-                lifetime: Some(parse_quote! { 'a }),
-            },
-            _ => ImplBlockKey {
-                ty: parse_quote! { # ty },
-                lifetime: None,
-            },
-        };
         Box::new(ImplBlockDetails {
             item: ImplItem::Fn(parse_quote! {
                 #(#doc_attrs)*
@@ -428,7 +401,7 @@ impl<'a> FnGenerator<'a> {
                     #call_body
                 }
             }),
-            ty,
+            ty: parse_quote! { # ty },
         })
     }
 
@@ -471,7 +444,7 @@ impl<'a> FnGenerator<'a> {
         };
         Box::new(ImplBlockDetails {
             item: ImplItem::Fn(parse_quote! { #stuff }),
-            ty: ImplBlockKey { ty, lifetime: None },
+            ty,
         })
     }
 

--- a/engine/src/conversion/codegen_rs/lifetime.rs
+++ b/engine/src/conversion/codegen_rs/lifetime.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 use crate::{
     conversion::analysis::fun::{
-        function_wrapper::RustConversionType, ArgumentAnalysis, ReceiverMutability,
+        function_wrapper::{RustConversionType, TypeConversionPolicy},
+        ArgumentAnalysis, ReceiverMutability,
     },
     types::QualifiedName,
 };
@@ -22,7 +23,7 @@ use syn::{
 
 /// Function which can add explicit lifetime parameters to function signatures
 /// where necessary, based on analysis of parameters and return types.
-/// This is necessary in three cases:
+/// This is necessary in four cases:
 /// 1) where the parameter is a Pin<&mut T>
 ///    and the return type is some kind of reference - because lifetime elision
 ///    is not smart enough to see inside a Pin.
@@ -31,11 +32,13 @@ use syn::{
 ///    built-in type
 /// 3) Any parameter is any form of reference, and we're returning an `impl New`
 ///    3a) an 'impl ValueParam' counts as a reference.
+/// 4) If we're using CppRef<'a, T> as a return type
 pub(crate) fn add_explicit_lifetime_if_necessary<'r>(
     param_details: &[ArgumentAnalysis],
     mut params: Punctuated<FnArg, Comma>,
     ret_type: Cow<'r, ReturnType>,
     non_pod_types: &HashSet<QualifiedName>,
+    ret_conversion: &Option<TypeConversionPolicy>,
 ) -> (
     Option<TokenStream>,
     Punctuated<FnArg, Comma>,
@@ -54,11 +57,22 @@ pub(crate) fn add_explicit_lifetime_if_necessary<'r>(
             )
     });
     let return_type_is_impl = return_type_is_impl(&ret_type);
+    let return_type_is_cppref = matches!(
+        ret_conversion,
+        Some(TypeConversionPolicy {
+            rust_conversion: RustConversionType::FromPointerToReferenceWrapper,
+            ..
+        })
+    );
     let non_pod_ref_param = reference_parameter_is_non_pod_reference(&params, non_pod_types);
     let ret_type_pod = return_type_is_pod_or_known_type_reference(&ret_type, non_pod_types);
     let returning_impl_with_a_reference_param = return_type_is_impl && any_param_is_reference;
     let hits_1024_bug = non_pod_ref_param && ret_type_pod;
-    if !(has_mutable_receiver || hits_1024_bug || returning_impl_with_a_reference_param) {
+    if !(has_mutable_receiver
+        || hits_1024_bug
+        || returning_impl_with_a_reference_param
+        || return_type_is_cppref)
+    {
         return (None, params, ret_type);
     }
     let new_return_type = match ret_type.as_ref() {
@@ -82,6 +96,12 @@ pub(crate) fn add_explicit_lifetime_if_necessary<'r>(
                 Some(parse_quote! {
                     #rarrow #old_tyit + 'a
                 })
+            }
+            Type::Ptr(_) if return_type_is_cppref => {
+                // The ptr will be converted to CppRef<'a, T> elsewhere, so we
+                // just need to return the return type as-is such that the
+                // next match statement adds <'a> to the function.
+                Some(ret_type.clone().into_owned())
             }
             _ => None,
         },

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -107,3 +107,25 @@ fn test_method_call_const() {
         &[],
     )
 }
+
+#[test]
+fn test_return_reference_cpprefs() {
+    let cxx = indoc! {"
+        const Bob& give_bob(const Bob& input_bob) {
+            return input_bob;
+        }
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        struct Bob {
+            uint32_t a;
+            uint32_t b;
+        };
+        const Bob& give_bob(const Bob& input_bob);
+    "};
+    let rs = quote! {
+        let b = ffi::Bob { a: 3, b: 4 };
+        assert_eq!(ffi::give_bob(&b).b, 4);
+    };
+    run_cpprefs_test(cxx, hdr, rs, &["give_bob"], &["Bob"]);
+}

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -12,6 +12,7 @@ use autocxx_integration_tests::{directives_from_lists, do_run_test};
 use indoc::indoc;
 use proc_macro2::TokenStream;
 use quote::quote;
+use test_log::test;
 
 const fn arbitrary_self_types_supported() -> bool {
     rustversion::cfg!(nightly)

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -124,8 +124,11 @@ fn test_return_reference_cpprefs() {
         const Bob& give_bob(const Bob& input_bob);
     "};
     let rs = quote! {
-        let b = ffi::Bob { a: 3, b: 4 };
-        assert_eq!(ffi::give_bob(&b).b, 4);
+        let b = CppPin::new(ffi::Bob { a: 3, b: 4 });
+        let b_ref = b.as_cpp_ref();
+        let bob = ffi::give_bob(&b_ref);
+        let val = unsafe { bob.as_ref() };
+        assert_eq!(val.b, 4);
     };
     run_cpprefs_test(cxx, hdr, rs, &["give_bob"], &["Bob"]);
 }


### PR DESCRIPTION
When enabling the (unusual) policy `unsafe_references_wrapped`, we were not adding lifetimes properly to some return types.