### PR TITLE
autocxx-build: Re-export result types used in API

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -12,6 +12,8 @@ use autocxx_engine::{BuilderContext, RebuildDependencyRecorder};
 use indexmap::set::IndexSet as HashSet;
 use std::{io::Write, sync::Mutex};
 
+pub use autocxx_engine::{BuilderError, BuilderSuccess};
+
 pub type Builder = autocxx_engine::Builder<'static, CargoBuilderContext>;
 
 #[doc(hidden)]


### PR DESCRIPTION
Without these, users' build scripts have no way to refer to the result type by name, meaning they can't rewrap or inspect the error. I'm guessing most users use miette like the documentation suggests, which avoids the issue, but we should still support other use cases.