### PR TITLE
Newtype wrappers for some names.

### DIFF
--- a/engine/src/conversion/analysis/abstract_types.rs
+++ b/engine/src/conversion/analysis/abstract_types.rs
@@ -20,7 +20,7 @@ use crate::conversion::{
     analysis::{depth_first::fields_and_bases_first, fun::ReceiverMutability},
     api::{ApiName, TypeKind},
     error_reporter::{convert_apis, convert_item_apis},
-    ConvertErrorFromCpp,
+    ConvertErrorFromCpp, CppEffectiveName,
 };
 use crate::{
     conversion::{api::Api, apivec::ApiVec},
@@ -30,7 +30,7 @@ use indexmap::set::IndexSet as HashSet;
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 struct Signature {
-    name: String,
+    name: CppEffectiveName,
     args: Vec<syn::Type>,
     constness: ReceiverMutability,
 }
@@ -201,7 +201,7 @@ pub(crate) fn mark_types_abstract(apis: ApiVec<FnPrePhase2>) -> ApiVec<FnPrePhas
         } if api
             .cpp_name()
             .as_ref()
-            .map(|n| n.contains("::"))
+            .map(|n| n.is_nested())
             .unwrap_or_default() =>
         {
             Err(ConvertErrorFromCpp::AbstractNestedType)

--- a/engine/src/conversion/analysis/fun/bridge_name_tracker.rs
+++ b/engine/src/conversion/analysis/fun/bridge_name_tracker.rs
@@ -90,11 +90,11 @@ impl BridgeNameTracker {
             *count += 1;
             return found_name.to_string();
         }
+        let type_name = type_name.map(|s| s.to_string());
         let prefix = ns
             .iter()
-            .cloned()
-            .chain(type_name.iter().map(|x| x.to_string()))
-            .chain(std::iter::once(found_name.to_string()))
+            .chain(type_name.iter().map(|s| s.as_str()))
+            .chain(std::iter::once(found_name))
             .join("_");
         let count = self
             .next_cxx_bridge_name_for_prefix

--- a/engine/src/conversion/analysis/fun/function_wrapper.rs
+++ b/engine/src/conversion/analysis/fun/function_wrapper.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::conversion::CppEffectiveName;
 use crate::minisyn::Ident;
 use crate::{
     conversion::{api::SubclassName, type_helpers::extract_pinned_mutable_reference_type},
@@ -233,8 +234,8 @@ impl TypeConversionPolicy {
 
 #[derive(Clone, Debug)]
 pub(crate) enum CppFunctionBody {
-    FunctionCall(Namespace, Ident),
-    StaticMethodCall(Namespace, Ident, Ident),
+    FunctionCall(Namespace, CppEffectiveName),
+    StaticMethodCall(Namespace, Ident, CppEffectiveName),
     PlacementNew(Namespace, Ident),
     ConstructSuperclass(String),
     Cast,
@@ -256,7 +257,7 @@ pub(crate) enum CppFunctionKind {
 pub(crate) struct CppFunction {
     pub(crate) payload: CppFunctionBody,
     pub(crate) wrapper_function_name: crate::minisyn::Ident,
-    pub(crate) original_cpp_name: String,
+    pub(crate) original_cpp_name: CppEffectiveName,
     pub(crate) return_conversion: Option<TypeConversionPolicy>,
     pub(crate) argument_conversion: Vec<TypeConversionPolicy>,
     pub(crate) kind: CppFunctionKind,

--- a/engine/src/conversion/analysis/name_check.rs
+++ b/engine/src/conversion/analysis/name_check.rs
@@ -17,7 +17,7 @@ use crate::{
         error_reporter::convert_item_apis,
         ConvertErrorFromCpp,
     },
-    types::{validate_ident_ok_for_cxx, QualifiedName},
+    types::validate_ident_ok_for_cxx,
 };
 
 use super::fun::FnPhase;
@@ -43,9 +43,7 @@ pub(crate) fn check_names(apis: ApiVec<FnPhase>) -> ApiVec<FnPhase> {
             if let Some(cpp_name) = name.cpp_name_if_present() {
                 // The C++ name might itself be outer_type::inner_type and thus may
                 // have multiple segments.
-                validate_all_segments_ok_for_cxx(
-                    QualifiedName::new_from_cpp_name(cpp_name).segment_iter(),
-                )?;
+                validate_all_segments_ok_for_cxx(cpp_name.to_qualified_name().segment_iter())?;
             }
             Ok(Box::new(std::iter::once(api)))
         }
@@ -105,11 +103,11 @@ pub(crate) fn check_names(apis: ApiVec<FnPhase>) -> ApiVec<FnPhase> {
     results
 }
 
-fn validate_all_segments_ok_for_cxx(
-    items: impl Iterator<Item = String>,
+fn validate_all_segments_ok_for_cxx<'a>(
+    items: impl Iterator<Item = &'a str>,
 ) -> Result<(), ConvertErrorFromCpp> {
     for seg in items {
-        validate_ident_ok_for_cxx(&seg).map_err(ConvertErrorFromCpp::InvalidIdent)?;
+        validate_ident_ok_for_cxx(seg).map_err(ConvertErrorFromCpp::InvalidIdent)?;
     }
     Ok(())
 }

--- a/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
+++ b/engine/src/conversion/analysis/replace_hopeless_typedef_targets.rs
@@ -63,12 +63,7 @@ pub(crate) fn replace_hopeless_typedef_targets(
             // that.
             {
                 let name_id = name.name.get_final_ident();
-                if api
-                    .cpp_name()
-                    .as_ref()
-                    .map(|n| n.contains("::"))
-                    .unwrap_or_default()
-                {
+                if api.effective_cpp_name().is_nested() {
                     Api::IgnoredItem {
                         name: api.name_info().clone(),
                         err: ConvertErrorFromCpp::NestedOpaqueTypedef,

--- a/engine/src/conversion/analysis/type_converter.rs
+++ b/engine/src/conversion/analysis/type_converter.rs
@@ -245,7 +245,7 @@ impl<'a> TypeConverter<'a> {
                     return Err(ConvertErrorFromCpp::UnsupportedBuiltInType(ty));
                 }
                 if !self.types_found.contains(&ty) {
-                    typ.path.segments = std::iter::once(&"root".to_string())
+                    typ.path.segments = std::iter::once("root")
                         .chain(ns.iter())
                         .map(|s| {
                             let i = make_ident(s);

--- a/engine/src/conversion/api.rs
+++ b/engine/src/conversion/api.rs
@@ -33,7 +33,8 @@ use super::{
         PointerTreatment,
     },
     convert_error::{ConvertErrorWithContext, ErrorContext},
-    ConvertErrorFromCpp,
+    parse::CppOriginalName,
+    ConvertErrorFromCpp, CppEffectiveName,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -282,7 +283,7 @@ pub(crate) struct FuncToConvert {
     pub(crate) special_member: Option<SpecialMemberKind>,
     pub(crate) unused_template_param: bool,
     pub(crate) references: References,
-    pub(crate) original_name: Option<String>,
+    pub(crate) original_name: Option<CppOriginalName>,
     /// Used for static functions only. For all other functons,
     /// this is figured out from the receiver type in the inputs.
     pub(crate) self_ty: Option<QualifiedName>,
@@ -328,7 +329,7 @@ pub(crate) enum TypedefKind {
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub(crate) struct ApiName {
     pub(crate) name: QualifiedName,
-    cpp_name: Option<String>,
+    cpp_name: Option<CppOriginalName>,
 }
 
 impl ApiName {
@@ -336,7 +337,11 @@ impl ApiName {
         Self::new_from_qualified_name(QualifiedName::new(ns, id))
     }
 
-    pub(crate) fn new_with_cpp_name(ns: &Namespace, id: Ident, cpp_name: Option<String>) -> Self {
+    pub(crate) fn new_with_cpp_name(
+        ns: &Namespace,
+        id: Ident,
+        cpp_name: Option<CppOriginalName>,
+    ) -> Self {
         Self {
             name: QualifiedName::new(ns, id),
             cpp_name,
@@ -354,23 +359,24 @@ impl ApiName {
         Self::new(&Namespace::new(), id)
     }
 
-    pub(crate) fn cpp_name(&self) -> String {
-        self.cpp_name
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| self.name.get_final_item().to_string())
+    pub(crate) fn cpp_name(&self) -> CppEffectiveName {
+        CppEffectiveName::from_api_details(&self.cpp_name, &self.name)
     }
 
     pub(crate) fn qualified_cpp_name(&self) -> String {
         let cpp_name = self.cpp_name();
         self.name
             .ns_segment_iter()
-            .cloned()
-            .chain(std::iter::once(cpp_name))
+            .chain(std::iter::once(
+                cpp_name
+                    .to_string_to_make_qualified_name()
+                    .to_string()
+                    .as_str(),
+            ))
             .join("::")
     }
 
-    pub(crate) fn cpp_name_if_present(&self) -> Option<&String> {
+    pub(crate) fn cpp_name_if_present(&self) -> Option<&CppOriginalName> {
         self.cpp_name.as_ref()
     }
 }
@@ -626,16 +632,14 @@ impl<T: AnalysisPhase> Api<T> {
 
     /// The name recorded for use in C++, if and only if
     /// it differs from Rust.
-    pub(crate) fn cpp_name(&self) -> &Option<String> {
+    pub(crate) fn cpp_name(&self) -> &Option<CppOriginalName> {
         &self.name_info().cpp_name
     }
 
     /// The name for use in C++, whether or not it differs
     /// from Rust.
-    pub(crate) fn effective_cpp_name(&self) -> &str {
-        self.cpp_name()
-            .as_deref()
-            .unwrap_or_else(|| self.name().get_final_item())
+    pub(crate) fn effective_cpp_name(&self) -> CppEffectiveName {
+        self.name_info().cpp_name()
     }
 
     /// If this API turns out to have the same QualifiedName as another,

--- a/engine/src/conversion/codegen_rs/mod.rs
+++ b/engine/src/conversion/codegen_rs/mod.rs
@@ -422,7 +422,7 @@ impl<'a> RsCodeGenerator<'a> {
             }))
         }
         for (child_name, child_ns_entries) in ns_entries.children() {
-            let new_ns = ns.push((*child_name).clone());
+            let new_ns = ns.push(child_name.to_string());
             let child_id = make_ident(child_name);
 
             let mut inner_output_items = Vec::new();
@@ -464,7 +464,7 @@ impl<'a> RsCodeGenerator<'a> {
     ) -> RsCodegenResult {
         let name = api.name().clone();
         let id = name.get_final_ident();
-        let cpp_call_name = api.effective_cpp_name().to_string();
+        let cpp_call_name = api.effective_cpp_name();
         match api {
             Api::StringConstructor { .. } => {
                 let make_string_name = make_ident(self.config.get_makestring_name());
@@ -1150,12 +1150,12 @@ impl<'a> RsCodeGenerator<'a> {
         // If we have a nested class, B::C, within namespace A,
         // we actually have to tell cxx that we have nested class C
         // within namespace A.
-        let mut ns_components: Vec<_> = ns.iter().cloned().collect();
+        let mut ns_components: Vec<_> = ns.iter().map(|s| s.to_string()).collect();
         let mut cxx_name = None;
         if let Some(cpp_name) = self.original_name_map.get(name) {
-            let cpp_name = QualifiedName::new_from_cpp_name(cpp_name);
+            let cpp_name = cpp_name.to_qualified_name();
             cxx_name = Some(cpp_name.get_final_item().to_string());
-            ns_components.extend(cpp_name.ns_segment_iter().cloned());
+            ns_components.extend(cpp_name.ns_segment_iter().map(|s| s.to_string()));
         };
 
         let mut for_extern_c_ts = if !ns_components.is_empty() {

--- a/engine/src/conversion/codegen_rs/namespace_organizer.rs
+++ b/engine/src/conversion/codegen_rs/namespace_organizer.rs
@@ -15,7 +15,7 @@ pub trait HasNs {
 
 pub struct NamespaceEntries<'a, T: HasNs> {
     entries: Vec<&'a T>,
-    children: BTreeMap<&'a String, NamespaceEntries<'a, T>>,
+    children: BTreeMap<&'a str, NamespaceEntries<'a, T>>,
 }
 
 impl<'a, T: HasNs> NamespaceEntries<'a, T> {
@@ -32,7 +32,7 @@ impl<'a, T: HasNs> NamespaceEntries<'a, T> {
         &self.entries
     }
 
-    pub(crate) fn children(&self) -> impl Iterator<Item = (&&String, &NamespaceEntries<T>)> {
+    pub(crate) fn children(&self) -> impl Iterator<Item = (&&str, &NamespaceEntries<T>)> {
         self.children.iter()
     }
 

--- a/engine/src/conversion/parse/mod.rs
+++ b/engine/src/conversion/parse/mod.rs
@@ -11,5 +11,5 @@ mod extern_fun_signatures;
 mod parse_bindgen;
 mod parse_foreign_mod;
 
-pub(crate) use bindgen_semantic_attributes::BindgenSemanticAttributes;
+pub(crate) use bindgen_semantic_attributes::{BindgenSemanticAttributes, CppOriginalName};
 pub(crate) use parse_bindgen::ParseBindgen;

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -233,7 +233,7 @@ impl<'a> ParseBindgen<'a> {
                     //
                     // We'll also at this point check for one specific problem with
                     // forward declarations.
-                    if err.is_none() && name.cpp_name().contains("::") {
+                    if err.is_none() && name.cpp_name().is_nested() {
                         err = Some(ConvertErrorWithContext(
                             ConvertErrorFromCpp::ForwardDeclaredNestedType,
                             Some(ErrorContext::new_for_item(s.ident.into())),

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -17,6 +17,8 @@ use thiserror::Error;
 
 use crate::known_types::known_types;
 
+use crate::conversion::CppEffectiveName;
+
 pub(crate) fn make_ident<S: AsRef<str>>(id: S) -> Ident {
     Ident::new(id.as_ref(), Span::call_site())
 }
@@ -42,8 +44,8 @@ impl Namespace {
         self.0.is_empty()
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &String> {
-        self.0.iter()
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(|s| s.as_str())
     }
 
     #[cfg(test)]
@@ -174,7 +176,11 @@ impl QualifiedName {
         let special_cpp_name = known_types().special_cpp_name(self);
         match special_cpp_name {
             Some(name) => name,
-            None => self.0.iter().chain(std::iter::once(&self.1)).join("::"),
+            None => self
+                .0
+                .iter()
+                .chain(std::iter::once(self.1.as_str()))
+                .join("::"),
         }
     }
 
@@ -183,9 +189,9 @@ impl QualifiedName {
             known_type_path
         } else {
             let root = "root".to_string();
-            let segs = std::iter::once(&root)
+            let segs = std::iter::once(root.as_str())
                 .chain(self.ns_segment_iter())
-                .chain(std::iter::once(&self.1))
+                .chain(std::iter::once(self.1.as_str()))
                 .map(make_ident);
             parse_quote! {
                 #(#segs)::*
@@ -196,7 +202,7 @@ impl QualifiedName {
     pub(crate) fn type_path_from_root(&self) -> TypePath {
         let segs = self
             .ns_segment_iter()
-            .chain(std::iter::once(&self.1))
+            .chain(std::iter::once(self.1.as_str()))
             .map(make_ident);
         parse_quote! {
             #(#segs)::*
@@ -204,15 +210,14 @@ impl QualifiedName {
     }
 
     /// Iterator over segments in the namespace of this name.
-    pub(crate) fn ns_segment_iter(&self) -> impl Iterator<Item = &String> {
+    pub(crate) fn ns_segment_iter(&self) -> impl Iterator<Item = &str> {
         self.0.iter()
     }
 
     /// Iterate over all segments of this name.
-    pub(crate) fn segment_iter(&self) -> impl Iterator<Item = String> + '_ {
+    pub(crate) fn segment_iter(&self) -> impl Iterator<Item = &str> {
         self.ns_segment_iter()
-            .cloned()
-            .chain(std::iter::once(self.get_final_item().to_string()))
+            .chain(std::iter::once(self.get_final_item()))
     }
 }
 
@@ -254,7 +259,7 @@ pub enum InvalidIdentError {
 /// wrapper for a CxxCompatibleIdent which is used in any context
 /// where code will be output as part of the `#[cxx::bridge]` mod.
 pub fn validate_ident_ok_for_cxx(id: &str) -> Result<(), InvalidIdentError> {
-    validate_ident_ok_for_rust(id)?;
+    validate_str_ok_for_rust(id)?;
     // Provide a couple of more specific diagnostics if we can.
     if id.starts_with("__BindgenBitfieldUnit") {
         Err(InvalidIdentError::Bitfield)
@@ -269,7 +274,11 @@ pub fn validate_ident_ok_for_cxx(id: &str) -> Result<(), InvalidIdentError> {
     }
 }
 
-pub fn validate_ident_ok_for_rust(label: &str) -> Result<(), InvalidIdentError> {
+pub fn validate_ident_ok_for_rust(label: &CppEffectiveName) -> Result<(), InvalidIdentError> {
+    validate_str_ok_for_rust(label.for_validation())
+}
+
+fn validate_str_ok_for_rust(label: &str) -> Result<(), InvalidIdentError> {
     let id = make_ident(label);
     syn::parse2::<syn::Ident>(id.into_token_stream())
         .map_err(|_| InvalidIdentError::ReservedName(label.to_string()))


### PR DESCRIPTION
This is an internal change which begins to dig us out of the mess of naming we have inside autocxx. We deal with all sorts of different kinds of identifiers - for Rust, for cxx, for C++, from bindgen - and convert between them in a fairly ad-hoc basis. It's all too fragile to be able to tackle changes like #1371.

Fortunately, Rust makes it easy to solve these sorts of messes using newtype wrappers. Unfortunately, I've tried that in the past and it's got to be a huge muddle.

Here's another attempt at carving off part of the space. This introduces such wrappers for two types of name:
* The [bindgen_original_name] identifiers discovered in bindgen attributes;
* The final name to be used for C++ function calls.

There are various FIXMEs added in locations where we're converting to or from other types of name in questionable ways.

A bit of #520.
