### PR TITLE
Add option to prettify generated Rust code

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -419,8 +419,8 @@ impl IncludeCppEngine {
             config: &self.config,
             rs: match &self.state {
                 State::NotGenerated => panic!("Generate first"),
-                State::Generated(gen_results) => gen_results.item_mod.to_token_stream(),
-                State::ParseOnly => TokenStream2::new(),
+                State::Generated(gen_results) => Some(&gen_results.item_mod),
+                State::ParseOnly => None,
             },
         }
     }

--- a/parser/src/config.rs
+++ b/parser/src/config.rs
@@ -215,6 +215,7 @@ pub struct IncludeCppConfig {
     pub unsafe_policy: UnsafePolicy,
     pub parse_only: bool,
     pub exclude_impls: bool,
+    pub prettify: bool,
     pub(crate) pod_requests: Vec<String>,
     pub allowlist: Allowlist,
     pub(crate) blocklist: Vec<String>,

--- a/parser/src/directives.rs
+++ b/parser/src/directives.rs
@@ -100,6 +100,13 @@ pub(crate) fn get_directives() -> &'static DirectivesMap {
                 |config| &config.exclude_utilities,
             )),
         );
+        need_exclamation.insert(
+            "pretty".into(),
+            Box::new(BoolFlag(
+                |config| &mut config.prettify,
+                |config| &config.prettify,
+            )),
+        );
         need_exclamation.insert("name".into(), Box::new(ModName));
         need_exclamation.insert("concrete".into(), Box::new(Concrete));
         need_exclamation.insert("rust_type".into(), Box::new(RustType { output: false }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,12 @@ macro_rules! exclude_utilities {
     ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
 }
 
+/// Prettify generated code.
+#[macro_export]
+macro_rules! pretty {
+    ($($tt:tt)*) => { $crate::usage!{$($tt)*} };
+}
+
 /// Entirely block some type from appearing in the generated
 /// code. This can be useful if there is a type which is not
 /// understood by bindgen or autocxx, and incorrect code is


### PR DESCRIPTION
Adds IncludeCppConfig::prettify and pretty!() macro
```
include_cpp! {
    pretty!()
}
 ```
This will pretty print generated Rust code with prettyplease crate, for human-readable output.
I'm open to adding additional documentation to the PR, if it's desired.