### PR TITLE
Remove code for unused template param detection.

### DIFF
--- a/engine/src/conversion/type_helpers.rs
+++ b/engine/src/conversion/type_helpers.rs
@@ -101,10 +101,6 @@ pub(crate) fn unwrap_reference(ty: &TypePath, search_for_rvalue: bool) -> Option
     }
 }
 
-pub(crate) fn type_has_unused_template_param(ty: &syn::Type) -> bool {
-    matches_bindgen_marker(ty, "__bindgen_marker_UnusedTemplateParam")
-}
-
 pub(crate) fn unwrap_has_unused_template_param(ty: &TypePath) -> Option<&syn::Type> {
     unwrap_bindgen_marker(ty, "__bindgen_marker_UnusedTemplateParam")
 }


### PR DESCRIPTION
This was reported two different ways by bindgen; I can't think of a reason we'd need both. Disable one of those ways.

Specifically, it should be:
* Reported by callback when announcing a type;
* Reported by wrapping any instances of that type in bindgen_marker_UnusedTemplateParam<T>

We'll disregard the second one. Then we don't need to upstream it as part of #124.