### PR TITLE
Fix a few documentation/spelling nits

### DIFF
--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -65,7 +65,7 @@ So, practically speaking, you would almost always move onto running one of the t
 in the test suite. With suitable options, you can get plenty of output. For instance:
 
 ```ignore
-RUST_BACKTRACE=1 RUST_LOG=autocxx_engine=info cargo test --all test_cycle_string_full_pipeline -- --nocapture
+RUST_BACKTRACE=1 RUST_LOG=autocxx_engine=info cargo test --workspace integration_test::test_cycle_string -- --exact --nocapture
 ```
 
 This is especially valuable to see the `bindgen` output Rust code, and then the converted Rust code which we pass into cxx. Usually, most problems are due to some mis-conversion somewhere

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -222,7 +222,7 @@ impl<'a> ParseBindgen<'a> {
                 // cxx::bridge can't cope with type aliases to generic
                 // types at the moment.
                 let name = api_name_qualified(ns, s.ident.clone(), self.parse_callback_results)?;
-                if known_types().is_known_subtitute_type(&name.name) {
+                if known_types().is_known_substitute_type(&name.name) {
                     // This is one of the replacement types, e.g.
                     // root::Str replacing rust::Str or
                     // root::string replacing root::std::string

--- a/engine/src/conversion/parse/parse_bindgen.rs
+++ b/engine/src/conversion/parse/parse_bindgen.rs
@@ -44,7 +44,7 @@ pub(crate) struct ParseBindgen<'a> {
 
 fn api_name(ns: &Namespace, id: Ident, callback_results: &ParseCallbackResults) -> ApiName {
     let qn = QualifiedName::new(ns, minisyn::Ident(id.clone()));
-    // TODO FIXME squash reduncancy
+    // TODO FIXME squash redundancy
     ApiName::new_with_cpp_name(ns, id.into(), callback_results.get_original_name(&qn))
 }
 

--- a/engine/src/known_types.rs
+++ b/engine/src/known_types.rs
@@ -270,7 +270,7 @@ impl TypeDatabase {
     }
 
     /// Whether this is the substitute type we made for some known type.
-    pub(crate) fn is_known_subtitute_type(&self, ty: &QualifiedName) -> bool {
+    pub(crate) fn is_known_substitute_type(&self, ty: &QualifiedName) -> bool {
         if ty.get_namespace().is_empty() {
             self.all_names()
                 .any(|n| n.get_final_item() == ty.get_final_item())

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -184,8 +184,8 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 /// A subclass of a C++ type.
 ///
 /// To create a Rust subclass of a C++ class, you must do these things:
-/// * Create a `struct` to act as your subclass, and add the #[`macro@crate::subclass`] attribute.
-///   This adds a field to your struct for autocxx record-keeping. You can
+/// * Create a `struct` to act as your subclass, and add the [`#[subclass]`][subclass]
+///   attribute. This adds a field to your struct for autocxx record-keeping. You can
 ///   instead choose to implement [`CppSubclass`] a different way, in which case
 ///   you must provide the [`macro@crate::subclass`] inside your [`crate::include_cpp`]
 ///   macro. (`autocxx` will do the required codegen for your subclass
@@ -273,13 +273,13 @@ pub trait CppPeerConstructor<CppPeer: CppSubclassCppPeer>: Sized {
 ///   [see this issue](https://github.com/google/autocxx/issues/610).
 pub trait CppSubclass<CppPeer: CppSubclassCppPeer>: CppPeerConstructor<CppPeer> {
     /// Return the field which holds the C++ peer object. This is normally
-    /// implemented by the #[`is_subclass`] macro, but you're welcome to
-    /// implement it yourself if you prefer.
+    /// implemented by the [`#[subclass]`][subclass] macro, but you're welcome
+    /// to implement it yourself if you prefer.
     fn peer_holder(&self) -> &CppSubclassCppPeerHolder<CppPeer>;
 
     /// Return the field which holds the C++ peer object. This is normally
-    /// implemented by the #[`is_subclass`] macro, but you're welcome to
-    /// implement it yourself if you prefer.
+    /// implemented by the [`#[subclass]`][subclass] macro, but you're welcome
+    /// to implement it yourself if you prefer.
     fn peer_holder_mut(&mut self) -> &mut CppSubclassCppPeerHolder<CppPeer>;
 
     /// Return a reference to the C++ part of this object pair.

--- a/src/subclass.rs
+++ b/src/subclass.rs
@@ -17,10 +17,6 @@ use std::{
 
 use cxx::{memory::UniquePtrTarget, UniquePtr};
 
-/// Deprecated - use [`subclass`] instead.
-#[deprecated]
-pub use autocxx_macro::subclass as is_subclass;
-
 /// Declare a Rust subclass of a C++ class.
 /// You can use this in two ways:
 /// * As an attribute macro on a struct which is to be a subclass.
@@ -54,6 +50,10 @@ pub use autocxx_macro::subclass as is_subclass;
 /// multiple steps you need to take to be able to make Rust
 /// subclasses of a C++ class.
 pub use autocxx_macro::subclass;
+
+/// Deprecated - use [`subclass`] instead.
+#[deprecated]
+pub use autocxx_macro::subclass as is_subclass;
 
 /// A prelude containing all the traits and macros required to create
 /// Rust subclasses of C++ classes. It's recommended that you:


### PR DESCRIPTION
See individual commit messages for details. If you'd like each commit in a separate PR I can do that, but I figure merging this without squashing is easier given how small each fix is.