### PR TITLE
Remove O(n^2) lookup in parse callback results.

### DIFF
--- a/engine/src/conversion/conversion_tests.rs
+++ b/engine/src/conversion/conversion_tests.rs
@@ -11,7 +11,7 @@ use autocxx_parser::UnsafePolicy;
 use syn::parse_quote;
 use syn::ItemMod;
 
-use crate::{CodegenOptions, ParseCallbackResults};
+use crate::{CodegenOptions, UnindexedParseCallbackResults};
 
 use super::BridgeConverter;
 
@@ -29,7 +29,7 @@ fn do_test(input: ItemMod) {
     let tc = parse_quote! {};
     let bc = BridgeConverter::new(&[], &tc);
     let inclusions = "".into();
-    let parse_callback_results = ParseCallbackResults::default();
+    let parse_callback_results = UnindexedParseCallbackResults::default().index();
     bc.convert(
         input,
         parse_callback_results,

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -195,9 +195,7 @@ impl<'a> ParseBindgen<'a> {
     fn parse_mod_items(&mut self, items: Option<&Vec<Item>>, ns: Namespace) {
         // This object maintains some state specific to this namespace, i.e.
         // this particular mod.
-        // TODO - ideally we'd get rid of this clone
-        let parse_callback_results = self.parse_callback_results.clone();
-        let mut mod_converter = ParseForeignMod::new(ns.clone(), &parse_callback_results);
+        let mut mod_converter = ParseForeignMod::new(ns.clone(), self.parse_callback_results);
         let mut more_apis = ApiVec::new();
         let empty_vec = vec![];
         for item in items.unwrap_or(&empty_vec) {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -31,7 +31,7 @@ use autocxx_bindgen::BindgenError;
 use autocxx_parser::{IncludeCppConfig, UnsafePolicy};
 use conversion::BridgeConverter;
 use miette::{SourceOffset, SourceSpan};
-use parse_callbacks::{AutocxxParseCallbacks, ParseCallbackResults};
+use parse_callbacks::{AutocxxParseCallbacks, ParseCallbackResults, UnindexedParseCallbackResults};
 use parse_file::CppBuildable;
 use proc_macro2::TokenStream as TokenStream2;
 use regex::Regex;
@@ -447,7 +447,8 @@ impl IncludeCppEngine {
             return Err(Error::WrappedReferencesButNoArbitrarySelfTypes);
         }
 
-        let parse_callback_results = Rc::new(RefCell::new(ParseCallbackResults::default()));
+        let parse_callback_results =
+            Rc::new(RefCell::new(UnindexedParseCallbackResults::default()));
         let mod_name = self.config.get_mod_name();
         let mut builder = self
             .make_bindgen_builder(&inc_dirs, extra_clang_args)
@@ -479,7 +480,7 @@ impl IncludeCppEngine {
         let conversion = converter
             .convert(
                 bindings,
-                parse_callback_results,
+                parse_callback_results.index(),
                 self.config.unsafe_policy.clone(),
                 header_contents,
                 codegen_options,


### PR DESCRIPTION
By building an index. This is not known to have caused any slowness but could in theory do so.
