### PR TITLE
Initialize env_logger in autocxx-build

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -10,26 +10,18 @@
 
 use autocxx_engine::{BuilderContext, RebuildDependencyRecorder};
 use indexmap::set::IndexSet as HashSet;
-use std::{
-    borrow::Borrow,
-    io::Write,
-    sync::{LazyLock, Mutex},
-};
+use std::{io::Write, sync::Mutex};
 
 pub type Builder = autocxx_engine::Builder<'static, CargoBuilderContext>;
 
 #[doc(hidden)]
 pub struct CargoBuilderContext;
 
-static ENV_LOGGER: LazyLock<()> = LazyLock::new(|| {
-    env_logger::builder()
-        .format(|buf, record| writeln!(buf, "cargo:warning=MESSAGE:{}", record.args()))
-        .init();
-});
-
 impl BuilderContext for CargoBuilderContext {
     fn setup() {
-        ENV_LOGGER.borrow();
+        let _ = env_logger::builder()
+            .format(|buf, record| writeln!(buf, "cargo:warning=MESSAGE:{}", record.args()))
+            .try_init();
     }
     fn get_dependency_recorder() -> Option<Box<dyn RebuildDependencyRecorder>> {
         Some(Box::new(CargoRebuildDependencyRecorder::new()))


### PR DESCRIPTION
There was previously a bug (#1384) where each call to `Builder::new()` in build.rs would try to re-initialize env_logger. Since `init()` panics if called more than once, that prevented multiple invocations of autocxx in one project. But the fix was also buggy, as it moved initialization into a LazyLock that was only ever `borrow()`ed. It seems like `borrow()` just takes a reference to the whole LazyLock without initializing it, meaning we now get no logging even when `RUST_LOG` is set appropriately.

We could make the existing fix work by calling `LazyLock::force()`, but since env_logger already has a `try_init()` method that doesn't panic on failure, let's just use that.

Fixes #1389