### PR TITLE
Fix code generation to comply with rfc 2585

### DIFF
--- a/engine/src/conversion/analysis/fun/mod.rs
+++ b/engine/src/conversion/analysis/fun/mod.rs
@@ -108,9 +108,6 @@ pub(crate) struct TraitMethodDetails {
     /// interface, we may need to reorder the parameters to fit that
     /// interface.
     pub(crate) parameter_reordering: Option<Vec<usize>>,
-    /// The function we're calling from the trait requires unsafe even
-    /// though the trait and its function aren't.
-    pub(crate) trait_call_is_unsafe: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -894,7 +891,6 @@ impl<'a> FnAnalyzer<'a> {
                                 avoid_self: true,
                                 method_name: make_ident(method_name),
                                 parameter_reordering: Some(vec![1, 0]),
-                                trait_call_is_unsafe: false,
                             }),
                         },
                         error_context,
@@ -930,7 +926,6 @@ impl<'a> FnAnalyzer<'a> {
                             avoid_self: false,
                             method_name: make_ident("drop"),
                             parameter_reordering: None,
-                            trait_call_is_unsafe: false,
                         }),
                     },
                     error_context,
@@ -1582,7 +1577,6 @@ impl<'a> FnAnalyzer<'a> {
                             avoid_self: false,
                             method_name,
                             parameter_reordering: None,
-                            trait_call_is_unsafe: false,
                         }),
                     },
                     ErrorContext::new_for_item(make_ident(&rust_name)),
@@ -1626,7 +1620,6 @@ impl<'a> FnAnalyzer<'a> {
                     avoid_self: false,
                     method_name: make_ident(method_name),
                     parameter_reordering: None,
-                    trait_call_is_unsafe: false,
                 }),
                 kind,
             },

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -367,7 +367,8 @@ impl IncludeCppEngine {
             .raw_line(raw_line)
             .every_module_raw_line(all_module_raw_line)
             .generate_private_functions(true)
-            .layout_tests(false); // TODO revisit later
+            .layout_tests(false) // TODO revisit later
+            .wrap_unsafe_ops(true);
 
         // 3. Passes allowlist and other options to the bindgen::Builder equivalent
         //    to --output-style=cxx --allowlist=<as passed in>
@@ -519,7 +520,6 @@ impl IncludeCppEngine {
             #[allow(dead_code)]
             #[allow(non_upper_case_globals)]
             #[allow(non_camel_case_types)]
-            #[allow(unsafe_op_in_unsafe_fn)]
             #[doc = "Generated using autocxx - do not edit directly"]
             #[doc = "@generated"]
             mod #mod_name {


### PR DESCRIPTION
This PR enhanced the work from PR #1473 by ensuring all necessary unsafe blocks are properly generated.