### PR TITLE
Suppress "unused import" for abstract param/return types

### DIFF
--- a/engine/src/conversion/codegen_rs/utils.rs
+++ b/engine/src/conversion/codegen_rs/utils.rs
@@ -16,9 +16,11 @@ pub(super) fn generate_cxx_use_stmt(name: &QualifiedName, alias: Option<&Ident>)
         .chain(std::iter::once(name.get_final_ident()));
     Item::Use(match alias {
         None => parse_quote! {
+            #[allow(unused_imports)]
             pub use #(#segs)::*;
         },
         Some(alias) => parse_quote! {
+            #[allow(unused_imports)]
             pub use #(#segs)::* as #alias;
         },
     })


### PR DESCRIPTION
When we generate a non-wrapped function or method binding that takes or returns an abstract (i.e. pure virtual) type not referenced elsewhere, we get an erroneous "unused import" warning for the user-visible re-export of that abstract type. This happens because the only use of the type is emitted by cxx and thus references the binding in `cxxbridge` instead of the re-export in `output`. [See the `unqualify_params_minisyn()` and `unqualify_ret_type()` calls in `codegen_rs::fun_codegen::gen_function()`.]

The warning is erroneous because the re-export is the only way for users to name the type, and we don't want to generate an API that takes or returns types the user can't name. So let's just suppress it, like we did for non-abstract types in #1345.