### PR TITLE
Minisyn to wrap inputs

### DIFF
--- a/engine/src/conversion/analysis/abstract_types.rs
+++ b/engine/src/conversion/analysis/abstract_types.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use indexmap::map::IndexMap as HashMap;
-use syn::{punctuated::Punctuated, token::Comma, FnArg};
+use syn::{punctuated::Punctuated, token::Comma};
 
 use super::{
     fun::{
@@ -16,11 +16,14 @@ use super::{
     },
     pod::PodAnalysis,
 };
-use crate::conversion::{
-    analysis::{depth_first::fields_and_bases_first, fun::ReceiverMutability},
-    api::{ApiName, TypeKind},
-    error_reporter::{convert_apis, convert_item_apis},
-    ConvertErrorFromCpp, CppEffectiveName,
+use crate::{
+    conversion::{
+        analysis::{depth_first::fields_and_bases_first, fun::ReceiverMutability},
+        api::{ApiName, TypeKind},
+        error_reporter::{convert_apis, convert_item_apis},
+        ConvertErrorFromCpp, CppEffectiveName,
+    },
+    minisyn::FnArg,
 };
 use crate::{
     conversion::{api::Api, apivec::ApiVec},
@@ -47,7 +50,7 @@ impl Signature {
                 .iter()
                 .skip(1) // skip `this` implicit argument
                 .filter_map(|p| {
-                    if let FnArg::Typed(t) = p {
+                    if let syn::FnArg::Typed(t) = &p.0 {
                         Some((*t.ty).clone())
                     } else {
                         None

--- a/engine/src/conversion/codegen_rs/fun_codegen.rs
+++ b/engine/src/conversion/codegen_rs/fun_codegen.rs
@@ -16,13 +16,13 @@ use syn::{
     parse_quote,
     punctuated::Punctuated,
     token::{Comma, Unsafe},
-    Attribute, FnArg, ForeignItem, Ident, ImplItem, Item, ReturnType,
+    Attribute, ForeignItem, Ident, ImplItem, Item, ReturnType,
 };
 
 use super::{
     function_wrapper_rs::RustParamConversion,
     maybe_unsafes_to_tokens,
-    unqualify::{unqualify_params, unqualify_ret_type},
+    unqualify::{unqualify_params_minisyn, unqualify_ret_type},
     ImplBlockDetails, MaybeUnsafeStmt, RsCodegenResult, TraitImplBlockDetails, Use,
 };
 use crate::{
@@ -33,7 +33,7 @@ use crate::{
         },
         api::UnsafetyNeeded,
     },
-    minisyn::minisynize_vec,
+    minisyn::{minisynize_vec, FnArg},
     types::{Namespace, QualifiedName},
 };
 use crate::{
@@ -193,7 +193,7 @@ pub(super) fn gen_function(
     // well-known types should be unqualified already (e.g. just UniquePtr)
     // and the following code will act to unqualify only those types
     // which the user has declared.
-    let params = unqualify_params(params);
+    let params = unqualify_params_minisyn(params);
     let ret_type = unqualify_ret_type(ret_type.into_owned());
     // And we need to make an attribute for the namespace that the function
     // itself is in.

--- a/engine/src/conversion/codegen_rs/unqualify.rs
+++ b/engine/src/conversion/codegen_rs/unqualify.rs
@@ -7,9 +7,11 @@
 // except according to those terms.
 
 use syn::{
-    parse_quote, punctuated::Punctuated, FnArg, GenericArgument, PathArguments, PathSegment,
-    ReturnType, Token, Type, TypePath,
+    parse_quote, punctuated::Punctuated, GenericArgument, PathArguments, PathSegment, ReturnType,
+    Token, Type, TypePath,
 };
+
+use crate::minisyn::FnArg;
 
 fn unqualify_type_path(typ: TypePath) -> TypePath {
     // If we've still got more than one
@@ -76,15 +78,31 @@ pub(crate) fn unqualify_ret_type(ret_type: ReturnType) -> ReturnType {
     }
 }
 
-pub(crate) fn unqualify_params(
+pub(crate) fn unqualify_params_minisyn(
     params: Punctuated<FnArg, Token![,]>,
 ) -> Punctuated<FnArg, Token![,]> {
     params
         .into_iter()
-        .map(|p| match p {
-            FnArg::Typed(mut pt) => {
+        .map(|p| match p.0 {
+            syn::FnArg::Typed(mut pt) => {
                 pt.ty = unqualify_boxed_type(pt.ty);
-                FnArg::Typed(pt)
+                syn::FnArg::Typed(pt)
+            }
+            _ => p.0,
+        })
+        .map(FnArg)
+        .collect()
+}
+
+pub(crate) fn unqualify_params(
+    params: Punctuated<syn::FnArg, Token![,]>,
+) -> Punctuated<syn::FnArg, Token![,]> {
+    params
+        .into_iter()
+        .map(|p| match p {
+            syn::FnArg::Typed(mut pt) => {
+                pt.ty = unqualify_boxed_type(pt.ty);
+                syn::FnArg::Typed(pt)
             }
             _ => p,
         })


### PR DESCRIPTION
The purpose of this is to make logging output more concise by displaying FnAnalysis's "inputs" as Rust code rather than a complex tree of syn types.
