### PR TITLE
Add missing `#include <cstdint>`s in tests

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -4506,6 +4506,7 @@ fn test_typedef_to_std() {
 fn test_typedef_to_up_in_fn_call() {
     let hdr = indoc! {"
         #include <string>
+        #include <cstdint>
         #include <memory>
         typedef std::unique_ptr<std::string> my_string;
         inline uint32_t take_str(my_string a) {
@@ -4566,6 +4567,7 @@ fn test_cint_in_pod_struct() {
 fn test_string_in_struct() {
     let hdr = indoc! {"
         #include <string>
+        #include <cstdint>
         #include <memory>
         struct A {
             std::string a;
@@ -4591,6 +4593,7 @@ fn test_string_in_struct() {
 fn test_up_in_struct() {
     let hdr = indoc! {"
         #include <string>
+        #include <cstdint>
         #include <memory>
         struct A {
             std::unique_ptr<std::string> a;
@@ -4642,6 +4645,7 @@ fn test_typedef_to_std_in_struct() {
 fn test_typedef_to_up_in_struct() {
     let hdr = indoc! {"
         #include <string>
+        #include <cstdint>
         #include <memory>
         typedef std::unique_ptr<std::string> my_string;
         struct A {


### PR DESCRIPTION
I'm not sure what's different about the GitHub Actions environment where CI runs, but on my computer with glibc 2.41 and gcc 15.1.1, these tests fail because `uint32_t` isn't defined.