### PR TITLE
Add CI check for MSRV 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,20 @@ jobs:
         shell: bash
       - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.77"
+      - uses: Swatinem/rust-cache@v1
+        with: { sharedKey: fullBuild }
+      - run: cargo +1.77 check --workspace --all-targets
+
   examples:
     name: Examples ${{matrix.name || format('Rust {0}', matrix.rust)}}
     runs-on: ${{matrix.os || 'ubuntu'}}-latest

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@
 // It would be nice to use the rustversion crate here instead,
 // but that doesn't work with inner attributes.
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
     if let Some(ver) = rustc_version() {
         if ver.contains("nightly") {
             println!("cargo:rustc-cfg=nightly")

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -367,6 +367,7 @@ impl IncludeCppEngine {
             .raw_line(raw_line)
             .every_module_raw_line(all_module_raw_line)
             .generate_private_functions(true)
+            .rust_target(bindgen::RustTarget::stable(77, 0).expect("Rust 1.77 is supported"))
             .layout_tests(false); // TODO revisit later
 
         // 3. Passes allowlist and other options to the bindgen::Builder equivalent

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -7,6 +7,6 @@
 // except according to those terms.
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(skip_windows_gnu_failing_tests)");
-    println!("cargo::rustc-check-cfg=cfg(skip_windows_msvc_failing_tests)");
+    println!("cargo:rustc-check-cfg=cfg(skip_windows_gnu_failing_tests)");
+    println!("cargo:rustc-check-cfg=cfg(skip_windows_msvc_failing_tests)");
 }


### PR DESCRIPTION
Fixes #1449.

This adds a GitHub Actions job to verify that autocxx continues to build with the declared MSRV, Rust 1.77.

While adding the check, two small MSRV compatibility issues surfaced:

* build script `cargo::` output is changed back to the Rust 1.77-compatible `cargo:` form.
* bindgen output is targeted at Rust 1.77 so generated bindings do not use newer Rust syntax.

Validation:

* `cargo +1.77 check --workspace --all-targets`
* `cargo check --workspace --all-targets`