### PR TITLE
Make CppMutRef's T invariant

### DIFF
--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -162,7 +162,7 @@ impl<'a, T: ?Sized> CppRef<'a, T> {
     pub fn const_cast(&self) -> CppMutRef<'a, T> {
         CppMutRef {
             ptr: self.ptr as *mut T,
-            phantom: self.phantom,
+            phantom: PhantomData,
         }
     }
 
@@ -296,7 +296,7 @@ impl<'a, T> From<CppMutRef<'a, T>> for CppRef<'a, T> {
     fn from(mutable: CppMutRef<'a, T>) -> Self {
         Self {
             ptr: mutable.ptr,
-            phantom: mutable.phantom,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -230,7 +230,7 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<CppRef<'_, U>> for CppRef
 #[repr(transparent)]
 pub struct CppMutRef<'a, T: ?Sized> {
     ptr: *mut T,
-    phantom: PhantomData<&'a T>,
+    phantom: PhantomData<&'a mut T>,
 }
 
 impl<T: ?Sized> CppMutRef<'_, T> {


### PR DESCRIPTION
CppMutRef previously used a `PhantomData<&'a mut T>` marker, but this allows for `T` to be covariant. `T` should instead be invariant since a `T` can be written through a `CppMutRef`.

See https://doc.rust-lang.org/nomicon/subtyping.html

This is technically a minor breaking change, though it's also a soundness fix.