### PR TITLE
CppRef<T> changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.77"
 resolver = "2"
 
 [features]
-arbitrary_self_types_pointers = []
+arbitrary_self_types = []
 
 [dependencies]
 autocxx-macro = { path="macro", version="0.29.0" }

--- a/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
+++ b/engine/src/conversion/codegen_rs/function_wrapper_rs.rs
@@ -172,9 +172,12 @@ impl TypeConversionPolicy {
                     _ => panic!("Not a pointer"),
                 };
                 let (ty, wrapper_name) = if is_mut {
-                    (parse_quote! { autocxx::CppMutRef<'a, #ty> }, "CppMutRef")
+                    (
+                        parse_quote! { autocxx::CppMutLtRef<'a, #ty> },
+                        "CppMutLtRef",
+                    )
                 } else {
-                    (parse_quote! { autocxx::CppRef<'a, #ty> }, "CppRef")
+                    (parse_quote! { autocxx::CppLtRef<'a, #ty> }, "CppLtRef")
                 };
                 let wrapper_name = make_ident(wrapper_name);
                 RustParamConversion::Param {
@@ -194,9 +197,9 @@ impl TypeConversionPolicy {
                     _ => panic!("Not a pointer"),
                 };
                 let ty = if is_mut {
-                    parse_quote! { &mut autocxx::CppMutRef<'a, #ty> }
+                    parse_quote! { autocxx::CppMutRef<#ty> }
                 } else {
-                    parse_quote! { &autocxx::CppRef<'a, #ty> }
+                    parse_quote! { autocxx::CppRef<#ty> }
                 };
                 RustParamConversion::Param {
                     ty,

--- a/examples/reference-wrappers/src/main.rs
+++ b/examples/reference-wrappers/src/main.rs
@@ -25,7 +25,7 @@
 
 // Necessary to be able to call methods on reference wrappers.
 // For that reason, this example only builds on nightly Rust.
-#![feature(arbitrary_self_types_pointers)]
+#![feature(arbitrary_self_types)]
 
 use autocxx::prelude::*;
 use std::pin::Pin;

--- a/integration-tests/tests/cpprefs_test.rs
+++ b/integration-tests/tests/cpprefs_test.rs
@@ -27,7 +27,7 @@ fn run_cpprefs_test(
     generate_pods: &[&str],
 ) {
     if !arbitrary_self_types_supported() {
-        // "unsafe_references_wrapped" requires arbitrary_self_types_pointers, which requires nightly.
+        // "unsafe_references_wrapped" requires arbitrary_self_types, which requires nightly.
         return;
     }
     do_run_test(
@@ -127,7 +127,7 @@ fn test_return_reference_cpprefs() {
     let rs = quote! {
         let b = CppPin::new(ffi::Bob { a: 3, b: 4 });
         let b_ref = b.as_cpp_ref();
-        let bob = ffi::give_bob(&b_ref);
+        let bob = ffi::give_bob(b_ref);
         let val = unsafe { bob.as_ref() };
         assert_eq!(val.b, 4);
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(nightly, feature(unsize))]
 #![cfg_attr(nightly, feature(dispatch_from_dyn))]
+#![cfg_attr(nightly, feature(arbitrary_self_types))]
 
 // Copyright 2020 Google LLC
 //
@@ -21,7 +22,9 @@ mod rvalue_param;
 pub mod subclass;
 mod value_param;
 
-pub use reference_wrapper::{AsCppMutRef, AsCppRef, CppMutRef, CppPin, CppRef, CppUniquePtrPin};
+pub use reference_wrapper::{
+    AsCppMutRef, AsCppRef, CppLtRef, CppMutLtRef, CppMutRef, CppPin, CppRef, CppUniquePtrPin,
+};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Include some C++ headers in your Rust project.
@@ -270,7 +273,7 @@ macro_rules! concrete {
 /// them to be wrapped in a `CppRef` type: see [`CppRef`].
 /// This only works on nightly Rust because it
 /// depends upon an unstable feature
-/// (`arbitrary_self_types_pointers`). However, it should
+/// (`arbitrary_self_types`). However, it should
 /// eliminate all undefined behavior related to Rust's
 /// stricter aliasing rules than C++.
 #[macro_export]
@@ -594,10 +597,7 @@ pub trait WithinBox {
     fn within_box(self) -> Pin<Box<Self::Inner>>;
     /// Create this item inside a [`CppPin`]. This is a good option if you
     /// want to own this option within Rust, but you want to create [`CppRef`]
-    /// C++ references to it. You'd only want to choose that option if you have
-    /// enabled the C++ reference wrapper support by using the
-    /// `safety!(unsafe_references_wrapped`) directive. If you haven't done
-    /// that, ignore this function.
+    /// C++ references to it.
     fn within_cpp_pin(self) -> CppPin<Self::Inner>;
 }
 

--- a/src/reference_wrapper.rs
+++ b/src/reference_wrapper.rs
@@ -148,7 +148,7 @@ impl<T: ?Sized> Receiver for CppRef<T> {
 
 impl<T: ?Sized> Clone for CppRef<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 
@@ -176,10 +176,7 @@ impl<T: ?Sized> Deref for CppLtRef<'_, T> {
 
 impl<T: ?Sized> Clone for CppLtRef<'_, T> {
     fn clone(&self) -> Self {
-        Self {
-            ptr: self.ptr.clone(),
-            phantom: self.phantom,
-        }
+        *self
     }
 }
 
@@ -269,7 +266,7 @@ impl<T: ?Sized> Deref for CppMutRef<T> {
 
 impl<T: ?Sized> Clone for CppMutRef<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 
@@ -549,7 +546,7 @@ impl<T: UniquePtrTarget> AsCppRef<T> for CppUniquePtrPin<T> {
 
 impl<T: UniquePtrTarget> AsCppMutRef<T> for CppUniquePtrPin<T> {
     fn as_cpp_mut_ref(&mut self) -> CppMutRef<T> {
-        self.1.clone()
+        self.1
     }
 }
 

--- a/src/value_param.rs
+++ b/src/value_param.rs
@@ -109,6 +109,8 @@ where
     }
 }
 
+// TODO implement for CppPin<T> and for CppRef<T: CopyNew>
+
 unsafe impl<T> ValueParam<T> for UniquePtr<T>
 where
     T: UniquePtrTarget,


### PR DESCRIPTION
These changes were made as part of the prototyping for use of the new arbitrary self types v2 Rust feature (#1429) but are worth promoting into main even before that's landed.

Some tweaks:
* We no longer depend on the `arbitrary_self_types_pointers` nightly feature but instead just `arbitrary_self_types`.
* CppRef<T> no longer has an associated lifetime. Instead there's a separate CppLtRef<T> type.
