### PR TITLE
Fix unsafe_op_in_unsafe_fn warning for unsafe operations in generated module

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -519,6 +519,7 @@ impl IncludeCppEngine {
             #[allow(dead_code)]
             #[allow(non_upper_case_globals)]
             #[allow(non_camel_case_types)]
+            #[allow(unsafe_op_in_unsafe_fn)]
             #[doc = "Generated using autocxx - do not edit directly"]
             #[doc = "@generated"]
             mod #mod_name {


### PR DESCRIPTION
## Fix unsafe_op_in_unsafe_fn warning for unsafe operations in generated module
This PR adds #[allow(unsafe_op_in_unsafe_fn)] attributes to autocxx-generated unsafe functions to suppress warnings that would appear when using Rust 2024 edition.

## Background
Rust 2024 edition introduces the stabilized unsafe_op_in_unsafe_fn lint ([Edition Guide](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html)), which requires unsafe operations inside unsafe functions to be explicitly wrapped in unsafe blocks.

While this is a valuable safety improvement for hand-written code (as described in [RFC #2585](https://rust-lang.github.io/rfcs/2585-unsafe-block-in-unsafe-fn.html)), it creates unnecessary noise for generated FFI bindings like those produced by autocxx.

## Example of warnings
Without this fix, code generated by autocxx produces warnings like:

```rust
warning[E0133]: call to unsafe function `std::pin::Pin::<&'a mut T>::get_unchecked_mut` is unsafe and requires unsafe block
 --> target/debug/build/utils-3c769df202ee350f/out/autocxx-build-dir/rs/autocxx-ffi-gen.rs:1:18417
  |
1 | ...b769b983bff6673a_autocxx_wrapper_0xb769b983bff6673a (this . get_unchecked_mut () . as_mut_ptr () , other) } } impl Drop for output :: PlainString { # [doc = ...
  |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
  |
  = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
  = note: consult the function's documentation for information on how to avoid undefined behavior
  ```
## Changes
This PR modifies the code generation templates to add the #[allow(unsafe_op_in_unsafe_fn)] attribute to generated unsafe functions. I think this is appropriate because:

* The generated bindings already have clear unsafe markers at the API boundary
* Internal implementation details are not directly visible to users
* The safety concerns are properly addressed at the function signature level