### PR TITLE
Revert "Ignore the test."

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -12200,7 +12200,6 @@ fn test_virtual_methods() {
 }
 
 #[test]
-#[ignore] // https://github.com/google/autocxx/issues/1192, or related
 fn test_issue_1192() {
     let hdr = indoc! {
         "#include <vector>


### PR DESCRIPTION
This reverts commit ee8686fab903a0b6623835808ad13f71a921f8d9 which ignored a test that seems to pass, oops.