### PR TITLE
Fix generated wrapper for nested struct with static fn, rebase and fix of original PR

### DIFF
--- a/engine/src/conversion/codegen_cpp/mod.rs
+++ b/engine/src/conversion/codegen_cpp/mod.rs
@@ -539,16 +539,22 @@ impl<'a> CppCodeGenerator<'a> {
                 }
             },
             CppFunctionBody::StaticMethodCall(ns, ty_id, fn_id) => {
+                // handle nested struct: A_B -> A::B
+                let full_name = QualifiedName::new(ns, ty_id.clone());
+
+                let ty_path = self
+                    .original_name_map
+                    .get(&full_name)
+                    .map(|name| name.to_string())
+                    .unwrap_or_else(|| ty_id.to_string());
+
                 let underlying_function_call = ns
                     .into_iter()
                     .cloned()
                     .chain(
-                        [
-                            ty_id.to_string(),
-                            fn_id.to_string_for_cpp_generation().to_string(),
-                        ]
-                        .iter()
-                        .cloned(),
+                        [ty_path, fn_id.to_string_for_cpp_generation().to_string()]
+                            .iter()
+                            .cloned(),
                     )
                     .join("::");
                 (

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -2603,6 +2603,21 @@ fn test_nested_with_destructor() {
     run_test("", hdr, rs, &["A", "A_B"], &[]);
 }
 
+#[test]
+fn test_nested_with_static_call() {
+    let hdr = indoc! {"
+        struct A {
+            struct B {
+                static void f() {}
+            };
+        };
+    "};
+    let rs = quote! {
+        ffi::A_B::new().within_unique_ptr();
+    };
+    run_test("", hdr, rs, &["A", "A_B"], &[]);
+}
+
 // Even without a `safety!`, we still need to generate a safe `fn drop`.
 #[test]
 fn test_destructor_no_safety() {


### PR DESCRIPTION
Based on https://github.com/google/autocxx/pull/1380
Original PR generated invalid code, I've made corrections, now integration_tests are passing locally, except for:
- integration_test::test_string_in_struct
- integration_test::test_typedef_to_up_in_fn_call
- integration_test::test_typedef_to_up_in_struct
- integration_test::test_up_in_struct
but they don't pass on main branch either.