### PR TITLE
Add test to demonstrate failed case with ToCppString

### DIFF
--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -1897,6 +1897,28 @@ fn test_pass_string_by_value() {
 }
 
 #[test]
+fn test_ns_pass_string_by_value() {
+    let cxx = indoc! {"
+        uint32_t A::measure_string(std::string z) {
+            return z.length();
+        }
+    "};
+    let hdr = indoc! {"
+        #include <cstdint>
+        #include <string>
+        namespace A {
+            uint32_t measure_string(std::string z);
+        }
+    "};
+    let rs = quote! {
+        use ffi::ToCppString;
+        let c = ffi::A::measure_string("hello".into_cpp());
+        assert_eq!(c, 5);
+    };
+    run_test(cxx, hdr, rs, &["A::measure_string"], &[]);
+}
+
+#[test]
 fn test_return_string_by_value() {
     let cxx = indoc! {"
         std::string get_msg() {


### PR DESCRIPTION
Test fails with:

```
test /var/folders/t0/6220z7_s6mzcvxrdk80tbv640000gn/T/.tmp7cfHIg/input.rs ... error
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0405]: cannot find trait `ToCppString` in this scope
 --> /var/folders/t0/6220z7_s6mzcvxrdk80tbv640000gn/T/.tmptOO7lq/autocxx-ffi-default-gen.rs:1:5299
  |
   1 | ... { cxxbridge , output , bindgen } ; pub fn measure_string (z : impl ToCppString) -> u32 { cxxbridge :: measure_string_autocxx_wrapper_0x23632f402293...
     |                                                                        ^^^^^^^^^^^
     |
    ::: $RUST/alloc/src/string.rs
     |
     | pub trait ToString {
     | ------------------ similarly named trait `ToString` defined here
     |
help: a trait with a similar name exists
```

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR