### PR TITLE
Update `CppPeerConstructor` documentation

### DIFF
--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -165,22 +165,19 @@ where
     me
 }
 
-/// A trait to be implemented by a subclass which knows how to construct
-/// its C++ peer object. Specifically, the implementation here will
-/// arrange to call one or other of the `make_unique` methods to be
-/// found on the superclass of the C++ object. If the superclass
-/// has a single trivial constructor, then this is implemented
-/// automatically for you. If there are multiple constructors, or
-/// a single constructor which takes parameters, you'll need to implement
-/// this trait for your subclass in order to call the correct
-/// constructor.
+/// A trait to be implemented by a subclass which knows how to construct its C++
+/// peer object. Specifically, the implementation here will arrange to call one
+/// or other of the `new` methods to be found on the peer type. If the C++
+/// superclass has a single trivial constructor, then this is implemented
+/// automatically for you. If there are multiple constructors, or a single
+/// constructor which takes parameters, you'll need to implement this trait for
+/// your subclass in order to call the correct constructor.
 pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
     /// Create the C++ peer. This method will be automatically generated
     /// for you *except* in cases where the superclass has multiple constructors,
-    /// or its only constructor takes parameters. In such a case you'll need
-    /// to implement this by calling a `make_unique` method on the
-    /// `<my subclass name>Cpp` type, passing `peer_holder` as the first
-    /// argument.
+    /// or its only constructor takes parameters. In such a case you'll need to
+    /// implement this by calling a `new` method on the `<my subclass name>Cpp`
+    /// type, passing `peer_holder` as the first argument.
     fn make_peer(&mut self, peer_holder: CppSubclassRustPeerHolder<Self>) -> UniquePtr<CppPeer>;
 }
 


### PR DESCRIPTION
These docstrings still refer to `::make_unique()`, which has been deprecated since v0.19.1 (#997) and entirely removed since v0.22.0 (#1040). Additionally, the top-level documentation said to call it on the superclass, which as far as I can tell is not correct (it should be called on the peer object instead, as the `make_peer()` docstring states).

Please check me on that latter change, though: I could be missing something, and maybe the reference to the superclass really is correct.