### PR TITLE
test: add test case for #1371

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -12456,6 +12456,16 @@ fn test_double_template_w_default() {
     run_test("", hdr, quote! {}, &["Problem"], &[]);
 }
 
+#[test]
+fn test_class_named_string() {
+    let hdr = indoc! {"
+        namespace a {
+            class String {};
+        } // namespace a
+    "};
+    run_test("", hdr, quote! {}, &["a::String"], &[]);
+}
+
 // Yet to test:
 // - Ifdef
 // - Out param pointers


### PR DESCRIPTION
I've added the simplest repro for #1371. The issue also occurs when e.g. generating something which has some mention (argument, return type, member variable) of a type named String. I can add additional such test cases if desired.